### PR TITLE
style(specs): add out-of-line-one-of rule (and allOf and anyOf) APIC-418

### DIFF
--- a/eslint/src/index.ts
+++ b/eslint/src/index.ts
@@ -1,16 +1,13 @@
 import { endWithDot } from './rules/endWithDot';
-import { outOfLineAllOf } from './rules/outOfLineAllOf';
-import { outOfLineAnyOf } from './rules/outOfLineAnyOf';
-import { outOfLineEnum } from './rules/outOfLineEnum';
-import { outOfLineOneOf } from './rules/outOfLineOneOf';
+import { createOutOfLineRule } from './rules/outOfLineRule';
 import { singleQuoteRef } from './rules/singleQuoteRef';
 
 const rules = {
   'end-with-dot': endWithDot,
-  'out-of-line-enum': outOfLineEnum,
-  'out-of-line-one-of': outOfLineOneOf,
-  'out-of-line-all-of': outOfLineAllOf,
-  'out-of-line-any-of': outOfLineAnyOf,
+  'out-of-line-enum': createOutOfLineRule({ property: 'enum' }),
+  'out-of-line-one-of': createOutOfLineRule({ property: 'oneOf' }),
+  'out-of-line-all-of': createOutOfLineRule({ property: 'allOf' }),
+  'out-of-line-any-of': createOutOfLineRule({ property: 'anyOf' }),
   'single-quote-ref': singleQuoteRef,
 };
 

--- a/eslint/src/rules/outOfLineAllOf.ts
+++ b/eslint/src/rules/outOfLineAllOf.ts
@@ -1,3 +1,0 @@
-import { createOutOfLineRule } from './outOfLineRule';
-
-export const outOfLineAllOf = createOutOfLineRule({ property: 'allOf' });

--- a/eslint/src/rules/outOfLineAnyOf.ts
+++ b/eslint/src/rules/outOfLineAnyOf.ts
@@ -1,3 +1,0 @@
-import { createOutOfLineRule } from './outOfLineRule';
-
-export const outOfLineAnyOf = createOutOfLineRule({ property: 'anyOf' });

--- a/eslint/src/rules/outOfLineEnum.ts
+++ b/eslint/src/rules/outOfLineEnum.ts
@@ -1,3 +1,0 @@
-import { createOutOfLineRule } from './outOfLineRule';
-
-export const outOfLineEnum = createOutOfLineRule({ property: 'enum' });

--- a/eslint/src/rules/outOfLineOneOf.ts
+++ b/eslint/src/rules/outOfLineOneOf.ts
@@ -1,3 +1,0 @@
-import { createOutOfLineRule } from './outOfLineRule';
-
-export const outOfLineOneOf = createOutOfLineRule({ property: 'oneOf' });

--- a/eslint/src/rules/outOfLineRule.ts
+++ b/eslint/src/rules/outOfLineRule.ts
@@ -5,7 +5,7 @@ import { isPairWithKey } from '../utils';
 export function createOutOfLineRule({
   property,
   description = `${property} must be out of line, not nested inside properties`,
-  messageId = `${property}OutOfLine`,
+  messageId = `${property}NotOutOfLine`,
   message = `${property} must be out of line`,
 }: {
   property: string;

--- a/eslint/tests/endWithDot.test.ts
+++ b/eslint/tests/endWithDot.test.ts
@@ -38,7 +38,7 @@ responses:
 simple:
   description: a number
     `,
-      errors: [{ messageId: 'descriptionNoDot' }],
+      errors: [{ messageId: 'endWithDot' }],
       output: `
 simple:
   description: a number.
@@ -51,7 +51,7 @@ multi:
     Multiline comment
     on description
     `,
-      errors: [{ messageId: 'descriptionNoDot' }],
+      errors: [{ messageId: 'endWithDot' }],
       output: `
 multi:
   description: >

--- a/eslint/tests/outOfLineRule.test.ts
+++ b/eslint/tests/outOfLineRule.test.ts
@@ -1,12 +1,13 @@
 import { RuleTester } from 'eslint';
 
-import { outOfLineEnum } from '../src/rules/outOfLineEnum';
+import { createOutOfLineRule } from '../src/rules/outOfLineRule';
 
 const ruleTester = new RuleTester({
   parser: require.resolve('yaml-eslint-parser'),
 });
 
-ruleTester.run('out-of-line-enum', outOfLineEnum, {
+// this test is enough for oneOf, allOf, anyOf, as they use the same rule.
+ruleTester.run('out-of-line-enum', createOutOfLineRule({ property: 'enum' }), {
   valid: [
     `
 simple:

--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -23,7 +23,7 @@ export const COMMON_DEPENDENCIES = {
     '.github/workflows',
     '.github/.cache_version',
   ],
-  SCRIPTS_CHANGED: ['scripts'],
+  SCRIPTS_CHANGED: ['scripts', 'eslint'],
   COMMON_SPECS_CHANGED: ['specs/common'],
 };
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [APIC-418](https://algolia.atlassian.net/browse/APIC-418)

Reuse the logic of the `out-of-line-enum` rule to create rules for `oneOf, allOf, anyOf`.
The specs already complied with this rule.

## 🧪 Test

CI
