### PR TITLE
fix(javascript): Move build files, fix template issue

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/builds/browser.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
-import { HttpRequester } from '@algolia/requester-node-http';
+import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createAbtestingApi } from './src/abtestingApi';
-import type { AbtestingApi, Region } from './src/abtestingApi';
+import { createAbtestingApi } from '../src/abtestingApi';
+import type { AbtestingApi, Region } from '../src/abtestingApi';
 
-export * from './src/abtestingApi';
+export * from '../src/abtestingApi';
 
 export function abtestingApi(
   appId: string,
@@ -25,12 +25,13 @@ export function abtestingApi(
     apiKey,
     region,
     timeouts: {
-      connect: 2,
-      read: 5,
+      connect: 1,
+      read: 2,
       write: 30,
     },
-    requester: options?.requester ?? new HttpRequester(),
-    userAgents: [{ segment: 'Node.js', version: process.versions.node }],
+    requester: options?.requester ?? new XhrRequester(),
+    userAgents: [{ segment: 'Browser' }],
+    authMode: 'WithinQueryParameters',
     ...options,
   });
 }

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/builds/node.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
-import { XhrRequester } from '@algolia/requester-browser-xhr';
+import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createAbtestingApi } from './src/abtestingApi';
-import type { AbtestingApi, Region } from './src/abtestingApi';
+import { createAbtestingApi } from '../src/abtestingApi';
+import type { AbtestingApi, Region } from '../src/abtestingApi';
 
-export * from './src/abtestingApi';
+export * from '../src/abtestingApi';
 
 export function abtestingApi(
   appId: string,
@@ -25,13 +25,12 @@ export function abtestingApi(
     apiKey,
     region,
     timeouts: {
-      connect: 1,
-      read: 2,
+      connect: 2,
+      read: 5,
       write: 30,
     },
-    requester: options?.requester ?? new XhrRequester(),
-    userAgents: [{ segment: 'Browser' }],
-    authMode: 'WithinQueryParameters',
+    requester: options?.requester ?? new HttpRequester(),
+    userAgents: [{ segment: 'Node.js', version: process.versions.node }],
     ...options,
   });
 }

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/builds/browser.ts
@@ -1,17 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createSourcesApi } from './src/sourcesApi';
-import type { SourcesApi, Region } from './src/sourcesApi';
+import { createAnalyticsApi } from '../src/analyticsApi';
+import type { AnalyticsApi, Region } from '../src/analyticsApi';
 
-export * from './src/sourcesApi';
+export * from '../src/analyticsApi';
 
-export function sourcesApi(
+export function analyticsApi(
   appId: string,
   apiKey: string,
-  region: Region,
+  region?: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): SourcesApi {
+): AnalyticsApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,11 +20,7 @@ export function sourcesApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  if (!region) {
-    throw new Error('`region` is missing.');
-  }
-
-  return createSourcesApi({
+  return createAnalyticsApi({
     appId,
     apiKey,
     region,

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/builds/node.ts
@@ -1,17 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createSourcesApi } from './src/sourcesApi';
-import type { SourcesApi, Region } from './src/sourcesApi';
+import { createAnalyticsApi } from '../src/analyticsApi';
+import type { AnalyticsApi, Region } from '../src/analyticsApi';
 
-export * from './src/sourcesApi';
+export * from '../src/analyticsApi';
 
-export function sourcesApi(
+export function analyticsApi(
   appId: string,
   apiKey: string,
-  region: Region,
+  region?: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): SourcesApi {
+): AnalyticsApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,11 +20,7 @@ export function sourcesApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  if (!region) {
-    throw new Error('`region` is missing.');
-  }
-
-  return createSourcesApi({
+  return createAnalyticsApi({
     appId,
     apiKey,
     region,

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -13,8 +13,7 @@
     "clean": "rm -rf dist/"
   },
   "engines": {
-    "node": "^14.0.0",
-    "yarn": "^3.0.0"
+    "node": "^14.0.0"
   },
   "devDependencies": {
     "@types/node": "16.11.11",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/builds/browser.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createInsightsApi } from './src/insightsApi';
-import type { InsightsApi, Region } from './src/insightsApi';
+import { createInsightsApi } from '../src/insightsApi';
+import type { InsightsApi, Region } from '../src/insightsApi';
 
-export * from './src/insightsApi';
+export * from '../src/insightsApi';
 
 export function insightsApi(
   appId: string,

--- a/clients/algoliasearch-client-javascript/packages/client-insights/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/builds/node.ts
@@ -1,16 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createPredictApi } from './src/predictApi';
-import type { PredictApi } from './src/predictApi';
+import { createInsightsApi } from '../src/insightsApi';
+import type { InsightsApi, Region } from '../src/insightsApi';
 
-export * from './src/predictApi';
+export * from '../src/insightsApi';
 
-export function predictApi(
+export function insightsApi(
   appId: string,
   apiKey: string,
+  region?: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): PredictApi {
+): InsightsApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -19,10 +20,10 @@ export function predictApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createPredictApi({
+  return createInsightsApi({
     appId,
     apiKey,
-
+    region,
     timeouts: {
       connect: 2,
       read: 5,

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/builds/browser.ts
@@ -1,16 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createSearchApi } from './src/searchApi';
-import type { SearchApi } from './src/searchApi';
+import { createPersonalizationApi } from '../src/personalizationApi';
+import type { PersonalizationApi, Region } from '../src/personalizationApi';
 
-export * from './src/searchApi';
+export * from '../src/personalizationApi';
 
-export function searchApi(
+export function personalizationApi(
   appId: string,
   apiKey: string,
+  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): SearchApi {
+): PersonalizationApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -19,10 +20,14 @@ export function searchApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createSearchApi({
+  if (!region) {
+    throw new Error('`region` is missing.');
+  }
+
+  return createPersonalizationApi({
     appId,
     apiKey,
-
+    region,
     timeouts: {
       connect: 1,
       read: 2,

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/builds/node.ts
@@ -1,16 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createRecommendApi } from './src/recommendApi';
-import type { RecommendApi } from './src/recommendApi';
+import { createPersonalizationApi } from '../src/personalizationApi';
+import type { PersonalizationApi, Region } from '../src/personalizationApi';
 
-export * from './src/recommendApi';
+export * from '../src/personalizationApi';
 
-export function recommendApi(
+export function personalizationApi(
   appId: string,
   apiKey: string,
+  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): RecommendApi {
+): PersonalizationApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -19,10 +20,14 @@ export function recommendApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createRecommendApi({
+  if (!region) {
+    throw new Error('`region` is missing.');
+  }
+
+  return createPersonalizationApi({
     appId,
     apiKey,
-
+    region,
     timeouts: {
       connect: 2,
       read: 5,

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-predict/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/builds/browser.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createPredictApi } from './src/predictApi';
-import type { PredictApi } from './src/predictApi';
+import { createPredictApi } from '../src/predictApi';
+import type { PredictApi } from '../src/predictApi';
 
-export * from './src/predictApi';
+export * from '../src/predictApi';
 
 export function predictApi(
   appId: string,
@@ -22,7 +22,6 @@ export function predictApi(
   return createPredictApi({
     appId,
     apiKey,
-
     timeouts: {
       connect: 1,
       read: 2,

--- a/clients/algoliasearch-client-javascript/packages/client-predict/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/builds/node.ts
@@ -1,17 +1,16 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createPersonalizationApi } from './src/personalizationApi';
-import type { PersonalizationApi, Region } from './src/personalizationApi';
+import { createPredictApi } from '../src/predictApi';
+import type { PredictApi } from '../src/predictApi';
 
-export * from './src/personalizationApi';
+export * from '../src/predictApi';
 
-export function personalizationApi(
+export function predictApi(
   appId: string,
   apiKey: string,
-  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): PersonalizationApi {
+): PredictApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,14 +19,9 @@ export function personalizationApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  if (!region) {
-    throw new Error('`region` is missing.');
-  }
-
-  return createPersonalizationApi({
+  return createPredictApi({
     appId,
     apiKey,
-    region,
     timeouts: {
       connect: 2,
       read: 5,

--- a/clients/algoliasearch-client-javascript/packages/client-predict/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-predict/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/builds/browser.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
-import { HttpRequester } from '@algolia/requester-node-http';
+import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createQuerySuggestionsApi } from './src/querySuggestionsApi';
-import type { QuerySuggestionsApi, Region } from './src/querySuggestionsApi';
+import { createQuerySuggestionsApi } from '../src/querySuggestionsApi';
+import type { QuerySuggestionsApi, Region } from '../src/querySuggestionsApi';
 
-export * from './src/querySuggestionsApi';
+export * from '../src/querySuggestionsApi';
 
 export function querySuggestionsApi(
   appId: string,
@@ -29,12 +29,13 @@ export function querySuggestionsApi(
     apiKey,
     region,
     timeouts: {
-      connect: 2,
-      read: 5,
+      connect: 1,
+      read: 2,
       write: 30,
     },
-    requester: options?.requester ?? new HttpRequester(),
-    userAgents: [{ segment: 'Node.js', version: process.versions.node }],
+    requester: options?.requester ?? new XhrRequester(),
+    userAgents: [{ segment: 'Browser' }],
+    authMode: 'WithinQueryParameters',
     ...options,
   });
 }

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/builds/node.ts
@@ -1,17 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createInsightsApi } from './src/insightsApi';
-import type { InsightsApi, Region } from './src/insightsApi';
+import { createQuerySuggestionsApi } from '../src/querySuggestionsApi';
+import type { QuerySuggestionsApi, Region } from '../src/querySuggestionsApi';
 
-export * from './src/insightsApi';
+export * from '../src/querySuggestionsApi';
 
-export function insightsApi(
+export function querySuggestionsApi(
   appId: string,
   apiKey: string,
-  region?: Region,
+  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): InsightsApi {
+): QuerySuggestionsApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,7 +20,11 @@ export function insightsApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createInsightsApi({
+  if (!region) {
+    throw new Error('`region` is missing.');
+  }
+
+  return createQuerySuggestionsApi({
     appId,
     apiKey,
     region,

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-search/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-search/builds/browser.ts
@@ -1,17 +1,16 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createQuerySuggestionsApi } from './src/querySuggestionsApi';
-import type { QuerySuggestionsApi, Region } from './src/querySuggestionsApi';
+import { createSearchApi } from '../src/searchApi';
+import type { SearchApi } from '../src/searchApi';
 
-export * from './src/querySuggestionsApi';
+export * from '../src/searchApi';
 
-export function querySuggestionsApi(
+export function searchApi(
   appId: string,
   apiKey: string,
-  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): QuerySuggestionsApi {
+): SearchApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,14 +19,9 @@ export function querySuggestionsApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  if (!region) {
-    throw new Error('`region` is missing.');
-  }
-
-  return createQuerySuggestionsApi({
+  return createSearchApi({
     appId,
     apiKey,
-    region,
     timeouts: {
       connect: 1,
       read: 2,

--- a/clients/algoliasearch-client-javascript/packages/client-search/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-search/builds/node.ts
@@ -1,17 +1,16 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createAnalyticsApi } from './src/analyticsApi';
-import type { AnalyticsApi, Region } from './src/analyticsApi';
+import { createSearchApi } from '../src/searchApi';
+import type { SearchApi } from '../src/searchApi';
 
-export * from './src/analyticsApi';
+export * from '../src/searchApi';
 
-export function analyticsApi(
+export function searchApi(
   appId: string,
   apiKey: string,
-  region?: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): AnalyticsApi {
+): SearchApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,10 +19,9 @@ export function analyticsApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createAnalyticsApi({
+  return createSearchApi({
     appId,
     apiKey,
-    region,
     timeouts: {
       connect: 2,
       read: 5,

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-search/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-sources/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/builds/browser.ts
@@ -1,17 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createAnalyticsApi } from './src/analyticsApi';
-import type { AnalyticsApi, Region } from './src/analyticsApi';
+import { createSourcesApi } from '../src/sourcesApi';
+import type { SourcesApi, Region } from '../src/sourcesApi';
 
-export * from './src/analyticsApi';
+export * from '../src/sourcesApi';
 
-export function analyticsApi(
+export function sourcesApi(
   appId: string,
   apiKey: string,
-  region?: Region,
+  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): AnalyticsApi {
+): SourcesApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,7 +20,11 @@ export function analyticsApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createAnalyticsApi({
+  if (!region) {
+    throw new Error('`region` is missing.');
+  }
+
+  return createSourcesApi({
     appId,
     apiKey,
     region,

--- a/clients/algoliasearch-client-javascript/packages/client-sources/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/builds/node.ts
@@ -1,16 +1,17 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createSearchApi } from './src/searchApi';
-import type { SearchApi } from './src/searchApi';
+import { createSourcesApi } from '../src/sourcesApi';
+import type { SourcesApi, Region } from '../src/sourcesApi';
 
-export * from './src/searchApi';
+export * from '../src/sourcesApi';
 
-export function searchApi(
+export function sourcesApi(
   appId: string,
   apiKey: string,
+  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): SearchApi {
+): SourcesApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -19,10 +20,14 @@ export function searchApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  return createSearchApi({
+  if (!region) {
+    throw new Error('`region` is missing.');
+  }
+
+  return createSourcesApi({
     appId,
     apiKey,
-
+    region,
     timeouts: {
       connect: 2,
       read: 5,

--- a/clients/algoliasearch-client-javascript/packages/client-sources/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/client-sources/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/recommend/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/recommend/builds/browser.ts
@@ -1,17 +1,16 @@
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { createPersonalizationApi } from './src/personalizationApi';
-import type { PersonalizationApi, Region } from './src/personalizationApi';
+import { createRecommendApi } from '../src/recommendApi';
+import type { RecommendApi } from '../src/recommendApi';
 
-export * from './src/personalizationApi';
+export * from '../src/recommendApi';
 
-export function personalizationApi(
+export function recommendApi(
   appId: string,
   apiKey: string,
-  region: Region,
   options?: { requester?: Requester; hosts?: Host[] }
-): PersonalizationApi {
+): RecommendApi {
   if (!appId) {
     throw new Error('`appId` is missing.');
   }
@@ -20,14 +19,9 @@ export function personalizationApi(
     throw new Error('`apiKey` is missing.');
   }
 
-  if (!region) {
-    throw new Error('`region` is missing.');
-  }
-
-  return createPersonalizationApi({
+  return createRecommendApi({
     appId,
     apiKey,
-    region,
     timeouts: {
       connect: 1,
       read: 2,

--- a/clients/algoliasearch-client-javascript/packages/recommend/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/recommend/builds/node.ts
@@ -1,10 +1,10 @@
 import type { Host, Requester } from '@algolia/client-common';
-import { XhrRequester } from '@algolia/requester-browser-xhr';
+import { HttpRequester } from '@algolia/requester-node-http';
 
-import { createRecommendApi } from './src/recommendApi';
-import type { RecommendApi } from './src/recommendApi';
+import { createRecommendApi } from '../src/recommendApi';
+import type { RecommendApi } from '../src/recommendApi';
 
-export * from './src/recommendApi';
+export * from '../src/recommendApi';
 
 export function recommendApi(
   appId: string,
@@ -22,15 +22,13 @@ export function recommendApi(
   return createRecommendApi({
     appId,
     apiKey,
-
     timeouts: {
-      connect: 1,
-      read: 2,
+      connect: 2,
+      read: 5,
       write: 30,
     },
-    requester: options?.requester ?? new XhrRequester(),
-    userAgents: [{ segment: 'Browser' }],
-    authMode: 'WithinQueryParameters',
+    requester: options?.requester ?? new HttpRequester(),
+    userAgents: [{ segment: 'Node.js', version: process.versions.node }],
     ...options,
   });
 }

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/clients/algoliasearch-client-javascript/packages/recommend/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["src", "model", "node.ts", "browser.ts"],
+  "include": ["src", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -13,8 +13,7 @@
     "clean": "rm -rf dist/"
   },
   "engines": {
-    "node": "^14.0.0",
-    "yarn": "^3.0.0"
+    "node": "^14.0.0"
   },
   "dependencies": {
     "@algolia/client-common": "5.0.0"

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -13,8 +13,7 @@
     "clean": "rm -rf dist/"
   },
   "engines": {
-    "node": "^14.0.0",
-    "yarn": "^3.0.0"
+    "node": "^14.0.0"
   },
   "dependencies": {
     "@algolia/client-common": "5.0.0"

--- a/openapitools.json
+++ b/openapitools.json
@@ -198,7 +198,7 @@
         "config": "#{cwd}/openapitools.json",
         "apiPackage": "src",
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-predict",
-        "glob": "specs/dist/predict.yml",
+        "glob": "specs/bundled/predict.yml",
         "gitHost": "algolia",
         "gitUserId": "algolia",
         "gitRepoId": "algoliasearch-client-javascript",

--- a/scripts/post-gen/javascript.sh
+++ b/scripts/post-gen/javascript.sh
@@ -7,6 +7,9 @@ FOLDER=$1
 
 # Generator does not allow new files, so we use existing ones to generate
 # our `node` and `browser` build files.
+destination=$FOLDER/builds
 
-mv $FOLDER/api.ts $FOLDER/node.ts
-mv $FOLDER/src/apis.ts $FOLDER/browser.ts
+mkdir -p $destination
+
+mv $FOLDER/api.ts $destination/node.ts
+mv $FOLDER/src/apis.ts $destination/browser.ts

--- a/templates/javascript/api-all.mustache
+++ b/templates/javascript/api-all.mustache
@@ -1,16 +1,16 @@
-{{! This file will be renamed to `browser.ts` after generating the client }}
+{{! This file will be renamed and moved to `builds/browser.ts` after generating the client }}
 
 import type { Host, Requester } from '@algolia/client-common';
 import { XhrRequester } from '@algolia/requester-browser-xhr';
 
-import { create{{capitalizedApiName}}Api } from './src/{{apiName}}Api';
-import type { {{capitalizedApiName}}Api } from './src/{{apiName}}Api';
+import { create{{capitalizedApiName}}Api } from '../src/{{apiName}}Api';
+import type { {{capitalizedApiName}}Api } from '../src/{{apiName}}Api';
 
 {{#hasRegionalHost}}
-import type { Region } from './src/{{apiName}}Api';
+import type { Region } from '../src/{{apiName}}Api';
 {{/hasRegionalHost}}
 
-export * from './src/{{apiName}}Api';
+export * from '../src/{{apiName}}Api';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function {{apiName}}Api(
@@ -36,8 +36,7 @@ export function {{apiName}}Api(
 
   return create{{capitalizedApiName}}Api({
     appId,
-    apiKey,
-    {{#hasRegionalHost}}region,{{/hasRegionalHost}}
+    apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
     timeouts: {
       connect: 1,
       read: 2,

--- a/templates/javascript/api.mustache
+++ b/templates/javascript/api.mustache
@@ -1,16 +1,16 @@
-{{! This file will be renamed to `node.ts` after generating the client }}
+{{! This file will be renamed and moved to `builds/node.ts` after generating the client }}
 
 import type { Host, Requester } from '@algolia/client-common';
 import { HttpRequester } from '@algolia/requester-node-http';
 
-import { create{{capitalizedApiName}}Api } from './src/{{apiName}}Api';
-import type { {{capitalizedApiName}}Api } from './src/{{apiName}}Api';
+import { create{{capitalizedApiName}}Api } from '../src/{{apiName}}Api';
+import type { {{capitalizedApiName}}Api } from '../src/{{apiName}}Api';
 
 {{#hasRegionalHost}}
-import type { Region } from './src/{{apiName}}Api';
+import type { Region } from '../src/{{apiName}}Api';
 {{/hasRegionalHost}}
 
-export * from './src/{{apiName}}Api';
+export * from '../src/{{apiName}}Api';
 
 export function {{apiName}}Api(
   appId: string,
@@ -35,8 +35,7 @@ export function {{apiName}}Api(
 
   return create{{capitalizedApiName}}Api({
     appId,
-    apiKey,
-    {{#hasRegionalHost}}region,{{/hasRegionalHost}}
+    apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
     timeouts: {
       connect: 2,
       read: 5,

--- a/templates/javascript/package.mustache
+++ b/templates/javascript/package.mustache
@@ -6,12 +6,12 @@
   "author": "Algolia",
   "private": true,
   "license": "MIT",
-  "main": "./dist/node.js",
-  "types": "./dist/node.d.ts",
-  "jsdelivr": "./dist/browser.js",
-  "unpkg": "./dist/browser.js",
+  "main": "./dist/builds/node.js",
+  "types": "./dist/builds/node.d.ts",
+  "jsdelivr": "./dist/builds/browser.js",
+  "unpkg": "./dist/builds/browser.js",
   "browser": {
-    "./index.js": "./dist/browser.js"
+    "./index.js": "./dist/builds/browser.js"
   },
   "scripts": {
     "build": "tsc",

--- a/templates/javascript/tsconfig.mustache
+++ b/templates/javascript/tsconfig.mustache
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
   },
-  "include": ["{{apiPackage}}", "model", "node.ts", "browser.ts"],
+  "include": ["{{apiPackage}}", "model", "builds/node.ts", "builds/browser.ts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-312

https://github.com/algolia/api-clients-automation/pull/135 introduces many side changes that are not directly related to the bundling. This PR groups the small fixes of this PR in order to ease the review on the bundling one.

### Changes included:

- Move `browser` and `node` build files to a `builds` folder
  - Those files are used the scope the user agent and requester dependency, we move them to a `builds` folder to make the folder cleaner and avoid confusion between generated code and build files. They will be used as `input` for the rollup bundler in https://github.com/algolia/api-clients-automation/pull/135
- Remove `yarn` engine enforcement in utils `package.json`
- Fix `predict` wrong path to bundled spec
- Remove empty line in the JavaScript templates

## 🧪 Test

CI :D
