### PR TITLE
chore(ci): fix regression regarding emptyDir

### DIFF
--- a/scripts/release/process-release.ts
+++ b/scripts/release/process-release.ts
@@ -112,7 +112,7 @@ async function updateOpenApiTools(
 }
 
 async function emptyDirExceptForDotGit(dir: string): Promise<void> {
-  for await (const file of await fsp.readdir(dir)) {
+  for (const file of await fsp.readdir(dir)) {
     if (file !== '.git') {
       await remove(path.resolve(dir, file));
     }


### PR DESCRIPTION
## 🧭 What and Why

### Changes included:

- This fixes the regression introduced #301. It emptied the directory completely including `.git` folder, which is not our intension.
- This PR adds `emptyDirExceptForDotGit` function for the purpose.