### PR TITLE
fix(scripts): get JS version from generators

### DIFF
--- a/scripts/release/process-release.ts
+++ b/scripts/release/process-release.ts
@@ -120,9 +120,7 @@ async function updateVersionForJavascript(
   Object.values(GENERATORS)
     .filter((gen) => gen.language === 'javascript')
     .forEach((gen) => {
-      const additionalProperties =
-        openapiConfig['generator-cli'].generators[gen.key].additionalProperties;
-
+      const additionalProperties = gen.additionalProperties;
       const newVersion = semver.inc(
         additionalProperties.packageVersion,
         jsVersion.releaseType


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

`algoliasearch` does not have an `openapiConfig` field, but defined in `generators`, to avoid having an edge case for it we can directly read it from here.

## 🧪 Test

CI :D 
