### PR TITLE
chore(ci): update cts and playground dependencies on release

### DIFF
--- a/scripts/release/process-release.ts
+++ b/scripts/release/process-release.ts
@@ -11,6 +11,7 @@ import openapitools from '../../openapitools.json';
 import {
   ROOT_ENV_PATH,
   toAbsolutePath,
+  updateDependenciesToLocalVersions,
   run,
   exists,
   getGitHubUrl,
@@ -44,6 +45,10 @@ const BEFORE_CLIENT_GENERATION: {
 } = {
   javascript: async ({ releaseType, dir }) => {
     await run(`yarn release:bump ${releaseType}`, { cwd: dir });
+
+    await updateDependenciesToLocalVersions('tests/output/javascript');
+    await updateDependenciesToLocalVersions('playground/javascript/browser');
+    await updateDependenciesToLocalVersions('playground/javascript/node');
   },
 };
 

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -48,6 +48,10 @@ export type Spec = {
   paths: Path[];
 };
 
+export type PackageLocationMap = {
+  [packageName: string]: string;
+};
+
 /**
  * Server of a spec.
  */


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-453

### Changes included:

This PR makes the release process to bump the versions in cts and playground to the locally latest versions. This only works for JavaScript, and for other languages, it should be dealt separately.