### PR TITLE
chore: make spread codegen commit cleaner

### DIFF
--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -1,5 +1,6 @@
 import { LANGUAGES } from '../../../common';
 import { decideWhereToSpread, cleanUpCommitMessage } from '../spreadGeneration';
+import text from '../text';
 
 describe('spread generation', () => {
   it('skips in case of release commit', () => {
@@ -43,6 +44,15 @@ describe('spread generation', () => {
       "fix(java): solve oneOf using a custom generator https://algolia.atlassian.net/browse/APIC-123
 
       https://github.com/algolia/api-clients-automation/pull/200"
+    `);
+  });
+
+  it('provides a link to the automation repo for commit with hash', () => {
+    const commitMessage = `${text.commitStartMessage} ed33e02f3e45fd72b4f420a56e4be7c6929fca9f. [skip ci]`;
+    expect(cleanUpCommitMessage(commitMessage)).toMatchInlineSnapshot(`
+      "chore: generated code for commit ed33e02f. [skip ci]
+
+      https://github.com/algolia/api-clients-automation/commit/ed33e02f3e45fd72b4f420a56e4be7c6929fca9f"
     `);
   });
 });

--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -3,6 +3,8 @@ import { MAIN_BRANCH, run } from '../../common';
 import { configureGitHubAuthor } from '../../release/common';
 import { getNbGitDiff } from '../utils';
 
+import text from './text';
+
 const PR_NUMBER = parseInt(process.env.PR_NUMBER || '0', 10);
 const FOLDERS_TO_CHECK = 'yarn.lock openapitools.json clients specs/bundled';
 
@@ -48,10 +50,9 @@ export async function pushGeneratedCode(): Promise<void> {
     await run(`git checkout -b ${branchToPush}`);
   }
 
-  const commitMessage =
-    await run(`git show -s ${baseBranch} --format="chore: generated code for commit %H. ${
-      isMainBranch ? '[skip ci]' : ''
-    }
+  const commitMessage = await run(`git show -s ${baseBranch} --format="${
+    text.commitStartMessage
+  } %H. ${isMainBranch ? '[skip ci]' : ''}
 
 Co-authored-by: %an <%ae>
 %(trailers:key=Co-authored-by)"`);

--- a/scripts/ci/codegen/text.ts
+++ b/scripts/ci/codegen/text.ts
@@ -1,6 +1,7 @@
 import { MAIN_BRANCH, REPO_URL } from '../../common';
 
 export default {
+  commitStartMessage: 'chore: generated code for commit',
   notification: {
     header: '### 🔨 The codegen job will run at the end of the CI.',
     body: '_Make sure your last commit does not contains generated code, it will be automatically pushed by our CI._',


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Commits from codegen loses context on other repositories (see https://github.com/algolia/algoliasearch-client-java-2/commit/80ba40c9bcc1548880ea54152aab2590266ae260), this PR aims at providing a link to the commit from the automation repository.

## 🧪 Test

CI :D 
