### PR TITLE
fix(php): make `requestOptions` match other clients

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -240,13 +240,13 @@ export function createTransporter({
       cacheable: baseRequestOptions?.cacheable,
       timeout: baseRequestOptions?.timeout,
       queryParameters: {
-        ...baseRequestOptions?.queryParameters,
         ...methodOptions.queryParameters,
+        ...baseRequestOptions?.queryParameters,
       },
       headers: {
         Accept: 'application/json',
-        ...baseRequestOptions?.headers,
         ...methodOptions.headers,
+        ...baseRequestOptions?.headers,
       },
     };
 

--- a/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptions.php
+++ b/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptions.php
@@ -8,7 +8,7 @@ final class RequestOptions
 {
     private $headers = [];
 
-    private $query = [];
+    private $queryParameters = [];
 
     private $body = [];
 
@@ -20,7 +20,7 @@ final class RequestOptions
 
     public function __construct(array $options = [])
     {
-        foreach (['headers', 'query', 'body'] as $name) {
+        foreach (['headers', 'queryParameters', 'body'] as $name) {
             if (isset($options[$name]) && !empty($options[$name])) {
                 $this->{$name} = $options[$name];
             }
@@ -120,7 +120,7 @@ final class RequestOptions
      */
     public function getQueryParameters()
     {
-        return $this->query;
+        return $this->queryParameters;
     }
 
     /**
@@ -128,7 +128,7 @@ final class RequestOptions
      */
     public function getBuiltQueryParameters()
     {
-        return Helpers::buildQuery($this->query);
+        return Helpers::buildQuery($this->queryParameters);
     }
 
     /**
@@ -141,7 +141,7 @@ final class RequestOptions
      */
     public function addQueryParameter($name, $value)
     {
-        $this->query[$name] = $value;
+        $this->queryParameters[$name] = $value;
 
         return $this;
     }
@@ -156,7 +156,10 @@ final class RequestOptions
      */
     public function addQueryParameters($parameters)
     {
-        $this->query = array_merge($this->query, $parameters);
+        $this->queryParameters = array_merge(
+            $this->queryParameters,
+            $parameters
+        );
 
         return $this;
     }
@@ -171,8 +174,8 @@ final class RequestOptions
      */
     public function addDefaultQueryParameter($name, $value)
     {
-        if (!isset($this->query[$name])) {
-            $this->query[$name] = $value;
+        if (!isset($this->queryParameters[$name])) {
+            $this->queryParameters[$name] = $value;
         }
 
         return $this;
@@ -203,7 +206,7 @@ final class RequestOptions
      */
     public function setQueryParameters($queryParameters)
     {
-        $this->query = $queryParameters;
+        $this->queryParameters = $queryParameters;
 
         return $this;
     }

--- a/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
+++ b/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
@@ -9,8 +9,6 @@ final class RequestOptionsFactory
 {
     private $config;
 
-    private $validHeaders = ['Content-type', 'User-Agent'];
-
     public function __construct(Configuration $config)
     {
         $this->config = $config;
@@ -22,21 +20,14 @@ final class RequestOptionsFactory
      *
      * @return \Algolia\AlgoliaSearch\RequestOptions\RequestOptions
      */
-    public function create($options, $defaults = [])
+    public function create($options)
     {
         if (is_array($options)) {
-            $options += $defaults;
-            $options = $this->format($options);
             $options = $this->normalize($options);
 
             $options = new RequestOptions($options);
         } elseif ($options instanceof RequestOptions) {
-            $defaults = $this->create($defaults);
-            $options->addDefaultHeaders($defaults->getHeaders());
-            $options->addDefaultQueryParameters(
-                $defaults->getQueryParameters()
-            );
-            $options->addDefaultBodyParameters($defaults->getBody());
+            $options = $this->create($options);
         } else {
             throw new \InvalidArgumentException(
                 'RequestOptions can only be created from array or from RequestOptions object'
@@ -46,9 +37,9 @@ final class RequestOptionsFactory
         return $options->addDefaultHeaders($this->config->getDefaultHeaders());
     }
 
-    public function createBodyLess($options, $defaults = [])
+    public function createBodyLess($options)
     {
-        $options = $this->create($options, $defaults);
+        $options = $this->create($options);
 
         return $options->addQueryParameters($options->getBody())->setBody([]);
     }
@@ -59,12 +50,13 @@ final class RequestOptionsFactory
             'headers' => [
                 'X-Algolia-Application-Id' => $this->config->getAppId(),
                 'X-Algolia-API-Key' => $this->config->getAlgoliaApiKey(),
-                'User-Agent' => $this->config->getUserAgent() !== null
+                'User-Agent' =>
+                    $this->config->getUserAgent() !== null
                         ? $this->config->getUserAgent()
                         : UserAgent::get(),
                 'Content-Type' => 'application/json',
             ],
-            'query' => [],
+            'queryParameters' => [],
             'body' => [],
             'readTimeout' => $this->config->getReadTimeout(),
             'writeTimeout' => $this->config->getWriteTimeout(),
@@ -72,18 +64,10 @@ final class RequestOptionsFactory
         ];
 
         foreach ($options as $optionName => $value) {
-            $type = $this->getOptionType($optionName);
-
-            if (
-                in_array(
-                    $type,
-                    ['readTimeout', 'writeTimeout', 'connectTimeout'],
-                    true
-                )
-            ) {
-                $normalized[$type] = $value;
+            if (is_array($value)) {
+                $normalized[$optionName] = $this->format($value);
             } else {
-                $normalized[$type][$optionName] = $value;
+                $normalized[$optionName] = $value;
             }
         }
 
@@ -101,36 +85,6 @@ final class RequestOptionsFactory
         }
 
         return $options;
-    }
-
-    private function getOptionType($optionName)
-    {
-        if ($this->isValidHeaderName($optionName)) {
-            return 'headers';
-        } elseif (
-            in_array(
-                $optionName,
-                ['connectTimeout', 'readTimeout', 'writeTimeout'],
-                true
-            )
-        ) {
-            return $optionName;
-        }
-
-        return 'query';
-    }
-
-    private function isValidHeaderName($name)
-    {
-        if (preg_match('/^X-[a-zA-Z-]+/', $name)) {
-            return true;
-        }
-
-        if (in_array($name, $this->validHeaders, true)) {
-            return true;
-        }
-
-        return false;
     }
 
     public static function getAttributesToFormat()

--- a/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapper.php
+++ b/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapper.php
@@ -66,21 +66,15 @@ final class ApiWrapper implements ApiWrapperInterface
         }
     }
 
-    public function read(
-        $method,
-        $path,
-        $requestOptions = [],
-        $defaultRequestOptions = []
-    ) {
+    public function read($method, $path, $requestOptions = [])
+    {
         if ('GET' === mb_strtoupper($method)) {
             $requestOptions = $this->requestOptionsFactory->createBodyLess(
-                $requestOptions,
-                $defaultRequestOptions
+                $requestOptions
             );
         } else {
             $requestOptions = $this->requestOptionsFactory->create(
-                $requestOptions,
-                $defaultRequestOptions
+                $requestOptions
             );
         }
 
@@ -93,23 +87,16 @@ final class ApiWrapper implements ApiWrapperInterface
         );
     }
 
-    public function write(
-        $method,
-        $path,
-        $data = [],
-        $requestOptions = [],
-        $defaultRequestOptions = []
-    ) {
+    public function write($method, $path, $data = [], $requestOptions = [])
+    {
         if ('DELETE' === mb_strtoupper($method)) {
             $requestOptions = $this->requestOptionsFactory->createBodyLess(
-                $requestOptions,
-                $defaultRequestOptions
+                $requestOptions
             );
             $data = [];
         } else {
             $requestOptions = $this->requestOptionsFactory->create(
-                $requestOptions,
-                $defaultRequestOptions
+                $requestOptions
             );
         }
 

--- a/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapperInterface.php
+++ b/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapperInterface.php
@@ -4,20 +4,9 @@ namespace Algolia\AlgoliaSearch\RetryStrategy;
 
 interface ApiWrapperInterface
 {
-    public function read(
-        $method,
-        $path,
-        $requestOptions = [],
-        $defaultRequestOptions = []
-    );
+    public function read($method, $path, $requestOptions = []);
 
-    public function write(
-        $method,
-        $path,
-        $data = [],
-        $requestOptions = [],
-        $defaultRequestOptions = []
-    );
+    public function write($method, $path, $data = [], $requestOptions = []);
 
     public function send($method, $path, $requestOptions = [], $hosts = null);
 }

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -139,7 +139,7 @@ use {{invokerPackage}}\RetryStrategy\ClusterHosts;
      * @see {{{dataType}}}
 {{/isModel}}
 {{/allParams}}
-     * @param array $requestOptions Request Options
+     * @param array $requestOptions The requestOptions to send along with the query, they will be merged with the transporter requestOptions.
      *
      * @return {{#returnType}}{{#responses}}{{#dataType}}{{#-first}}array<string, mixed>|{{{dataType}}}{{/-first}}{{/dataType}}{{/responses}}{{/returnType}}{{^returnType}}void{{/returnType}}
   {{#isDeprecated}}
@@ -206,6 +206,7 @@ use {{invokerPackage}}\RetryStrategy\ClusterHosts;
 
         $resourcePath = '{{{path}}}';
         $queryParameters = [];
+        $headers = [];
         $httpBody = [];
         {{#vendorExtensions}}{{#queryParams}}
 
@@ -257,7 +258,7 @@ use {{invokerPackage}}\RetryStrategy\ClusterHosts;
         } 
         {{/bodyParams}}
         {{#headerParams}}
-            $queryParameters['{{baseName}}'] = ${{paramName}};
+            $headers['{{baseName}}'] = ${{paramName}};
         {{/headerParams}}
         {{#servers.0}}
         $operationHosts = [{{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}}];
@@ -267,16 +268,25 @@ use {{invokerPackage}}\RetryStrategy\ClusterHosts;
         $operationHost = $operationHosts[$this->hostIndex];
 
         {{/servers.0}}
-        $requestOptions += $queryParameters;
 
-        return $this->sendRequest('{{httpMethod}}', $resourcePath, $queryParameters, $httpBody, $requestOptions);
+        return $this->sendRequest('{{httpMethod}}', $resourcePath, $headers, $queryParameters, $httpBody, $requestOptions);
     }
 
     {{/operation}}
 
-    private function sendRequest($method, $resourcePath, $queryParameters, $httpBody, $requestOptions)
+    private function sendRequest($method, $resourcePath, $headers, $queryParameters, $httpBody, $requestOptions)
     {
-        $query = \GuzzleHttp\Psr7\Query::build($queryParameters);
+        if (!isset($requestOptions['headers'])) {
+            $requestOptions['headers'] = [];
+        }
+        if (!isset($requestOptions['queryParameters'])) {
+            $requestOptions['queryParameters'] = [];
+        }
+
+        $requestOptions['headers'] = array_merge($headers, $requestOptions['headers']);
+        $requestOptions['queryParameters'] = array_merge($queryParameters, $requestOptions['queryParameters']);
+
+        $query = \GuzzleHttp\Psr7\Query::build($requestOptions['queryParameters']);
 
         if($method == 'GET') {
             $request = $this->api->read(


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-483

### Changes included:

- Remove some logic in the `RequestOptionsFactory` to make the parameter shape match other clients
- Store header parameters in `$headers`
- Remove unused parameter

Javascript:
- Make `requestOptions` override default parameters

## 🧪 Test

CI :D 
