### PR TITLE
refactor(javascript): simplify transporter.request

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -7,7 +7,6 @@ import type {
   StackFrame,
   TransporterOptions,
   Transporter,
-  Headers,
   QueryParameters,
 } from '../types';
 
@@ -99,7 +98,7 @@ export function createTransporter({
     const method = request.method;
 
     // On `GET`, the data is proxied to query parameters.
-    const dataQueryParameters: Record<string, any> =
+    const dataQueryParameters: QueryParameters =
       request.method === 'GET'
         ? {
             ...request.data,
@@ -238,10 +237,6 @@ export function createTransporter({
 
   function createRequest<TResponse>(
     baseRequest: Request,
-    methodOptions: {
-      headers: Headers;
-      queryParameters: QueryParameters;
-    },
     baseRequestOptions?: RequestOptions
   ): Promise<TResponse> {
     const mergedData: Request['data'] = Array.isArray(baseRequest.data)
@@ -258,12 +253,12 @@ export function createTransporter({
       cacheable: baseRequestOptions?.cacheable,
       timeout: baseRequestOptions?.timeout,
       queryParameters: {
-        ...methodOptions.queryParameters,
+        ...baseRequest.queryParameters,
         ...baseRequestOptions?.queryParameters,
       },
       headers: {
         Accept: 'application/json',
-        ...methodOptions.headers,
+        ...baseRequest.headers,
         ...baseRequestOptions?.headers,
       },
     };

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
@@ -1,11 +1,13 @@
-import type { Headers } from './Transporter';
+import type { Headers, QueryParameters } from './Transporter';
 
 export type Method = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 
 export type Request = {
   method: Method;
   path: string;
+  queryParameters: QueryParameters;
   data?: Array<Record<string, any>> | Record<string, any>;
+  headers: Headers;
   cacheable?: boolean;
   /**
    * Some POST methods in the Algolia REST API uses the `read` transporter.

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Transporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Transporter.ts
@@ -198,10 +198,6 @@ export type Transporter = {
    */
   request: <TResponse>(
     baseRequest: Request,
-    methodOptions: {
-      headers: Headers;
-      queryParameters: QueryParameters;
-    },
     baseRequestOptions?: RequestOptions
   ) => Promise<TResponse>;
 };

--- a/templates/javascript/api-single.mustache
+++ b/templates/javascript/api-single.mustache
@@ -215,6 +215,8 @@ export function create{{capitalizedApiName}}(options: CreateClientOptions{{#hasR
       const request: Request = {
         method: '{{httpMethod}}',
         path: requestPath,
+        queryParameters,
+        headers,
         {{#bodyParam}}
         data: {{paramName}},
         {{/bodyParam}}
@@ -226,10 +228,7 @@ export function create{{capitalizedApiName}}(options: CreateClientOptions{{#hasR
         {{/vendorExtensions.x-cacheable}}
       };
 
-      return transporter.request(request, {
-        queryParameters,
-        headers,
-      }, requestOptions);
+      return transporter.request(request, requestOptions);
     },
 
     {{/operation}}


### PR DESCRIPTION



## 🧭 What and Why

Simplify `transporter.request` by turning it from three arguments to only two. 

I can't see any significant difference between the first (request) and second (methodOptions) argument of `request`, so this PR changes that to both be in the first argument. requestOptions is still separate.

Other API clients don't seem to distinguish that clearly in the arguments to sendRequest, as they use mostly positional arguments

PHP: https://github.com/algolia/api-clients-automation/blob/bf4271246f9282d3c11dd46918e74cb86d9c96dc/templates/php/api.mustache#L263

Java: https://github.com/algolia/api-clients-automation/blob/bf4271246f9282d3c11dd46918e74cb86d9c96dc/templates/java/libraries/okhttp-gson/api.mustache#L196


### Changes included:

- transporter.request(request, methodOptions, requestOptions) -> transporter.request(request, requestOptions)

## 🧪 Test

This is a breaking change if you'd be using a custom request using the requester, but I guess that doesn't count yet.

If there's a historic reason for why there are three arguments and not two, feel free to research that too