### PR TITLE
fix(api-single-template): correct return type

### DIFF
--- a/algolia-typescript-template/api-single.mustache
+++ b/algolia-typescript-template/api-single.mustache
@@ -127,7 +127,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public async {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.IncomingMessage; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public async {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{{{returnType}}}> {
         const path = '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let headers: Headers = {};

--- a/output/client-search/searchApi.ts
+++ b/output/client-search/searchApi.ts
@@ -80,7 +80,7 @@ export class SearchApi {
     indexName: string,
     batchObject: BatchObject,
     options: { headers: { [name: string]: string } } = { headers: {} }
-  ): Promise<{ response: http.IncomingMessage; body: BatchResponse }> {
+  ): Promise<BatchResponse> {
     const path = '/1/indexes/{indexName}/batch'.replace(
       '{' + 'indexName' + '}',
       encodeURIComponent(String(indexName))
@@ -151,7 +151,7 @@ export class SearchApi {
   public async multipleQueries(
     multipleQueriesObject: MultipleQueriesObject,
     options: { headers: { [name: string]: string } } = { headers: {} }
-  ): Promise<{ response: http.IncomingMessage; body: MultipleQueriesResponse }> {
+  ): Promise<MultipleQueriesResponse> {
     const path = '/1/indexes/*/queries';
     let headers: Headers = {};
     let queryParameters: Record<string, string> = {};
@@ -218,7 +218,7 @@ export class SearchApi {
     indexName: string,
     requestBody: { [key: string]: object },
     options: { headers: { [name: string]: string } } = { headers: {} }
-  ): Promise<{ response: http.IncomingMessage; body: SaveObjectResponse }> {
+  ): Promise<SaveObjectResponse> {
     const path = '/1/indexes/{indexName}'.replace(
       '{' + 'indexName' + '}',
       encodeURIComponent(String(indexName))

--- a/output/complement
+++ b/output/complement
@@ -1,1 +1,0 @@
-/Users/pierre.millot/Documents/apiClients/api-client-automation-experiment/complement

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,8 +188,8 @@ __metadata:
 
 "algoliasearch-client-javascript@file:output/::locator=%40algolia%2Fautomation-javascript-client%40workspace%3A.":
   version: 5.0.0
-  resolution: "algoliasearch-client-javascript@file:output/#output/::hash=892be8&locator=%40algolia%2Fautomation-javascript-client%40workspace%3A."
-  checksum: efc65e36fc802d92d12c6d199daad038886325e334f9067d65242da736a3fd098b18ebaaf37914f58a04f95b3f474d4cfbc04264db8bd429c22f9785c6d2b804
+  resolution: "algoliasearch-client-javascript@file:output/#output/::hash=4ddc2e&locator=%40algolia%2Fautomation-javascript-client%40workspace%3A."
+  checksum: 2d82602e6f0874106d06f1118faa6dc32bdfbb367ff0a454890b82b4b7f5853270f509db510aeecd178646063840b03f920a5f5ea402f492d1f9a6101abaa592
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Summary**

We no longer return a `{ response, body }` object but the API response directly.