### PR TITLE
feat(java): add fat jar APIC-262

### DIFF
--- a/clients/algoliasearch-client-java-2/algoliasearch-core/build.gradle
+++ b/clients/algoliasearch-client-java-2/algoliasearch-core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library'
     id 'com.vanniktech.maven.publish'
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
 description = 'algoliasearch-client-java-2'


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [APIC-262](https://algolia.atlassian.net/browse/APIC-262)

Include fat jar including all libs requested by some clients, this make the size of the jar go from `500KB` to `3.5MB`
It can be accessed has `com.algolia.algoliasearch-core-all:0.0.1-SNAPSHOT`

### Changes included:

- Add fat jar

## 🧪 Test

`./gradle/gradlew -p clients/algoliasearch-client-java-2 assemble`