### PR TITLE
chore: fix `client_*` matrix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -133,7 +133,11 @@ jobs:
       - setup
       - specs
       - client_javascript_common
-    if: ${{ needs.setup.outputs.RUN_JS == 'true' }}
+    if: |
+      always() &&
+      needs.setup.outputs.RUN_JS == 'true' &&
+      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.JS_MATRIX) }}
     steps:
@@ -172,7 +176,11 @@ jobs:
     needs:
       - setup
       - specs
-    if: ${{ needs.setup.outputs.RUN_JAVA == 'true' }}
+    if: |
+      always() &&
+      needs.setup.outputs.RUN_JAVA == 'true' &&
+      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.JAVA_MATRIX) }}
     steps:
@@ -211,7 +219,11 @@ jobs:
     needs:
       - setup
       - specs
-    if: ${{ needs.setup.outputs.RUN_PHP == 'true' }}
+    if: |
+      always() &&
+      needs.setup.outputs.RUN_PHP == 'true' &&
+      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.PHP_MATRIX) }}
     steps:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Follow up of https://github.com/algolia/api-clients-automation/pull/250

As seen in https://github.com/algolia/api-clients-automation/pull/252, jobs that are `skipped` due to an empty matrix are not returning a `success` status, so subsequent jobs won't run.

This PR applies the same fix found for the `CTS` to the `client_*` jobs.

## 🧪 Test

CI :D 
