### PR TITLE
fix(javascript): use babel plugin for classProperties

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.17.2",
+    "@babel/plugin-proposal-class-properties": "7.16.7",
     "@babel/plugin-transform-runtime": "7.17.0",
     "@babel/preset-env": "7.16.11",
     "@babel/runtime": "7.17.2",

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -10,10 +10,7 @@
   "types": "index.d.ts",
   "jsdelivr": "dist/algoliasearch.umd.browser.js",
   "unpkg": "dist/algoliasearch.umd.browser.js",
-  "browser": {
-    "./index.js": "./dist/algoliasearch.cjs.browser.js",
-    "./lite.js": "./dist/algoliasearch-lite.cjs.browser.js"
-  },
+  "browser": "dist/algoliasearch.cjs.browser.js",
   "scripts": {
     "clean": "rm -rf ./dist"
   },

--- a/clients/algoliasearch-client-javascript/rollup.config.js
+++ b/clients/algoliasearch-client-javascript/rollup.config.js
@@ -203,6 +203,17 @@ packagesConfig.forEach((packageConfig) => {
           }),
         ]
       : [];
+    const clientCommonPlugins =
+      packageConfig.package === 'client-common'
+        ? [
+            babel({
+              babelrc: false,
+              extensions: ['.ts'],
+              exclude: 'node_modules/**',
+              plugins: ['@babel/plugin-proposal-class-properties'],
+            }),
+          ]
+        : [];
 
     if (isUmdBuild || isEsmBrowserBuild) {
       // eslint-disable-next-line no-param-reassign
@@ -227,6 +238,7 @@ packagesConfig.forEach((packageConfig) => {
             },
           },
         }),
+        ...clientCommonPlugins,
         ...transpilerPlugins,
         ...compressorPlugins,
         filesize({

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,7 +615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-class-properties@npm:^7.16.7":
+"@babel/plugin-proposal-class-properties@npm:7.16.7, @babel/plugin-proposal-class-properties@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/plugin-proposal-class-properties@npm:7.16.7"
   dependencies:
@@ -3524,6 +3524,7 @@ __metadata:
   resolution: "algoliasearch-client-javascript@workspace:clients/algoliasearch-client-javascript"
   dependencies:
     "@babel/core": 7.17.2
+    "@babel/plugin-proposal-class-properties": 7.16.7
     "@babel/plugin-transform-runtime": 7.17.0
     "@babel/preset-env": 7.16.11
     "@babel/runtime": 7.17.2


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Fix https://codesandbox.io/s/bold-forest-jc82hd?file=/src/index.js, I was not able to reproduce locally so I'm testing it blindfolded.

- Use babel plugin helper to handle class properties

The impact on the bundlesize is minimal, while the advantage of having this property are quite cool

- Fix `browser` entry, we don't have a `lite` version yet

## 🧪 Test

CI :D