### PR TITLE
chore(ci): allow deps as PR title scope

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Pull Request title rules
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
-          regex: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:generators|javascript|php|java|cts|specs|scripts|ci|templates)\)): .+'
+          regex: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:generators|javascript|php|java|cts|specs|scripts|ci|templates|deps)\)): .+'


### PR DESCRIPTION
## 🧭 What and Why

Allow `deps` as pr title scope, for example, https://github.com/algolia/api-clients-automation/pull/602

🎟 JIRA Ticket: -

## 🧪 Test

-