### PR TITLE
chore: make ci push `yarn.lock` updates

### DIFF
--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -3,7 +3,7 @@ import { run } from '../../common';
 import { configureGitHubAuthor } from '../../release/common';
 
 const PR_NUMBER = parseInt(process.env.PR_NUMBER || '0', 10);
-const FOLDERS_TO_CHECK = 'openapitools.json clients specs/bundled';
+const FOLDERS_TO_CHECK = 'yarn.lock openapitools.json clients specs/bundled';
 
 /**
  * Push generated code for the current `JOB` and `CLIENT` on a `generated/` branch.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

Bumping version of the generated clients will update the `yarn.lock`, so we should also check for their changes.

It should be enough to fix https://github.com/algolia/api-clients-automation/pull/264

## 🧪 Test

CI :D 
