### PR TITLE
chore: set token when checking out

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -399,6 +399,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.TOKEN_RELEASE_BOT }}
 
       - name: Restore cache
         uses: ./.github/actions/cache


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

Follow up of https://github.com/algolia/api-clients-automation/pull/310

checkout action uses the default token when checking out, which is not ideal in our case as we need to let the bot push to `main`, which is protected.

## 🧪 Test

CI :D 
