### PR TITLE
fix(php): fix header management issue introduced by latest request options rework

### DIFF
--- a/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
+++ b/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
@@ -71,14 +71,14 @@ final class RequestOptionsFactory
                         $headersToLowerCase[mb_strtolower($key)] = $v;
                     }
 
-                    $normalized[$optionName] = $this->format(
+                    $normalized[$optionName] += $this->format(
                         $headersToLowerCase
                     );
                 } else {
-                    $normalized[$optionName] = $this->format($value);
+                    $normalized[$optionName] += $this->format($value);
                 }
             } else {
-                $normalized[$optionName] = $value;
+                $normalized[$optionName] += $value;
             }
         }
 


### PR DESCRIPTION
### Changes included:

This fixes a (huge) bug introduced by latest rework of the request options (https://github.com/algolia/api-clients-automation/pull/497) which erase the existing headers (including appId and apiKey) and basically breaks every call from the PHP clients :p . 

As we don't check the call in the CTS, it passed the CI without any issues, but this proves I really need to implement the client tests as it's done for javascript 👀 
