### PR TITLE
fix(script): restore previous CLI build logic

### DIFF
--- a/clients/algoliasearch-client-javascript/rollup.config.js
+++ b/clients/algoliasearch-client-javascript/rollup.config.js
@@ -95,14 +95,18 @@ function getUtilConfigs() {
   ];
 }
 
-function isClientBuilt(client) {
+function shouldBuildUtil(utilClient) {
+  if (process.env.SKIP_UTILS === 'true') {
+    return false;
+  }
+
   // Checking existence of `dist` folder doesn't really guarantee the built files are up-to-date.
   // However, on the CI, it's very likely.
   // For the local environment, we simply return `false`, which will trigger unnecessary builds.
   // We can come back here and improve this part (checking if `dist` folder exists and if it's up-to-date).
   return process.env.CI
-    ? fs.existsSync(path.resolve('packages', client, 'dist'))
-    : false;
+    ? !fs.existsSync(path.resolve('packages', utilClient, 'dist'))
+    : true;
 }
 
 function getPackageConfigs() {
@@ -168,7 +172,7 @@ function getPackageConfigs() {
   });
 
   return [
-    ...getUtilConfigs().filter((config) => !isClientBuilt(config.package)),
+    ...getUtilConfigs().filter((config) => shouldBuildUtil(config.package)),
     ...configs,
   ];
 }

--- a/scripts/buildClients.ts
+++ b/scripts/buildClients.ts
@@ -1,47 +1,40 @@
-import {
-  createGeneratorKey,
-  GENERATORS,
-  LANGUAGES,
-  run,
-  toAbsolutePath,
-} from './common';
+import { run } from './common';
 import { getLanguageFolder } from './config';
 import { createSpinner } from './oraLog';
+import type { Generator } from './types';
+
+const multiBuildLanguage = new Set(['javascript']);
+
+/**
+ * Build only a specific client for one language, used by javascript for example.
+ */
+async function buildPerClient(
+  { language, key, additionalProperties: { packageName } }: Generator,
+  verbose: boolean
+): Promise<void> {
+  const spinner = createSpinner(`building ${key}`, verbose).start();
+  switch (language) {
+    case 'javascript':
+      await run(`yarn workspace ${packageName} clean`, { verbose });
+      await run(
+        `SKIP_UTILS=true yarn workspace algoliasearch-client-javascript build ${packageName}`,
+        { verbose }
+      );
+      break;
+    default:
+  }
+  spinner.succeed();
+}
 
 /**
  * Build all client for a language at the same time, for those who live in the same folder.
  */
-async function buildPerLanguage({
-  language,
-  client,
-  verbose,
-}: {
-  language: string;
-  client: string;
-  verbose: boolean;
-}): Promise<void> {
+async function buildAllClients(
+  language: string,
+  verbose: boolean
+): Promise<void> {
   const spinner = createSpinner(`building '${language}'`, verbose).start();
-  const cwd = toAbsolutePath(getLanguageFolder(language));
-  const generator =
-    client === 'all'
-      ? null
-      : GENERATORS[createGeneratorKey({ language, client })];
-
   switch (language) {
-    case 'javascript':
-      await run(`yarn clean`, { cwd, verbose });
-      await run(
-        `yarn build ${
-          client === 'all'
-            ? ''
-            : generator?.additionalProperties.buildFile ?? client
-        }`,
-        {
-          cwd,
-          verbose,
-        }
-      );
-      break;
     case 'java':
       await run(
         `./gradle/gradlew --no-daemon -p ${getLanguageFolder(
@@ -60,19 +53,37 @@ async function buildPerLanguage({
 }
 
 export async function buildClients(
-  language: string,
-  client: string,
+  generators: Generator[],
   verbose: boolean
 ): Promise<void> {
-  const languages = language === 'all' ? LANGUAGES : [language];
+  const langs = [...new Set(generators.map((gen) => gen.language))];
 
-  await Promise.all(
-    languages.map((lang) =>
-      buildPerLanguage({
-        language: lang,
-        client,
-        verbose,
-      })
-    )
-  );
+  if (langs.includes('javascript')) {
+    const spinner = createSpinner(
+      "building 'JavaScript' utils",
+      verbose
+    ).start();
+
+    await run('yarn workspace algoliasearch-client-javascript clean:utils', {
+      verbose,
+    });
+    await run('yarn workspace algoliasearch-client-javascript build:utils', {
+      verbose,
+    });
+
+    spinner.succeed();
+  }
+
+  await Promise.all([
+    Promise.all(
+      generators
+        .filter(({ language }) => multiBuildLanguage.has(language))
+        .map((gen) => buildPerClient(gen, verbose))
+    ),
+    Promise.all(
+      langs
+        .filter((lang) => !multiBuildLanguage.has(lang))
+        .map((lang) => buildAllClients(lang, verbose))
+    ),
+  ]);
 }

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -151,13 +151,14 @@ buildCommand
     ) => {
       language = await promptLanguage(language, interactive);
 
-      const shouldBuildJs = language === 'javascript' || language === 'all';
-      const clientList = shouldBuildJs
-        ? [...CLIENTS_JS_UTILS, ...CLIENTS_JS]
-        : CLIENTS;
+      const clientList =
+        language === 'javascript' || language === 'all' ? CLIENTS_JS : CLIENTS;
       client = await promptClient(client, interactive, clientList);
 
-      await buildClients(language, client, Boolean(verbose));
+      await buildClients(
+        generatorList({ language, client, clientList }),
+        Boolean(verbose)
+      );
     }
   );
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

As seen in https://github.com/algolia/api-clients-automation/pull/383, changes in https://github.com/algolia/api-clients-automation/pull/371 introduced many changes regarding the JS build. This PR fixes issue at the CLI level of the monorepo:
- Erase all `dist` folders
- Does not build clients in parallel (memory issue, `all` runs for ~20 mins)
  - I've restored the previous logic, which prevent memory issue on the CLI and build all clients in ~5 mins.

This PR does not introduce changes on the rollup config other than what's in https://github.com/algolia/api-clients-automation/pull/383, so it should not interfere with @eunjae-lee's work but can allow us to work on JS clients until fixed.

## 🧪 Test

CI :D 