### PR TITLE
chore: fix JavaScript algoliasearch artifacts

### DIFF
--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -53,17 +53,6 @@ runs:
         path: clients/algoliasearch-client-javascript/packages/requester-node-http/
 
     # JavaScript
-    - name: Download client-javascript-algoliasearch artifact
-      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: client-javascript-algoliasearch
-
-    - name: Unzip client-javascript-algoliasearch artifact
-      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
-      shell: bash
-      run: unzip -q -o client-javascript-algoliasearch.zip && rm client-javascript-algoliasearch.zip
-
     - name: Download clients-javascript artifact
       if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
       uses: actions/download-artifact@v3
@@ -74,6 +63,17 @@ runs:
       if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
       shell: bash
       run: unzip -q -o clients-javascript.zip && rm clients-javascript.zip
+
+    - name: Download client-javascript-algoliasearch artifact
+      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
+      uses: actions/download-artifact@v3
+      with:
+        name: client-javascript-algoliasearch
+
+    - name: Unzip client-javascript-algoliasearch artifact
+      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
+      shell: bash
+      run: unzip -q -o client-javascript-algoliasearch.zip && rm client-javascript-algoliasearch.zip
 
     # PHP
     - name: Download clients-php artifact

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -264,25 +264,22 @@ jobs:
             )}}
           path: clients/algoliasearch-client-javascript/packages/algoliasearch/
 
-      - name: Restore clients
+      - name: Download JavaScript clients artifact
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: actions/download-artifact@v3
         with:
           name: clients-javascript
-          path: clients/algoliasearch-client-javascript/
+
+      - name: Unzip JavaScript clients artifact
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: unzip -q -o clients-javascript.zip && rm clients-javascript.zip
 
       - name: Setup
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/setup
         with:
           type: minimal
-
-      - name: Download JavaScript clients
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/restore-artifacts
-        with:
-          javascript: true
-          type: all
 
       - name: Build 'algoliasearch' client
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

We were restoring the clients twice in the JavaScript algoliasearch job, one included the `algoliasearch` client itself.

## 🧪 Test

CI :D 
