### PR TITLE
chore(ci): fix regression on release issue generation

### DIFF
--- a/scripts/release/__tests__/create-release-issue.test.ts
+++ b/scripts/release/__tests__/create-release-issue.test.ts
@@ -2,9 +2,20 @@ import {
   parseCommit,
   getVersionChangesText,
   decideReleaseStrategy,
+  readVersions,
 } from '../create-release-issue';
 
 describe('create release issue', () => {
+  it('reads versions openapitools.json', () => {
+    expect(readVersions()).toEqual({
+      java: {
+        current: expect.any(String),
+      },
+      javascript: { current: expect.any(String) },
+      php: { current: expect.any(String) },
+    });
+  });
+
   it('parses commit', () => {
     expect(parseCommit(`abcdefg fix(javascript): fix the thing`)).toEqual({
       hash: 'abcdefg',

--- a/scripts/release/create-release-issue.ts
+++ b/scripts/release/create-release-issue.ts
@@ -23,12 +23,12 @@ import type {
 
 dotenv.config({ path: ROOT_ENV_PATH });
 
-function readVersions(): VersionsWithoutReleaseType {
+export function readVersions(): VersionsWithoutReleaseType {
   return Object.keys(MAIN_GENERATOR).reduce((acc, lang) => {
     return {
       ...acc,
       [lang]: {
-        current: getPackageVersion(lang),
+        current: getPackageVersion(MAIN_GENERATOR[lang]),
       },
     };
   }, {});


### PR DESCRIPTION
## 🧭 What and Why


### Changes included:

- It fixes a regression which was introduced lately. `readVersions` failed because it didn't read versions correctly.

## 🧪 Test

- New test is added