### PR TITLE
chore: fix spread code throwing on CI

### DIFF
--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -124,6 +124,13 @@ async function spreadGeneration(): Promise<void> {
     await emptyDirExceptForDotGit(tempGitDir);
     await copy(clientPath, tempGitDir, { preserveTimestamps: true });
 
+    // We want to ensure we have an up to date `yarn.lock` in the JS client repository
+    if (lang === 'javascript') {
+      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', {
+        cwd: tempGitDir,
+      });
+    }
+
     if (
       (await getNbGitDiff({
         head: null,
@@ -141,15 +148,8 @@ async function spreadGeneration(): Promise<void> {
     const version = getPackageVersionDefault(lang);
     const commitMessage = cleanUpCommitMessage(lastCommitMessage, version);
 
-    // We want to ensure we have an up to date `yarn.lock` in the JS client repository
-    if (lang === 'javascript') {
-      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', {
-        cwd: tempGitDir,
-      });
-    }
-
     await configureGitHubAuthor(tempGitDir);
-    await run(`git add .`, { cwd: tempGitDir });
+    await run('git add .', { cwd: tempGitDir });
     await gitCommit({
       message: commitMessage,
       coAuthors: [author, ...coAuthors],


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

The git diff check was done before the `yarn.lock` file was re-generated, which made the script trying to push changes (because the file was deleted), when there might be none.

## 🧪 Test

CI :D 
