### PR TITLE
chore: fix codegen check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -406,7 +406,7 @@ jobs:
       - client_javascript_algoliasearch
     if: |
       always() &&
-      github.event_name == 'refs/heads/main' &&
+      github.ref == 'refs/heads/main' &&
       needs.setup.outputs.RUN_CODEGEN == 'true' &&
       needs.cts.result == 'success'
     steps:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

The CI skipped the codegen on main because it checked for the event name, instead of the ref name.

## 🧪 Test

CI :D 
