### PR TITLE
chore: replace auth bot token

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -311,7 +311,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.TOKEN_GENERATE_BOT }}
+          token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
       - name: Download all artifacts
         if: ${{ needs.setup.outputs.RUN_CODEGEN == 'true' }}
@@ -331,11 +331,11 @@ jobs:
         id: pushGeneratedCode
         run: yarn workspace scripts pushGeneratedCode
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
 
       - name: Spread generation to each repository
         if: ${{ steps.pushGeneratedCode.exitcode == 0 && github.ref == 'refs/heads/main' }}
         run: yarn workspace scripts spreadGeneration
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Add notification comment
         run: yarn workspace scripts upsertGenerationComment notification
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           HEAD_BRANCH: ${{ github.head_ref }}
 
@@ -45,7 +45,7 @@ jobs:
       - name: Add cleanup comment
         run: yarn workspace scripts upsertGenerationComment cleanup
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_GENERATE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
 
       - name: Clean previously generated branch

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,4 +19,4 @@ jobs:
 
       - run: yarn workspace scripts renovateWeeklyPR
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_RELEASE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -19,4 +19,4 @@ jobs:
 
       - run: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_RELEASE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Since they have the same ACL, we can use the same token for both.

Name is updated because it has been re-generated.

## 🧪 Test

CI :D
