### PR TITLE
feat(cts): add tests for Predict

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCtsGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCtsGenerator.java
@@ -145,6 +145,7 @@ public class AlgoliaCtsGenerator extends DefaultCodegen {
       bundle.put("clientPrefix", Utils.createClientName(client, language));
       bundle.put("import", createImportName());
       bundle.put("hasRegionalHost", hasRegionalHost);
+      bundle.put("defaultRegion", client.equals("predict") ? "ew" : "us");
       bundle.put("lambda", lambda);
 
       List<Object> blocks = new ArrayList<>();

--- a/playground/javascript/node/predict.ts
+++ b/playground/javascript/node/predict.ts
@@ -11,7 +11,7 @@ const apiKey =
 const userId = 'user1';
 
 // Init client with appId and apiKey
-const client = predictClient(appId, apiKey);
+const client = predictClient(appId, apiKey, 'ew');
 
 async function testPredict() {
   try {

--- a/scripts/cts/client/generate.ts
+++ b/scripts/cts/client/generate.ts
@@ -101,6 +101,7 @@ export async function generateClientTests(
       client: `${createClientName(client, language)}Client`,
       blocks: modifyForMustache(testsBlocks),
       hasRegionalHost: hasRegionalHost ? true : undefined,
+      defaultRegion: client === 'predict' ? 'ew' : 'us',
     },
     partialTemplates
   );

--- a/specs/predict/common/enums.yml
+++ b/specs/predict/common/enums.yml
@@ -1,7 +1,0 @@
-modelsToRetrieve:
-  type: string
-  enum: [funnel_stage, order_value, affinities]
-
-typesToRetrieve:
-  type: string
-  enum: [properties, segments]

--- a/specs/predict/common/schemas/Params.yml
+++ b/specs/predict/common/schemas/Params.yml
@@ -1,0 +1,38 @@
+params:
+  oneOf:
+    - $ref: '#/modelsToRetrieve'
+    - $ref: '#/typesToRetrieve'
+    - $ref: '#/allParams'
+
+allParams:
+  allOf:
+    - $ref: '#/modelsToRetrieve'
+    - $ref: '#/typesToRetrieve'
+
+modelsToRetrieve:
+  type: object
+  required:
+    - modelsToRetrieve
+  properties:
+    modelsToRetrieve:
+      type: array
+      items:
+        $ref: '#/modelsToRetrieveEnum'
+
+typesToRetrieve:
+  type: object
+  required:
+    - typesToRetrieve
+  properties:
+    typesToRetrieve:
+      type: array
+      items:
+        $ref: '#/typesToRetrieveEnum'
+
+modelsToRetrieveEnum:
+  type: string
+  enum: [funnel_stage, order_value, affinities]
+
+typesToRetrieveEnum:
+  type: string
+  enum: [properties, segments]

--- a/specs/predict/paths/fetchUserProfile.yml
+++ b/specs/predict/paths/fetchUserProfile.yml
@@ -9,22 +9,7 @@ post:
     content:
       application/json:
         schema:
-          title: params
-          type: object
-          description: Object with models and types to retrieve.
-          additionalProperties: false
-          properties:
-            modelsToRetrieve:
-              type: array
-              description: List with model types for which to retrieve predictions.
-              items:
-                $ref: '../common/enums.yml#/modelsToRetrieve'
-            typesToRetrieve:
-              type: array
-              description: List with types to be retrieved.
-              items:
-                $ref: '../common/enums.yml#/typesToRetrieve'
-              minItems: 1
+          $ref: '../common/schemas/Params.yml#/params'
   responses:
     '200':
       description: OK

--- a/tests/CTS/client/predict/api.json
+++ b/tests/CTS/client/predict/api.json
@@ -1,0 +1,56 @@
+[
+  {
+    "testName": "calls api with correct user agent",
+    "steps": [
+      {
+        "type": "method",
+        "object": "$client",
+        "path": "fetchUserProfile",
+        "parameters": [
+          {
+            "userID": "user1",
+            "params": {
+              "modelsToRetrieve": [
+                "funnel_stage"
+              ]
+            }
+          }
+        ],
+        "expected": {
+          "testSubject": "actual.userAgent",
+          "match": {
+            "regexp": "/Algolia%20for%20(.+)%20\\(\\d+\\.\\d+\\.\\d+\\)/"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "testName": "calls api with correct timeouts",
+    "steps": [
+      {
+        "type": "method",
+        "object": "$client",
+        "path": "fetchUserProfile",
+        "parameters": [
+          {
+            "userID": "user1",
+            "params": {
+              "modelsToRetrieve": [
+                "funnel_stage"
+              ]
+            }
+          }
+        ],
+        "expected": {
+          "match": {
+            "objectContaining": {
+              "connectTimeout": 2,
+              "responseTimeout": 30
+            }
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/predict/parameters.json
+++ b/tests/CTS/client/predict/parameters.json
@@ -1,0 +1,36 @@
+[
+  {
+    "testName": "throws when region is not given",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "my-app-id",
+          "apiKey": "my-api-key",
+          "region": ""
+        },
+        "expected": {
+          "error": "`region` is missing."
+        }
+      }
+    ]
+  },
+  {
+    "testName": "does not throw when region is given",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "my-app-id",
+          "apiKey": "my-api-key",
+          "region": "ew"
+        },
+        "expected": {
+          "error": false
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/templates/javascript/suite.mustache
+++ b/tests/CTS/client/templates/javascript/suite.mustache
@@ -11,7 +11,7 @@ const apiKey = 'test-api-key';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function createClient() {
-  return {{client}}(appId, apiKey, {{#hasRegionalHost}}'us', {{/hasRegionalHost}}{ requester: echoRequester() });
+  return {{client}}(appId, apiKey, {{#hasRegionalHost}}'{{{defaultRegion}}}', {{/hasRegionalHost}}{ requester: echoRequester() });
 }
 
 {{#blocks}}

--- a/tests/CTS/methods/requests/predict/fetchUserProfile.json
+++ b/tests/CTS/methods/requests/predict/fetchUserProfile.json
@@ -1,0 +1,80 @@
+[
+  {
+    "testName": "fetchUserProfile with minimal parameters for modelsToRetrieve",
+    "parameters": {
+      "userID": "user1",
+      "params": {
+        "modelsToRetrieve": [
+          "funnel_stage",
+          "order_value",
+          "affinities"
+        ]
+      }
+    },
+    "request": {
+      "path": "/1/users/user1/fetch",
+      "method": "POST",
+      "body": {
+        "modelsToRetrieve": [
+          "funnel_stage",
+          "order_value",
+          "affinities"
+        ]
+      }
+    }
+  },
+  {
+    "testName": "fetchUserProfile with minimal parameters for typesToRetrieve",
+    "parameters": {
+      "userID": "user1",
+      "params": {
+        "typesToRetrieve": [
+          "properties",
+          "segments"
+        ]
+      }
+    },
+    "request": {
+      "path": "/1/users/user1/fetch",
+      "method": "POST",
+      "body": {
+        "typesToRetrieve": [
+          "properties",
+          "segments"
+        ]
+      }
+    }
+  },
+  {
+    "testName": "fetchUserProfile with all parameters",
+    "parameters": {
+      "userID": "user1",
+      "params": {
+        "modelsToRetrieve": [
+          "funnel_stage",
+          "order_value",
+          "affinities"
+        ],
+        "typesToRetrieve": [
+          "properties",
+          "segments"
+        ]
+      }
+    },
+    "request": {
+      "path": "/1/users/user1/fetch",
+      "method": "POST",
+      "body": {
+        "modelsToRetrieve": [
+          "funnel_stage",
+          "order_value",
+          "affinities"
+        ],
+        "typesToRetrieve": [
+          "properties",
+          "segments"
+        ]
+      }
+    }
+  }
+]

--- a/tests/CTS/methods/requests/templates/javascript/requests.mustache
+++ b/tests/CTS/methods/requests/templates/javascript/requests.mustache
@@ -5,7 +5,7 @@ import type { EchoResponse } from '@experimental-api-clients-automation/client-c
 const appId = process.env.ALGOLIA_APPLICATION_ID || 'test_app_id';
 const apiKey = process.env.ALGOLIA_SEARCH_KEY || 'test_api_key';
 
-const client = {{client}}(appId, apiKey, {{#hasRegionalHost}}'us', {{/hasRegionalHost}}{ requester: echoRequester() });
+const client = {{client}}(appId, apiKey, {{#hasRegionalHost}}'{{{defaultRegion}}}', {{/hasRegionalHost}}{ requester: echoRequester() });
 
 {{#blocks}}
 describe('{{operationId}}', () => {

--- a/tests/output/java/src/test/java/com/algolia/methods/requests/predict.test.java
+++ b/tests/output/java/src/test/java/com/algolia/methods/requests/predict.test.java
@@ -1,0 +1,364 @@
+package com.algolia.methods.requests;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.algolia.JSON;
+import com.algolia.Pair;
+import com.algolia.api.PredictClient;
+import com.algolia.model.predict.*;
+import com.algolia.utils.echo.*;
+import com.google.gson.reflect.TypeToken;
+import java.util.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PredictClientTests {
+
+  private PredictClient client;
+
+  @BeforeAll
+  void init() {
+    client = new PredictClient("appId", "apiKey", new EchoRequester());
+  }
+
+  @Test
+  @DisplayName("allow del method for a custom path with minimal parameters")
+  void delTest0() {
+    String path0 = "/test/minimal";
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.del(path0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/minimal");
+    assertEquals(req.getMethod(), "DELETE");
+  }
+
+  @Test
+  @DisplayName("allow del method for a custom path with all parameters")
+  void delTest1() {
+    String path0 = "/test/all";
+    Map<String, Object> parameters0 = new HashMap<>();
+    {
+      String query1 = "parameters";
+      parameters0.put("query", query1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.del(path0, parameters0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/all");
+    assertEquals(req.getMethod(), "DELETE");
+
+    Map<String, String> expectedQuery = JSON.deserialize(
+      "{\"query\":\"parameters\"}",
+      new TypeToken<HashMap<String, String>>() {}.getType()
+    );
+    List<Pair> actualQuery = req.getQueryParams();
+    assertEquals(expectedQuery.size(), actualQuery.size());
+    for (Pair p : actualQuery) {
+      assertEquals(expectedQuery.get(p.getName()), p.getValue());
+    }
+  }
+
+  @Test
+  @DisplayName("fetchUserProfile with minimal parameters for modelsToRetrieve")
+  void fetchUserProfileTest0() {
+    String userID0 = "user1";
+    ModelsToRetrieve params0 = new ModelsToRetrieve();
+    {
+      List<ModelsToRetrieveEnum> modelsToRetrieve1 = new ArrayList<>();
+      {
+        ModelsToRetrieveEnum modelsToRetrieve_02 = ModelsToRetrieveEnum.fromValue(
+          "funnel_stage"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_02);
+        ModelsToRetrieveEnum modelsToRetrieve_12 = ModelsToRetrieveEnum.fromValue(
+          "order_value"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_12);
+        ModelsToRetrieveEnum modelsToRetrieve_22 = ModelsToRetrieveEnum.fromValue(
+          "affinities"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_22);
+      }
+      params0.setModelsToRetrieve(modelsToRetrieve1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.fetchUserProfile(
+          userID0,
+          Params.ofModelsToRetrieve(params0)
+        );
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/users/user1/fetch");
+    assertEquals(req.getMethod(), "POST");
+
+    assertDoesNotThrow(() -> {
+      JSONAssert.assertEquals(
+        "{\"modelsToRetrieve\":[\"funnel_stage\",\"order_value\",\"affinities\"]}",
+        req.getBody(),
+        JSONCompareMode.STRICT_ORDER
+      );
+    });
+  }
+
+  @Test
+  @DisplayName("fetchUserProfile with minimal parameters for typesToRetrieve")
+  void fetchUserProfileTest1() {
+    String userID0 = "user1";
+    TypesToRetrieve params0 = new TypesToRetrieve();
+    {
+      List<TypesToRetrieveEnum> typesToRetrieve1 = new ArrayList<>();
+      {
+        TypesToRetrieveEnum typesToRetrieve_02 = TypesToRetrieveEnum.fromValue(
+          "properties"
+        );
+        typesToRetrieve1.add(typesToRetrieve_02);
+        TypesToRetrieveEnum typesToRetrieve_12 = TypesToRetrieveEnum.fromValue(
+          "segments"
+        );
+        typesToRetrieve1.add(typesToRetrieve_12);
+      }
+      params0.setTypesToRetrieve(typesToRetrieve1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.fetchUserProfile(
+          userID0,
+          Params.ofTypesToRetrieve(params0)
+        );
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/users/user1/fetch");
+    assertEquals(req.getMethod(), "POST");
+
+    assertDoesNotThrow(() -> {
+      JSONAssert.assertEquals(
+        "{\"typesToRetrieve\":[\"properties\",\"segments\"]}",
+        req.getBody(),
+        JSONCompareMode.STRICT_ORDER
+      );
+    });
+  }
+
+  @Test
+  @DisplayName("fetchUserProfile with all parameters")
+  void fetchUserProfileTest2() {
+    String userID0 = "user1";
+    AllParams params0 = new AllParams();
+    {
+      List<ModelsToRetrieveEnum> modelsToRetrieve1 = new ArrayList<>();
+      {
+        ModelsToRetrieveEnum modelsToRetrieve_02 = ModelsToRetrieveEnum.fromValue(
+          "funnel_stage"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_02);
+        ModelsToRetrieveEnum modelsToRetrieve_12 = ModelsToRetrieveEnum.fromValue(
+          "order_value"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_12);
+        ModelsToRetrieveEnum modelsToRetrieve_22 = ModelsToRetrieveEnum.fromValue(
+          "affinities"
+        );
+        modelsToRetrieve1.add(modelsToRetrieve_22);
+      }
+      params0.setModelsToRetrieve(modelsToRetrieve1);
+      List<TypesToRetrieveEnum> typesToRetrieve1 = new ArrayList<>();
+      {
+        TypesToRetrieveEnum typesToRetrieve_02 = TypesToRetrieveEnum.fromValue(
+          "properties"
+        );
+        typesToRetrieve1.add(typesToRetrieve_02);
+        TypesToRetrieveEnum typesToRetrieve_12 = TypesToRetrieveEnum.fromValue(
+          "segments"
+        );
+        typesToRetrieve1.add(typesToRetrieve_12);
+      }
+      params0.setTypesToRetrieve(typesToRetrieve1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.fetchUserProfile(userID0, Params.ofAllParams(params0));
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/users/user1/fetch");
+    assertEquals(req.getMethod(), "POST");
+
+    assertDoesNotThrow(() -> {
+      JSONAssert.assertEquals(
+        "{\"modelsToRetrieve\":[\"funnel_stage\",\"order_value\",\"affinities\"],\"typesToRetrieve\":[\"properties\",\"segments\"]}",
+        req.getBody(),
+        JSONCompareMode.STRICT_ORDER
+      );
+    });
+  }
+
+  @Test
+  @DisplayName("allow get method for a custom path with minimal parameters")
+  void getTest0() {
+    String path0 = "/test/minimal";
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.get(path0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/minimal");
+    assertEquals(req.getMethod(), "GET");
+  }
+
+  @Test
+  @DisplayName("allow get method for a custom path with all parameters")
+  void getTest1() {
+    String path0 = "/test/all";
+    Map<String, Object> parameters0 = new HashMap<>();
+    {
+      String query1 = "parameters";
+      parameters0.put("query", query1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.get(path0, parameters0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/all");
+    assertEquals(req.getMethod(), "GET");
+
+    Map<String, String> expectedQuery = JSON.deserialize(
+      "{\"query\":\"parameters\"}",
+      new TypeToken<HashMap<String, String>>() {}.getType()
+    );
+    List<Pair> actualQuery = req.getQueryParams();
+    assertEquals(expectedQuery.size(), actualQuery.size());
+    for (Pair p : actualQuery) {
+      assertEquals(expectedQuery.get(p.getName()), p.getValue());
+    }
+  }
+
+  @Test
+  @DisplayName("allow post method for a custom path with minimal parameters")
+  void postTest0() {
+    String path0 = "/test/minimal";
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.post(path0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/minimal");
+    assertEquals(req.getMethod(), "POST");
+  }
+
+  @Test
+  @DisplayName("allow post method for a custom path with all parameters")
+  void postTest1() {
+    String path0 = "/test/all";
+    Map<String, Object> parameters0 = new HashMap<>();
+    {
+      String query1 = "parameters";
+      parameters0.put("query", query1);
+    }
+    Map<String, String> body0 = new HashMap<>();
+    {
+      String body1 = "parameters";
+      body0.put("body", body1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.post(path0, parameters0, body0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/all");
+    assertEquals(req.getMethod(), "POST");
+
+    assertDoesNotThrow(() -> {
+      JSONAssert.assertEquals(
+        "{\"body\":\"parameters\"}",
+        req.getBody(),
+        JSONCompareMode.STRICT_ORDER
+      );
+    });
+
+    Map<String, String> expectedQuery = JSON.deserialize(
+      "{\"query\":\"parameters\"}",
+      new TypeToken<HashMap<String, String>>() {}.getType()
+    );
+    List<Pair> actualQuery = req.getQueryParams();
+    assertEquals(expectedQuery.size(), actualQuery.size());
+    for (Pair p : actualQuery) {
+      assertEquals(expectedQuery.get(p.getName()), p.getValue());
+    }
+  }
+
+  @Test
+  @DisplayName("allow put method for a custom path with minimal parameters")
+  void putTest0() {
+    String path0 = "/test/minimal";
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.put(path0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/minimal");
+    assertEquals(req.getMethod(), "PUT");
+  }
+
+  @Test
+  @DisplayName("allow put method for a custom path with all parameters")
+  void putTest1() {
+    String path0 = "/test/all";
+    Map<String, Object> parameters0 = new HashMap<>();
+    {
+      String query1 = "parameters";
+      parameters0.put("query", query1);
+    }
+    Map<String, String> body0 = new HashMap<>();
+    {
+      String body1 = "parameters";
+      body0.put("body", body1);
+    }
+
+    EchoResponseInterface req = (EchoResponseInterface) assertDoesNotThrow(() -> {
+        return client.put(path0, parameters0, body0);
+      }
+    );
+
+    assertEquals(req.getPath(), "/1/test/all");
+    assertEquals(req.getMethod(), "PUT");
+
+    assertDoesNotThrow(() -> {
+      JSONAssert.assertEquals(
+        "{\"body\":\"parameters\"}",
+        req.getBody(),
+        JSONCompareMode.STRICT_ORDER
+      );
+    });
+
+    Map<String, String> expectedQuery = JSON.deserialize(
+      "{\"query\":\"parameters\"}",
+      new TypeToken<HashMap<String, String>>() {}.getType()
+    );
+    List<Pair> actualQuery = req.getQueryParams();
+    assertEquals(expectedQuery.size(), actualQuery.size());
+    for (Pair p : actualQuery) {
+      assertEquals(expectedQuery.get(p.getName()), p.getValue());
+    }
+  }
+}

--- a/tests/output/javascript/package.json
+++ b/tests/output/javascript/package.json
@@ -11,6 +11,7 @@
     "@experimental-api-clients-automation/client-common": "0.2.0",
     "@experimental-api-clients-automation/client-insights": "0.2.0",
     "@experimental-api-clients-automation/client-personalization": "0.2.0",
+    "@experimental-api-clients-automation/client-predict": "0.2.0",
     "@experimental-api-clients-automation/client-query-suggestions": "0.2.0",
     "@experimental-api-clients-automation/client-search": "0.2.0",
     "@experimental-api-clients-automation/client-sources": "0.2.0",

--- a/tests/output/javascript/src/client/predict.test.ts
+++ b/tests/output/javascript/src/client/predict.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable prefer-const */
+// @ts-nocheck Failing tests will have type errors, but we cannot suppress them even with @ts-expect-error because it doesn't work for a block of lines.
+import { predictClient } from '@experimental-api-clients-automation/client-predict';
+import { echoRequester } from '@experimental-api-clients-automation/requester-node-http';
+
+const appId = 'test-app-id';
+const apiKey = 'test-api-key';
+
+function createClient() {
+  return predictClient(appId, apiKey, 'ew', { requester: echoRequester() });
+}
+
+describe('api', () => {
+  test('calls api with correct user agent', async () => {
+    let $client;
+    $client = createClient();
+
+    let actual;
+
+    actual = $client.fetchUserProfile({
+      userID: 'user1',
+      params: { modelsToRetrieve: ['funnel_stage'] },
+    });
+
+    if (actual instanceof Promise) {
+      actual = await actual;
+    }
+
+    expect(actual.userAgent).toMatch(
+      /Algolia%20for%20(.+)%20\(\d+\.\d+\.\d+\)/
+    );
+  });
+
+  test('calls api with correct timeouts', async () => {
+    let $client;
+    $client = createClient();
+
+    let actual;
+
+    actual = $client.fetchUserProfile({
+      userID: 'user1',
+      params: { modelsToRetrieve: ['funnel_stage'] },
+    });
+
+    if (actual instanceof Promise) {
+      actual = await actual;
+    }
+
+    expect(actual).toEqual(
+      expect.objectContaining({ connectTimeout: 2, responseTimeout: 30 })
+    );
+  });
+});
+
+describe('parameters', () => {
+  test('throws when region is not given', async () => {
+    let $client;
+
+    let actual;
+    await expect(
+      new Promise((resolve, reject) => {
+        $client = predictClient('my-app-id', 'my-api-key', '', {
+          requester: echoRequester(),
+        });
+
+        actual = $client;
+
+        if (actual instanceof Promise) {
+          actual.then(resolve).catch(reject);
+        } else {
+          resolve();
+        }
+      })
+    ).rejects.toThrow('`region` is missing.');
+  });
+
+  test('does not throw when region is given', async () => {
+    let $client;
+
+    let actual;
+
+    await expect(
+      new Promise((resolve, reject) => {
+        $client = predictClient('my-app-id', 'my-api-key', 'ew', {
+          requester: echoRequester(),
+        });
+
+        actual = $client;
+
+        if (actual instanceof Promise) {
+          actual.then(resolve).catch(reject);
+        } else {
+          resolve();
+        }
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/tests/output/javascript/src/methods/requests/predict.test.ts
+++ b/tests/output/javascript/src/methods/requests/predict.test.ts
@@ -1,0 +1,160 @@
+import type { EchoResponse } from '@experimental-api-clients-automation/client-common';
+import { predictClient } from '@experimental-api-clients-automation/client-predict';
+import { echoRequester } from '@experimental-api-clients-automation/requester-node-http';
+
+const appId = process.env.ALGOLIA_APPLICATION_ID || 'test_app_id';
+const apiKey = process.env.ALGOLIA_SEARCH_KEY || 'test_api_key';
+
+const client = predictClient(appId, apiKey, 'ew', {
+  requester: echoRequester(),
+});
+
+describe('del', () => {
+  test('allow del method for a custom path with minimal parameters', async () => {
+    const req = (await client.del({
+      path: '/test/minimal',
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/minimal');
+    expect(req.method).toEqual('DELETE');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('allow del method for a custom path with all parameters', async () => {
+    const req = (await client.del({
+      path: '/test/all',
+      parameters: { query: 'parameters' },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/all');
+    expect(req.method).toEqual('DELETE');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual({ query: 'parameters' });
+  });
+});
+
+describe('fetchUserProfile', () => {
+  test('fetchUserProfile with minimal parameters for modelsToRetrieve', async () => {
+    const req = (await client.fetchUserProfile({
+      userID: 'user1',
+      params: {
+        modelsToRetrieve: ['funnel_stage', 'order_value', 'affinities'],
+      },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/users/user1/fetch');
+    expect(req.method).toEqual('POST');
+    expect(req.data).toEqual({
+      modelsToRetrieve: ['funnel_stage', 'order_value', 'affinities'],
+    });
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('fetchUserProfile with minimal parameters for typesToRetrieve', async () => {
+    const req = (await client.fetchUserProfile({
+      userID: 'user1',
+      params: { typesToRetrieve: ['properties', 'segments'] },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/users/user1/fetch');
+    expect(req.method).toEqual('POST');
+    expect(req.data).toEqual({ typesToRetrieve: ['properties', 'segments'] });
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('fetchUserProfile with all parameters', async () => {
+    const req = (await client.fetchUserProfile({
+      userID: 'user1',
+      params: {
+        modelsToRetrieve: ['funnel_stage', 'order_value', 'affinities'],
+        typesToRetrieve: ['properties', 'segments'],
+      },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/users/user1/fetch');
+    expect(req.method).toEqual('POST');
+    expect(req.data).toEqual({
+      modelsToRetrieve: ['funnel_stage', 'order_value', 'affinities'],
+      typesToRetrieve: ['properties', 'segments'],
+    });
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+});
+
+describe('get', () => {
+  test('allow get method for a custom path with minimal parameters', async () => {
+    const req = (await client.get({
+      path: '/test/minimal',
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/minimal');
+    expect(req.method).toEqual('GET');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('allow get method for a custom path with all parameters', async () => {
+    const req = (await client.get({
+      path: '/test/all',
+      parameters: { query: 'parameters' },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/all');
+    expect(req.method).toEqual('GET');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual({ query: 'parameters' });
+  });
+});
+
+describe('post', () => {
+  test('allow post method for a custom path with minimal parameters', async () => {
+    const req = (await client.post({
+      path: '/test/minimal',
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/minimal');
+    expect(req.method).toEqual('POST');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('allow post method for a custom path with all parameters', async () => {
+    const req = (await client.post({
+      path: '/test/all',
+      parameters: { query: 'parameters' },
+      body: { body: 'parameters' },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/all');
+    expect(req.method).toEqual('POST');
+    expect(req.data).toEqual({ body: 'parameters' });
+    expect(req.searchParams).toStrictEqual({ query: 'parameters' });
+  });
+});
+
+describe('put', () => {
+  test('allow put method for a custom path with minimal parameters', async () => {
+    const req = (await client.put({
+      path: '/test/minimal',
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/minimal');
+    expect(req.method).toEqual('PUT');
+    expect(req.data).toEqual(undefined);
+    expect(req.searchParams).toStrictEqual(undefined);
+  });
+
+  test('allow put method for a custom path with all parameters', async () => {
+    const req = (await client.put({
+      path: '/test/all',
+      parameters: { query: 'parameters' },
+      body: { body: 'parameters' },
+    })) as unknown as EchoResponse;
+
+    expect(req.path).toEqual('/1/test/all');
+    expect(req.method).toEqual('PUT');
+    expect(req.data).toEqual({ body: 'parameters' });
+    expect(req.searchParams).toStrictEqual({ query: 'parameters' });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -13220,6 +13220,7 @@ __metadata:
     "@experimental-api-clients-automation/client-common": 0.2.0
     "@experimental-api-clients-automation/client-insights": 0.2.0
     "@experimental-api-clients-automation/client-personalization": 0.2.0
+    "@experimental-api-clients-automation/client-predict": 0.2.0
     "@experimental-api-clients-automation/client-query-suggestions": 0.2.0
     "@experimental-api-clients-automation/client-search": 0.2.0
     "@experimental-api-clients-automation/client-sources": 0.2.0


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-464

### Changes included:

This PR adds tests for the Predict client to the CTS, with some tweaking around this client.

- Our types were wrong, it's actually a kind-of complicated oneOf/allOf, which should be good now.
- The CTS gen defaulted regions to `us`, which is wrong in that case.

## 🧪 Test

CI :D 
