### PR TITLE
fix(javascript): prevent conflict with `version` variable

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingApi.ts
@@ -11,7 +11,7 @@ import type { ABTestResponse } from '../model/aBTestResponse';
 import type { AddABTestsRequest } from '../model/addABTestsRequest';
 import type { ListABTestsResponse } from '../model/listABTestsResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 export type Region = 'de' | 'us';
 
@@ -42,7 +42,7 @@ export const createAbtestingApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Abtesting',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsApi.ts
@@ -26,7 +26,7 @@ import type { GetTopSearchesResponse } from '../model/getTopSearchesResponse';
 import type { GetTopSearchesResponseWithAnalytics } from '../model/getTopSearchesResponseWithAnalytics';
 import type { GetUsersCountResponse } from '../model/getUsersCountResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 export type Region = 'de' | 'us';
 
@@ -57,7 +57,7 @@ export const createAnalyticsApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Analytics',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsApi.ts
@@ -9,7 +9,7 @@ import type {
 import type { InsightEvents } from '../model/insightEvents';
 import type { PushEventsResponse } from '../model/pushEventsResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 export type Region = 'de' | 'us';
 
@@ -40,7 +40,7 @@ export const createInsightsApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Insights',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationApi.ts
@@ -11,7 +11,7 @@ import type { GetUserTokenResponse } from '../model/getUserTokenResponse';
 import type { PersonalizationStrategyParams } from '../model/personalizationStrategyParams';
 import type { SetPersonalizationStrategyResponse } from '../model/setPersonalizationStrategyResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 export type Region = 'eu' | 'us';
 
@@ -40,7 +40,7 @@ export const createPersonalizationApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Personalization',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-predict/src/predictApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/src/predictApi.ts
@@ -9,7 +9,7 @@ import type {
 import type { FetchUserProfileResponse } from '../model/fetchUserProfileResponse';
 import type { Params } from '../model/params';
 
-export const version = '0.0.1';
+export const apiClientVersion = '0.0.1';
 
 function getDefaultHosts(): Host[] {
   return [
@@ -34,7 +34,7 @@ export const createPredictApi = (options: CreateClientOptions) => {
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Predict',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsApi.ts
@@ -13,7 +13,7 @@ import type { QuerySuggestionsIndexWithIndexParam } from '../model/querySuggesti
 import type { Status } from '../model/status';
 import type { SucessResponse } from '../model/sucessResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 export type Region = 'eu' | 'us';
 
@@ -42,7 +42,7 @@ export const createQuerySuggestionsApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'QuerySuggestions',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-search/src/searchApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-search/src/searchApi.ts
@@ -68,7 +68,7 @@ import type { UpdatedAtWithObjectIdResponse } from '../model/updatedAtWithObject
 import type { UpdatedRuleResponse } from '../model/updatedRuleResponse';
 import type { UserId } from '../model/userId';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 function getDefaultHosts(appId: string): Host[] {
   return (
@@ -118,7 +118,7 @@ export const createSearchApi = (options: CreateClientOptions) => {
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Search',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/client-sources/src/sourcesApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/src/sourcesApi.ts
@@ -9,7 +9,7 @@ import type {
 import type { PostIngestUrlResponse } from '../model/postIngestUrlResponse';
 import type { PostURLJob } from '../model/postURLJob';
 
-export const version = '0.0.1';
+export const apiClientVersion = '0.0.1';
 
 export type Region = 'de' | 'us';
 
@@ -38,7 +38,7 @@ export const createSourcesApi = (
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Sources',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/clients/algoliasearch-client-javascript/packages/recommend/src/recommendApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/recommend/src/recommendApi.ts
@@ -14,7 +14,7 @@ import type {
 import type { GetRecommendationsParams } from '../model/getRecommendationsParams';
 import type { GetRecommendationsResponse } from '../model/getRecommendationsResponse';
 
-export const version = '5.0.0';
+export const apiClientVersion = '5.0.0';
 
 function getDefaultHosts(appId: string): Host[] {
   return (
@@ -64,7 +64,7 @@ export const createRecommendApi = (options: CreateClientOptions) => {
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: 'Recommend',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,

--- a/templates/javascript/api-single.mustache
+++ b/templates/javascript/api-single.mustache
@@ -5,7 +5,7 @@ import type { CreateClientOptions, Headers, Host, Request } from '@algolia/clien
 import { {{classname}} } from '{{filename}}';
 {{/imports}}
 
-export const version = '{{packageVersion}}';
+export const apiClientVersion = '{{packageVersion}}';
 
 {{#operations}}
 {{#description}}
@@ -82,7 +82,7 @@ export const create{{capitalizedApiName}}Api = (options: CreateClientOptions{{#h
     userAgent: getUserAgent({
       userAgents: options.userAgents,
       client: '{{{capitalizedApiName}}}',
-      version,
+      version: apiClientVersion,
     }),
     timeouts: options.timeouts,
     requester: options.requester,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

The `version` variable can conflict with API method parameters, see https://github.com/algolia/api-clients-automation/pull/140 for an example

### Changes included:

Rename exported `version` to `apiClientVersion`.

## 🧪 Test

CI :D
