### PR TITLE
fix(scripts): codegen cleanup

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
           PR_NUMBER: ${{ github.event.number }}
+          HEAD_BRANCH: ${{ github.head_ref }}
 
   cleanup:
     runs-on: ubuntu-20.04

--- a/scripts/ci/codegen/text.ts
+++ b/scripts/ci/codegen/text.ts
@@ -15,9 +15,10 @@ export default {
   cleanup: {
     header: '### ✗ The generated branch has been deleted.',
     body: (
-      generatedCommit: string
+      generatedCommit: string,
+      branch: string
     ): string => `If the PR has been merged, you can check the generated code on the [\`${MAIN_BRANCH}\` branch](${REPO_URL}/tree/${MAIN_BRANCH}).
-You can still access [the last generated commit](${REPO_URL}/commit/${generatedCommit}).`,
+You can still access the code generated on \`${branch}\` via [this commit](${REPO_URL}/commit/${generatedCommit}).`,
   },
   codegen: {
     header: '### ✔️ Code generated!',

--- a/scripts/ci/codegen/upsertGenerationComment.ts
+++ b/scripts/ci/codegen/upsertGenerationComment.ts
@@ -19,10 +19,16 @@ const allowedTriggers = [
 type Trigger = typeof allowedTriggers[number];
 
 export async function getCommentBody(trigger: Trigger): Promise<string> {
-  const generatedBranch = await run('git branch --show-current');
+  let generatedBranch = await run('git branch --show-current');
+
+  // `cleanup` is triggered on PR close, which runs on `main`, so we lose the
+  // branch name context at this point
+  if (generatedBranch === 'main' && process.env.HEAD_BRANCH) {
+    generatedBranch = `generated/${process.env.HEAD_BRANCH}`;
+  }
+
   const baseBranch = generatedBranch.replace('generated/', '');
   const baseCommit = await run(`git show ${baseBranch} -s --format=%H`);
-
   const generatedCommit = await run(
     `git show ${generatedBranch} -s --format=%H`
   );


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Follow up of https://github.com/algolia/api-clients-automation/pull/513

It seems that the `cleanup` job is ran on `main` (https://github.com/algolia/api-clients-automation/runs/6507516796?check_suite_focus=true), so the comment ends up being wrong: https://github.com/algolia/api-clients-automation/pull/513#issuecomment-1131495868

We now provide the current branch name directly from `HEAD_BRANCH`, so we can fallback to it if we are on main

## 🧪 Test

CI :D 
