### PR TITLE
chore(ci): push generated code before cts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -428,8 +428,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
 
       - name: Spread generation to each repository
-        if: |
-          steps.pushGeneratedCode.exitcode == 0
+        if: steps.pushGeneratedCode.exitcode == 0
         run: yarn workspace scripts spreadGeneration
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_RELEASE_BOT }}

--- a/specs/abtesting/paths/abtest.yml
+++ b/specs/abtesting/paths/abtest.yml
@@ -16,6 +16,8 @@ get:
             $ref: '../common/schemas/ABTest.yml#/ABTest'
     '400':
       $ref: '../../common/responses/BadRequest.yml'
+    '402':
+      $ref: '../../common/responses/FeatureNotEnabled.yml'
     '403':
       $ref: '../../common/responses/MethodNotAllowed.yml'
     '404':


### PR DESCRIPTION
## 🧭 What and Why

On the PRs, we don't have to wait for the CTS before pushing the generated code, and it can help debug the CTS.

### Changes included:

- Create special job for PR just to push code.

## 🧪 Test

CI
