### PR TITLE
fix(javascript): use package version in rollup

### DIFF
--- a/clients/algoliasearch-client-javascript/version.js
+++ b/clients/algoliasearch-client-javascript/version.js
@@ -1,1 +1,0 @@
-export const version = '0.0.4';


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-365

### Changes included:

Fix rollup config to read the `version` from the `package.json` file instead of a global `version.js` file.

## 🧪 Test

CI :D