### PR TITLE
refactor(javascript): type setTimeout in a way compatible with node & browser

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/createXhrRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/createXhrRequester.ts
@@ -4,6 +4,8 @@ import type {
   Response,
 } from '@experimental-api-clients-automation/client-common';
 
+type Timeout = ReturnType<typeof setTimeout>;
+
 export function createXhrRequester(): Requester {
   function send(request: EndRequest): Promise<Response> {
     return new Promise((resolve) => {
@@ -14,10 +16,7 @@ export function createXhrRequester(): Requester {
         baseRequester.setRequestHeader(key, request.headers[key])
       );
 
-      const createTimeout = (
-        timeout: number,
-        content: string
-      ): NodeJS.Timeout => {
+      const createTimeout = (timeout: number, content: string): Timeout => {
         return setTimeout(() => {
           baseRequester.abort();
 
@@ -34,7 +33,7 @@ export function createXhrRequester(): Requester {
         'Connection timeout'
       );
 
-      let responseTimeout: NodeJS.Timeout | undefined;
+      let responseTimeout: Timeout | undefined;
 
       baseRequester.onreadystatechange = (): void => {
         if (
@@ -54,7 +53,7 @@ export function createXhrRequester(): Requester {
         // istanbul ignore next
         if (baseRequester.status === 0) {
           clearTimeout(connectTimeout);
-          clearTimeout(responseTimeout as NodeJS.Timeout);
+          clearTimeout(responseTimeout!);
 
           resolve({
             content: baseRequester.responseText || 'Network request failed',
@@ -66,7 +65,7 @@ export function createXhrRequester(): Requester {
 
       baseRequester.onload = (): void => {
         clearTimeout(connectTimeout);
-        clearTimeout(responseTimeout as NodeJS.Timeout);
+        clearTimeout(responseTimeout!);
 
         resolve({
           content: baseRequester.responseText,


### PR DESCRIPTION
## 🧭 What and Why

in node the output of setTimeout is NodeJS.Timeout, in browser it's number. This difference doesn't matter for us, and thus the return type can be used.

This allows us (if needed) to run the type checking with both node types enabled and disabled.

### Changes included:

- internally setTimeout types have been changed from NodeJS.Timeout to ReturnType<typeof setTimeout>

## 🧪 Test

TSC works