### PR TITLE
chore: use gen token for CTS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -431,7 +431,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.TOKEN_RELEASE_BOT }}
+          token: ${{ secrets.TOKEN_GENERATE_BOT }}
 
       - name: Restore cache
         uses: ./.github/actions/cache


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

We don't need to use the release token here, only the gen one should be enough.

## 🧪 Test

CI
