### PR TITLE
chore(ci): replace github token for processing release

### DIFF
--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.TOKEN_RELEASE_BOT }}
 
       - name: Setup
         id: setup


### PR DESCRIPTION
## 🧭 What and Why

### Changes included:

`actions/checkout@v2` checks out the repository with the default github token which is provided by github. However it does not have as much access as we expect. We need to use a personal access token from `algolia-bot` account, because this repository allows that user to bypass the rules on the protected branch (`main`), so that it can push commits to `main` branch directly on github action without any pull requests.

We update `openapitools.json` and changelogs.

## 🧪 Test
