### PR TITLE
chore: use cache to avoid building specs everytime APIC-283

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -11,12 +11,18 @@ LANGUAGE=$1
 CLIENT=$2
 GENERATOR="$1-$2"
 
+compute_hash() {
+    cacheSpec=$(find specs/$CLIENT -type f -print0 | xargs -0 sha1sum | sha1sum | tr -d ' ')
+    cacheCommon=$(find specs/common -type f -print0 | xargs -0 sha1sum | sha1sum | tr -d ' ')
+    echo "$cacheSpec$cacheCommon"
+}
+
 # build spec before generating client
 build_spec() {
     # check if file and cache exist
     cacheFile="specs/dist/$CLIENT.cache"
     if [[ -f specs/dist/$CLIENT.yml ]]; then
-        cache=$(find specs/$CLIENT -type f -print0 | xargs -0 sha1sum | sha1sum | tr -d ' ')
+        cache=$(compute_hash)
         # compare with stored cache
         if [[ -f $cacheFile && $(cat $cacheFile) == $cache ]]; then
             echo "> Skipped building spec because the files did not change..."
@@ -26,7 +32,7 @@ build_spec() {
     yarn build:specs $CLIENT
 
     # store hash
-    cache=$(find specs/$CLIENT -type f -print0 | xargs -0 sha1sum | sha1sum | tr -d ' ')
+    cache=$(compute_hash)
     echo $cache > $cacheFile
 }
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [APIC-283](https://algolia.atlassian.net/browse/APIC-283)

Compare the built spec to the real one and only build it if it changed, this way we can avoid 10 seconds of build spec (per client !) when doing `yarn docker generate`

### Changes included:

- Compute hash of spec and compare to stored one

## 🧪 Test

Run `yarn docker generate javascript recommend` twice for example.