### PR TITLE
chore: prevent running jobs on cancel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -149,7 +149,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_JS == 'true' &&
-      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.JS_MATRIX) }}
@@ -198,8 +198,8 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_JS_ALGOLIASEARCH == 'true' &&
-      contains(needs.client_javascript.result, 'success') &&
-      !contains(needs.client_javascript.result, 'failure')
+      !contains(needs.*.result, 'cancelled') &&
+      !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@v2
 
@@ -236,7 +236,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_JAVA == 'true' &&
-      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.JAVA_MATRIX) }}
@@ -285,7 +285,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_PHP == 'true' &&
-      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.PHP_MATRIX) }}
@@ -334,7 +334,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_JS_TESTS == 'true' &&
-      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@v2
@@ -358,7 +358,7 @@ jobs:
     if: |
       always() &&
       needs.setup.outputs.RUN_CTS == 'true' &&
-      contains(needs.*.result, 'success') &&
+      !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Follow up of https://github.com/algolia/api-clients-automation/pull/253

As seen on https://github.com/algolia/api-clients-automation/actions/runs/2101479001 cancelled jobs are not considered as failure, this should fix the condition.

I've tried to remove the `always` condition by early exiting jobs, but it's not supported in GitHub actions yet https://github.com/actions/runner/issues/662

## 🧪 Test

CI :D
