### PR TITLE
fix(java): use outputs on release workflow

### DIFF
--- a/clients/algoliasearch-client-java-2/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-java-2/.github/workflows/release.yml
@@ -40,5 +40,5 @@ jobs:
           fi
 
       - name: Release Artifacts
-        if: ${{ steps.snapshot.IS_SNAPHOT != 'true' }}
+        if: ${{ steps.snapshot.outputs.IS_SNAPHOT != 'true' }}
         run: ./gradlew closeAndReleaseRepository


### PR DESCRIPTION
## 🧭 What and Why

Forgot to add `outputs` in the github actions

## 🧪 Test

Release java
