### PR TITLE
fix(javascript): cache on POST read request

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -268,7 +268,9 @@ export function createTransporter({
       },
     };
 
-    if (request.method !== 'GET') {
+    const isRead = request.useReadTransporter || request.method === 'GET';
+
+    if (!isRead) {
       /**
        * On write requests, no cache mechanisms are applied, and we
        * proxy the request immediately to the requester.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: /

### Changes included:

- allows a "read post request" to be cached too

## 🧪 Test

Do multiple identical search requests (this doesn't work yet until #612, as it's not set as cacheable: true, setting up a separate PR for that)
