### PR TITLE
fix(script): build `javascript-algoliasearch` after other clients

### DIFF
--- a/scripts/buildClients.ts
+++ b/scripts/buildClients.ts
@@ -94,22 +94,11 @@ export async function buildClients(
   // We exclude `javascript-algoliasearch` from the build batch because it
   // is made of built generated clients and can cause race issue when executed
   // together.
-  const { generators, jsAlgoliasearch } = allGenerators.reduce(
-    (prev, curr) => {
-      const gens = prev;
-
-      if (curr.key === 'javascript-algoliasearch') {
-        gens.jsAlgoliasearch = curr;
-      } else {
-        prev.generators.push(curr);
-      }
-
-      return gens;
-    },
-    { generators: [], jsAlgoliasearch: undefined } as {
-      generators: Generator[];
-      jsAlgoliasearch?: Generator;
-    }
+  const jsAlgoliasearch = allGenerators.find(
+    (gen) => gen.key === 'javascript-algoliasearch'
+  );
+  const generators = allGenerators.filter(
+    (gen) => gen.key !== 'javascript-algoliasearch'
   );
 
   await Promise.all([


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

_bug nb 1239234 regarding `javascript-algoliasearch`_

As the JavaScript `algoliasearch` client needs generated clients to be built, we can encounter race issue when clients are not built in the right order.

This PR exclude the `javascript-algoliasearch` client from the generators and runs it after.

## 🧪 Test

CI :D 
