### PR TITLE
chore: revert "chore: release 2022-04-11"

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,5 +1,0 @@
-## [v0.0.6](https://github.com/algolia/algoliasearch-client-javascript/compare/v0.0.5...v0.0.6)
-
-### javascript
-- b07f5f99 fix(javascript): handle parent in models (#339)
-

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/algoliasearch",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -18,12 +18,12 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-analytics": "0.0.6",
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/client-personalization": "0.0.6",
-    "@experimental-api-clients-automation/client-search": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-analytics": "0.0.5",
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/client-personalization": "0.0.5",
+    "@experimental-api-clients-automation/client-search": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-abtesting",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingApi.ts
@@ -18,7 +18,7 @@ import type { AddABTestsRequest } from '../model/addABTestsRequest';
 import type { ListABTestsResponse } from '../model/listABTestsResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'de' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-analytics",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsApi.ts
@@ -31,7 +31,7 @@ import type { GetTopSearchesResponse } from '../model/getTopSearchesResponse';
 import type { GetUsersCountResponse } from '../model/getUsersCountResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'de' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-common",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-insights",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsApi.ts
@@ -16,7 +16,7 @@ import type { InsightEvents } from '../model/insightEvents';
 import type { PushEventsResponse } from '../model/pushEventsResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'de' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-personalization",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationApi.ts
@@ -18,7 +18,7 @@ import type { PersonalizationStrategyParams } from '../model/personalizationStra
 import type { SetPersonalizationStrategyResponse } from '../model/setPersonalizationStrategyResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'eu' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/client-predict/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-predict",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-predict",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-predict/src/predictApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-predict/src/predictApi.ts
@@ -16,7 +16,7 @@ import type { FetchUserProfileResponse } from '../model/fetchUserProfileResponse
 import type { Params } from '../model/params';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 function getDefaultHosts(): Host[] {
   return [

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-query-suggestions",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsApi.ts
@@ -20,7 +20,7 @@ import type { Status } from '../model/status';
 import type { SucessResponse } from '../model/sucessResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'eu' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-search",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-search/src/searchApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-search/src/searchApi.ts
@@ -73,7 +73,7 @@ import type { UpdatedRuleResponse } from '../model/updatedRuleResponse';
 import type { UserId } from '../model/userId';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/client-sources/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-sources",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/client-sources",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/client-sources/src/sourcesApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-sources/src/sourcesApi.ts
@@ -16,7 +16,7 @@ import type { PostIngestUrlResponse } from '../model/postIngestUrlResponse';
 import type { PostURLJob } from '../model/postURLJob';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 export type Region = 'de' | 'us';
 

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/recommend",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "JavaScript client for @experimental-api-clients-automation/recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -24,9 +24,9 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6",
-    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.6",
-    "@experimental-api-clients-automation/requester-node-http": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5",
+    "@experimental-api-clients-automation/requester-browser-xhr": "0.0.5",
+    "@experimental-api-clients-automation/requester-node-http": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/recommend/src/recommendApi.ts
+++ b/clients/algoliasearch-client-javascript/packages/recommend/src/recommendApi.ts
@@ -17,7 +17,7 @@ import type { GetRecommendationsParams } from '../model/getRecommendationsParams
 import type { GetRecommendationsResponse } from '../model/getRecommendationsResponse';
 
 export * from '../model/models';
-export const apiClientVersion = '0.0.6';
+export const apiClientVersion = '0.0.5';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/requester-browser-xhr",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -21,7 +21,7 @@
     "index.ts"
   ],
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/requester-node-http",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "author": "Algolia",
@@ -20,7 +20,7 @@
     "index.ts"
   ],
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.0.6"
+    "@experimental-api-clients-automation/client-common": "0.0.5"
   },
   "devDependencies": {
     "@types/node": "16.11.26",

--- a/openapitools.json
+++ b/openapitools.json
@@ -21,9 +21,9 @@
           "buildFile": "client-search",
           "apiName": "search",
           "capitalizedApiName": "Search",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-search",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-recommend": {
@@ -44,9 +44,9 @@
           "buildFile": "recommend",
           "apiName": "recommend",
           "capitalizedApiName": "Recommend",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/recommend",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-personalization": {
@@ -66,13 +66,13 @@
           "buildFile": "client-personalization",
           "apiName": "personalization",
           "capitalizedApiName": "Personalization",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-personalization",
           "hasRegionalHost": true,
           "isEuHost": true,
           "host": "personalization",
           "topLevelDomain": "com",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-analytics": {
@@ -92,14 +92,14 @@
           "buildFile": "client-analytics",
           "apiName": "analytics",
           "capitalizedApiName": "Analytics",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-analytics",
           "fallbackToAliasHost": true,
           "hasRegionalHost": true,
           "isDeHost": true,
           "host": "analytics",
           "topLevelDomain": "com",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-insights": {
@@ -119,14 +119,14 @@
           "buildFile": "client-insights",
           "apiName": "insights",
           "capitalizedApiName": "Insights",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-insights",
           "fallbackToAliasHost": true,
           "hasRegionalHost": true,
           "isDeHost": true,
           "host": "insights",
           "topLevelDomain": "io",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-abtesting": {
@@ -146,14 +146,14 @@
           "buildFile": "client-abtesting",
           "apiName": "abtesting",
           "capitalizedApiName": "Abtesting",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-abtesting",
           "hasRegionalHost": true,
           "fallbackToAliasHost": true,
           "isDeHost": true,
           "host": "analytics",
           "topLevelDomain": "com",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-query-suggestions": {
@@ -173,13 +173,13 @@
           "buildFile": "client-query-suggestions",
           "apiName": "querySuggestions",
           "capitalizedApiName": "QuerySuggestions",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-query-suggestions",
           "hasRegionalHost": true,
           "isEuHost": true,
           "host": "query-suggestions",
           "topLevelDomain": "com",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-sources": {
@@ -199,13 +199,13 @@
           "buildFile": "client-sources",
           "apiName": "sources",
           "capitalizedApiName": "Sources",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-sources",
           "hasRegionalHost": true,
           "isDeHost": true,
           "host": "data",
           "topLevelDomain": "com",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "javascript-predict": {
@@ -225,10 +225,10 @@
           "buildFile": "client-predict",
           "apiName": "predict",
           "capitalizedApiName": "Predict",
-          "packageVersion": "0.0.6",
+          "packageVersion": "0.0.5",
           "packageName": "@experimental-api-clients-automation/client-predict",
           "experimentalHost": "predict-api-oslcbws3zq-ew.a.run.app",
-          "utilsPackageVersion": "0.0.6"
+          "utilsPackageVersion": "0.0.5"
         }
       },
       "java-search": {


### PR DESCRIPTION
## 🧭 What and Why

### Changes included:

The whole flow worked on the monorepo side, but it failed on the JS repository (https://github.com/algolia/algoliasearch-client-javascript/runs/5973086555?check_suite_focus=true). So we revert the commit, and retry later after fixing the issue with the JS repo.

## 🧪 Test
