### PR TITLE
chore(ci): display skipped commits in release issue

### DIFF
--- a/scripts/release/__tests__/create-release-issue.test.ts
+++ b/scripts/release/__tests__/create-release-issue.test.ts
@@ -1,6 +1,7 @@
 import {
   parseCommit,
   getVersionChangesText,
+  getSkippedCommitsText,
   decideReleaseStrategy,
   readVersions,
 } from '../create-release-issue';
@@ -246,5 +247,34 @@ describe('create release issue', () => {
     expect(versions.javascript.skipRelease).toEqual(true);
     expect(versions.java.skipRelease).toBeUndefined();
     expect(versions.php.skipRelease).toBeUndefined();
+  });
+
+  it('generates text for skipped commits', () => {
+    expect(
+      getSkippedCommitsText({
+        commitsWithoutLanguageScope: [],
+        commitsWithUnknownLanguageScope: [],
+      })
+    ).toMatchInlineSnapshot(`"_(None)_"`);
+
+    expect(
+      getSkippedCommitsText({
+        commitsWithoutLanguageScope: ['abcdefg fix: something'],
+        commitsWithUnknownLanguageScope: ['abcdef2 fix(pascal): what'],
+      })
+    ).toMatchInlineSnapshot(`
+      "<p></p>
+        <p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>
+
+        <p>Commits without language scope:</p>
+        <ul>
+          <li>abcdefg fix: something</li>
+        </ul>
+
+        <p>Commits with unknown language scope:</p>
+        <ul>
+          <li>abcdef2 fix(pascal): what</li>
+        </ul>"
+    `);
   });
 });

--- a/scripts/release/text.ts
+++ b/scripts/release/text.ts
@@ -2,6 +2,8 @@ export default {
   header: `## Summary`,
 
   versionChangeHeader: `## Version Changes`,
+  skippedCommitsHeader: `### Skipped Commits`,
+  skippedCommitsDesc: `It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.`,
   noCommit: `no commit`,
   currentVersionNotFound: `current version not found`,
   descriptionVersionChanges: [


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-372

### Changes included:

It updates the release issue to display skipped commits.

example1.
<kbd>
<img width="173" alt="ScreenShot 2022-04-26 at 16 04 42@2x" src="https://user-images.githubusercontent.com/499898/165319142-50ff69e5-04b6-4c67-aa75-fcb4240d9c08.png">
</kbd>



example2.
<kbd>
<img width="823" alt="ScreenShot 2022-04-26 at 16 04 27@2x" src="https://user-images.githubusercontent.com/499898/165319153-f7be056c-e424-494f-9c6a-196c9f73146b.png">
</kbd>



## 🧪 Test

- CI