### PR TITLE
feat(scripts): consider `specs` commits for versioning

### DIFF
--- a/scripts/release/__tests__/create-release-issue.test.ts
+++ b/scripts/release/__tests__/create-release-issue.test.ts
@@ -21,7 +21,7 @@ describe('create release issue', () => {
     it('parses commit', () => {
       expect(parseCommit(`b2501882 fix(javascript): fix the thing`)).toEqual({
         hash: 'b2501882',
-        lang: 'javascript',
+        scope: 'javascript',
         message: 'fix the thing',
         raw: 'b2501882 fix(javascript): fix the thing',
         type: 'fix',
@@ -31,7 +31,7 @@ describe('create release issue', () => {
     it('considers `specs` as a lang commit', () => {
       expect(parseCommit(`b2501882 fix(specs): fix the thing`)).toEqual({
         hash: 'b2501882',
-        lang: 'specs',
+        scope: 'specs',
         message: 'fix the thing',
         raw: 'b2501882 fix(specs): fix the thing',
         type: 'fix',
@@ -149,7 +149,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'feat',
-            lang: 'javascript',
+            scope: 'javascript',
             message: 'update the API (BREAKING CHANGE)',
             raw: 'b2501882 feat(javascript): update the API (BREAKING CHANGE)',
           },
@@ -176,7 +176,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'feat',
-            lang: 'php',
+            scope: 'php',
             message: 'update the API',
             raw: 'b2501882 feat(php): update the API',
           },
@@ -203,7 +203,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'fix',
-            lang: 'java',
+            scope: 'java',
             message: 'fix some bug',
             raw: 'b2501882 fix(java): fix some bug',
           },
@@ -230,7 +230,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'fix',
-            lang: 'java',
+            scope: 'java',
             message: 'fix some bug',
             raw: 'b2501882 fix(java): fix some bug',
           },
@@ -259,7 +259,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'fix',
-            lang: 'specs',
+            scope: 'specs',
             message: 'fix some descriptions',
             raw: 'b2501882 fix(specs): fix some descriptions',
           },
@@ -291,14 +291,14 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'fix',
-            lang: 'php',
+            scope: 'php',
             message: 'fix some descriptions',
             raw: 'b2501882 feat(php): fix some descriptions',
           },
           {
             hash: 'b2501882',
             type: 'feat',
-            lang: 'specs',
+            scope: 'specs',
             message: 'add some descriptions',
             raw: 'b2501882 feat(specs): add some descriptions',
           },
@@ -330,7 +330,7 @@ describe('create release issue', () => {
           {
             hash: 'b2501882',
             type: 'chore',
-            lang: 'javascript',
+            scope: 'javascript',
             message: 'update devDevpendencies',
             raw: 'b2501882 chore(javascript): update devDevpendencies',
           },

--- a/scripts/release/create-release-issue.ts
+++ b/scripts/release/create-release-issue.ts
@@ -12,7 +12,6 @@ import {
   REPO,
 } from '../common';
 import { getPackageVersionDefault } from '../config';
-import type { Language } from '../types';
 
 import { RELEASED_TAG, getOctokit } from './common';
 import TEXT from './text';
@@ -21,9 +20,12 @@ import type {
   VersionsWithoutReleaseType,
   PassedCommit,
   Commit,
+  Scope,
 } from './types';
 
 dotenv.config({ path: ROOT_ENV_PATH });
+
+const COMMON_SCOPES = ['specs'];
 
 export function readVersions(): VersionsWithoutReleaseType {
   return Object.fromEntries(
@@ -101,18 +103,18 @@ export function parseCommit(commit: string): Commit {
   }
   message = message.slice(message.indexOf(':') + 1).trim();
   type = matchResult[1];
-  const lang = matchResult[2] as Language;
+  const scope = matchResult[2] as Scope;
   // A spec commit should be added to every clients, as it mostly imply a client change.
-  const allowedLanguages = [...LANGUAGES, 'specs'];
+  const allowedScopes = [...LANGUAGES, ...COMMON_SCOPES];
 
-  if (!allowedLanguages.includes(lang)) {
+  if (!allowedScopes.includes(scope)) {
     return { error: 'unknown-language-scope' };
   }
 
   return {
     hash,
     type, // `fix` | `feat` | `chore` | ...
-    lang, // `specs` | `javascript` | `php` | `java` | ...
+    scope, // `specs` | `javascript` | `php` | `java` | ...
     message,
     raw: commit,
   };
@@ -129,7 +131,8 @@ export function decideReleaseStrategy({
   return Object.entries(versions).reduce(
     (versionsWithReleaseType: Versions, [lang, version]) => {
       const commitsPerLang = commits.filter(
-        (commit) => commit.lang === lang || commit.lang === 'specs'
+        (commit) =>
+          commit.scope === lang || COMMON_SCOPES.includes(commit.scope)
       );
       const currentVersion = versions[lang].current;
 
@@ -272,7 +275,10 @@ async function createReleaseIssue(): Promise<void> {
       return [
         `### ${lang}`,
         ...validCommits
-          .filter((commit) => commit.lang === lang)
+          .filter(
+            (commit) =>
+              commit.scope === lang || COMMON_SCOPES.includes(commit.scope)
+          )
           .map((commit) => `- ${commit.raw}`),
       ];
     })

--- a/scripts/release/types.ts
+++ b/scripts/release/types.ts
@@ -17,13 +17,15 @@ export type VersionsWithoutReleaseType = {
   [lang: string]: Omit<Version, 'releaseType'>;
 };
 
+export type Scope = Language | 'specs';
+
 export type PassedCommit = {
   hash: string;
   type: string;
   /**
    * A commit can be scoped to a language, or the specs, which impacts all clients.
    */
-  lang: Language | 'specs';
+  scope: Scope;
   message: string;
   raw: string;
 };


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-493

### Changes included:

`specs` commit are currently considered as `unknown-language-scope`, while they should bump all languages.

- Add `specs` to the conditions when detecting a commit scope/language
- Add tests for it

## 🧪 Test

CI :D 
