### PR TITLE
chore: codegen start from current branch

### DIFF
--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { run, GENERATED_MAIN_BRANCH } from '../../common';
+import { run } from '../../common';
 import { configureGitHubAuthor } from '../../release/common';
 import { getNbGitDiff } from '../utils';
 
@@ -45,9 +45,7 @@ export async function pushGeneratedCode(): Promise<void> {
     await run(`yarn workspace scripts cleanGeneratedBranch ${baseBranch}`);
 
     console.log(`Creating branch for generated code: '${generatedCodeBranch}'`);
-    await run(
-      `git branch ${generatedCodeBranch} origin/${GENERATED_MAIN_BRANCH}`
-    );
+    await run(`git branch ${generatedCodeBranch}`);
   }
 
   await run(`git checkout ${generatedCodeBranch}`);


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

I've previously assumed that it made sense to start the new generated branch from the `generated/main` one to reduce the commit size, but it should not matter as long as the compare is correct.

This should prevent checkout issue and fix the current issue on main (hopefully)

## 🧪 Test

CI :D
