### PR TITLE
chore(lint): don't lint ts with prettier

### DIFF
--- a/clients/algoliasearch-client-javascript/client-search/src/searchApi.ts
+++ b/clients/algoliasearch-client-javascript/client-search/src/searchApi.ts
@@ -106,7 +106,7 @@ export class SearchApi {
   /**
    * Performs multiple write operations in a single API call.
    *
-   * @param indexName  - The index in which to perform the request.
+   * @param indexName - The index in which to perform the request.
    * @param batchObject - The batchObject.
    */
   batch(indexName: string, batchObject: BatchObject): Promise<BatchResponse> {
@@ -145,7 +145,7 @@ export class SearchApi {
   /**
    * Retrieve settings of a given indexName.
    *
-   * @param indexName  - The index in which to perform the request.
+   * @param indexName - The index in which to perform the request.
    */
   getSettings(indexName: string): Promise<IndexSettings> {
     const path = '/1/indexes/{indexName}/settings'.replace(
@@ -207,8 +207,8 @@ export class SearchApi {
   /**
    * Add an object to the index, automatically assigning it an object ID.
    *
-   * @param indexName  - The index in which to perform the request.
-   * @param requestBody  - The Algolia object.
+   * @param indexName - The index in which to perform the request.
+   * @param requestBody - The Algolia object.
    */
   saveObject(
     indexName: string,
@@ -249,7 +249,7 @@ export class SearchApi {
   /**
    * Get search results.
    *
-   * @param indexName  - The index in which to perform the request.
+   * @param indexName - The index in which to perform the request.
    * @param searchParamsAsStringSearchParams - The searchParamsAsStringSearchParams.
    */
   search(
@@ -294,9 +294,9 @@ export class SearchApi {
   /**
    * Update settings of a given indexName. Only specified settings are overridden; unspecified settings are left unchanged. Specifying null for a setting resets it to its default value.
    *
-   * @param indexName  - The index in which to perform the request.
+   * @param indexName - The index in which to perform the request.
    * @param indexSettings - The indexSettings.
-   * @param forwardToReplicas  - When true, changes are also propagated to replicas of the given indexName.
+   * @param forwardToReplicas - When true, changes are also propagated to replicas of the given indexName.
    */
   setSettings(
     indexName: string,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "client:build-js:recommend": "yarn workspace @algolia/recommend build",
     "client:build-js": "yarn client:build-js:search && yarn client:build-js:recommend",
     "client:build": "yarn client:build-js",
-    "lint:client:fix": "yarn prettier --write ${CLIENT} && eslint --ext=ts ${CLIENT} --fix",
+    "lint:client:fix": "eslint --ext=ts ${CLIENT} --fix",
     "lint": "eslint --ext=ts .",
     "format:specs": "yarn prettier --write specs",
     "generate:js:recommend": "yarn openapi-generator-cli generate --generator-key javascript-recommend && CLIENT=recommend yarn utils:import-js && CLIENT=clients/algoliasearch-client-javascript/recommend/ yarn lint:client:fix",

--- a/playground/javascript/package.json
+++ b/playground/javascript/package.json
@@ -12,7 +12,6 @@
     "@algolia/client-search": "5.0.0",
     "@algolia/recommend": "5.0.0",
     "dotenv": "10.0.0",
-    "prettier": "2.5.0",
     "typescript": "4.5.2"
   },
   "engines": {

--- a/templates/javascript/api-single.mustache
+++ b/templates/javascript/api-single.mustache
@@ -103,7 +103,7 @@ export class {{classname}} {
   * @summary {{&summary}}
   {{/summary}}
   {{#allParams}}
-  * @param {{paramName}} {{^description}}The {{paramName}} {{/description}} {{#description}}{{description}}{{/description}}
+  * @param {{paramName}} {{^description}}The {{paramName}}{{/description}}{{#description}}{{description}}{{/description}}
   {{/allParams}}
   */
   public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}) : Promise<{{{returnType}}}> {

--- a/templates/javascript/package.mustache
+++ b/templates/javascript/package.mustache
@@ -20,8 +20,7 @@
   "devDependencies": {
     "@types/node": "^16.11.6",
     "typescript": "4.5.2"
-  }
-  {{#npmRepository}},
+  }{{#npmRepository}},
   "publishConfig": {
     "registry": "{{npmRepository}}"
   }{{/npmRepository}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,9 +412,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^16.11.6":
-  version: 16.11.10
-  resolution: "@types/node@npm:16.11.10"
-  checksum: 9c79419c5c3d92d5825bffa30f3668533f598d8b63a73ea7fc24e47f162bdbed92b0f8e4f4261cc3314b39cee050e303366d2aa154abc95c63a572a110b8c160
+  version: 16.11.11
+  resolution: "@types/node@npm:16.11.11"
+  checksum: 1c472bd63f23ca0e4effc96e6e0c693b83b027f613a1f41b6d1bd7791f65ce171a351e0a5c92575cb59e84ad0a930875397bfbbb91a7c925ddbbb558f7461af8
   languageName: node
   linkType: hard
 
@@ -946,9 +946,9 @@ __metadata:
   linkType: hard
 
 "date-fns@npm:^2.16.1":
-  version: 2.26.0
-  resolution: "date-fns@npm:2.26.0"
-  checksum: 49ad59bc788134a6552ef4e4af0d18792001c1ca0070d543de4f36aba5761058b6e6a57b8ca51dd3b0f07f3bd55376b8bc69602bd7940648ba3869c5253c6ae8
+  version: 2.27.0
+  resolution: "date-fns@npm:2.27.0"
+  checksum: db62036b3816eb0322c9532b353beac7f660a91e1a55dbd21c14893c621ebb8509f21c66ba287844dabd34dee0207edd54a9537bce6bb7cab9383dedc6b8bc90
   languageName: node
   linkType: hard
 
@@ -2032,7 +2032,6 @@ __metadata:
     "@algolia/client-search": 5.0.0
     "@algolia/recommend": 5.0.0
     dotenv: 10.0.0
-    prettier: 2.5.0
     typescript: 4.5.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 🧭 What and Why

Prettier and eslint does the same job, and running both generate the same output, so I've remove `prettier` for ts linting,
this reduce the time to run `yarn generate` by a whopping 9% !! (it's insignificant)

### Changes included:

- Remove prettier for ts

## 🧪 Test

- `time yarn generate`