### PR TITLE
chore(ci): update release process

### DIFF
--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -26,3 +26,4 @@ jobs:
         env:
           EVENT_NUMBER: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.TOKEN_RELEASE_BOT }}
+          RELEASE_TEST: ${{ secrets.RELEASE_TEST }}

--- a/scripts/release/process-release.ts
+++ b/scripts/release/process-release.ts
@@ -109,13 +109,14 @@ new Set([...Object.keys(versionsToRelease), ...langsToUpdateRepo]).forEach(
 );
 
 // commit openapitools and changelogs
-// Temporarily disabled ↓
-// run('git config user.name "api-clients-bot"');
-// run('git config user.email "bot@algolia.com"');
-// run('git add openapitools.json');
-// run('git add doc/changelogs/*');
-// execa.sync('git', ['commit', '-m', TEXT.commitMessage]);
-// run(`git push origin ${MAIN_BRANCH}`);
+if (process.env.RELEASE_TEST !== 'true') {
+  run('git config user.name "api-clients-bot"');
+  run('git config user.email "bot@algolia.com"');
+  run('git add openapitools.json');
+  run('git add doc/changelogs/*');
+  execa.sync('git', ['commit', '-m', TEXT.commitMessage]);
+  run(`git push origin ${MAIN_BRANCH}`);
+}
 
 // generate clients to release
 Object.keys(versionsToRelease).forEach((lang) => {


### PR DESCRIPTION
## 🧭 What and Why

### Changes included:

- It uses `secrets.TOKEN_RELEASE_BOT` for `process-release.ts` script because it needs to create a commit (openapitools.json and changelogs) and push to `main` branch directly, but the branch is protected. So we can have a bot account that is allowed to push to protected branch directly.

![ScreenShot 2022-02-22 at 11 22 47@2x](https://user-images.githubusercontent.com/499898/155112857-3c9e679e-7c1f-4a8c-aafe-e06e4dfa9706.png)


- It temporarily disables version changing part of the release process for easier test. (Otherwise we will see new commits every time we test release process)
