### PR TITLE
fix(scripts): missing lock file in JS repository

### DIFF
--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -141,6 +141,13 @@ async function spreadGeneration(): Promise<void> {
     const version = getPackageVersionDefault(lang);
     const commitMessage = cleanUpCommitMessage(lastCommitMessage, version);
 
+    // We want to ensure we have an up to date `yarn.lock` in the JS client repository
+    if (lang === 'javascript') {
+      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', {
+        cwd: tempGitDir,
+      });
+    }
+
     await configureGitHubAuthor(tempGitDir);
     await run(`git add .`, { cwd: tempGitDir });
     await gitCommit({


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

The lock file is missing in the JS repository, hopefully this is enough to generate it there.

## 🧪 Test

CI :D 
