### PR TITLE
chore(ci): use correct variable to get the latest commit message in js repo

### DIFF
--- a/clients/algoliasearch-client-javascript/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-javascript/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: Publish
     runs-on: ubuntu-20.04
-    if: "startsWith(github.event.issue.title, 'chore: release v')"
+    if: "startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/scripts/release/process-release.ts
+++ b/scripts/release/process-release.ts
@@ -214,7 +214,7 @@ async function processRelease(): Promise<void> {
     const next = semver.inc(current, releaseType);
 
     await gitCommit({
-      message: `chore: release ${next}`,
+      message: `chore: release v${next}`,
       cwd: tempGitDir,
     });
     await execa('git', ['tag', `v${next}`], { cwd: tempGitDir });


### PR DESCRIPTION
## 🧭 What and Why

### Changes included:

- The GitHub Action in the JS repo checked the wrong variable. It needs to check if `github.event.head_commit.message` starts with `chore: release v`.
- It also updates the release script to include `v` in the commit message, which was missing.
