### PR TITLE
chore(ci): schedule release

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -2,7 +2,7 @@ name: Scheduled Release
 
 on:
   schedule:
-    - cron: '0 9 * * 2'
+    - cron: '30 6 * * 2'
 
 jobs:
   release:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-368

### Changes included:

- Run `yarn release` every Tuesday 11am (GMT+2)
