### PR TITLE
feat(javascript): use the text/plain content-type

### DIFF
--- a/templates/javascript/api-single.mustache
+++ b/templates/javascript/api-single.mustache
@@ -91,7 +91,7 @@ export function create{{capitalizedApiName}}(options: CreateClientOptions{{#hasR
     requestsCache: options.requestsCache,
     responsesCache: options.responsesCache,
     baseHeaders: {
-      'content-type': 'application/x-www-form-urlencoded',
+      'content-type': 'text/plain',
       ...auth.headers(),
     },
     baseQueryParameters: auth.queryParameters(),


### PR DESCRIPTION


## 🧭 What and Why

in https://github.com/algolia/react-instantsearch/issues/3487 I discovered the text/pain content-type is also accepted by the engine, and also doesn't create a full CORS request.

`text/plain` is preferable over `application/x-www-form-urlencoded` as the request we send isn't actually form encoded which means that debug tools like the network panel won't parse them wrong.

🎟 JIRA Ticket:

### Changes included:

- content-type for JS client changed to text/plain

## 🧪 Test

run requests and see that everything works with text/plain, especially including different clients like recommend.