### PR TITLE
fix: test the cts on the CI

### DIFF
--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -1,0 +1,30 @@
+name: cts
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Generate client
+        run: yarn generate:js
+
+      - name: Build client
+        run: yarn client:build
+
+      - name: Generate CTS
+        run: yarn cts:generate
+
+      - name: Run CTS
+        run: yarn cts:test


### PR DESCRIPTION
## 🧭 What and Why

Test that the CTS compiles and run without error.
For now it builds the client but later it will use composite to avoid building.

### Changes included:

- Add `cts` workflow

## 🧪 Test

[![cts](https://github.com/algolia/api-clients-automation/actions/workflows/cts.yml/badge.svg)](https://github.com/algolia/api-clients-automation/actions/workflows/cts.yml)
