### PR TITLE
chore: set lower github actions timeout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
   specs:
     runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    timeout-minutes: 10
     needs: setup
     if: ${{ always() && needs.setup.outputs.RUN_SPECS == 'true' }}
     strategy:
@@ -67,7 +67,7 @@ jobs:
         run: yarn build:specs ${{ matrix.client }}
 
   client_javascript:
-    timeout-minutes: 1
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     needs:
       - setup
@@ -105,7 +105,7 @@ jobs:
 
   client_java:
     runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    timeout-minutes: 10
     needs:
       - setup
       - specs
@@ -143,7 +143,7 @@ jobs:
 
   client_php:
     runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    timeout-minutes: 10
     needs:
       - setup
       - specs
@@ -174,7 +174,7 @@ jobs:
 
   cts:
     runs-on: ubuntu-20.04
-    timeout-minutes: 1
+    timeout-minutes: 20
     needs:
       - client_javascript
       - client_java


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

Default timeout seems to be 360 minutes https://github.com/algolia/api-clients-automation/actions/runs/1817303458

Setting a lower value in case this happen again

## 🧪 Test

CI :D
