### PR TITLE
chore: make renovate bump mustache files

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -23,7 +23,7 @@
     "@experimental-api-clients-automation/requester-node-http": "0.3.0"
   },
   "devDependencies": {
-    "@types/node": "16.11.26",
+    "@types/node": "16.11.38",
     "typescript": "4.6.3"
   },
   "engines": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:js-app",
     "algolia"
@@ -7,7 +8,8 @@
     "npm",
     "nvm",
     "gradle",
-    "composer"
+    "composer",
+    "regex"
   ],
   "baseBranches": [
     "chore/renovateBaseBranch"
@@ -22,20 +24,75 @@
   ],
   "regexManagers": [
     {
+      "description": "Update openapitools-cli version in the config file",
       "fileMatch": [
-        "config/openapitools.json"
+        "openapitools.json"
       ],
       "matchStrings": [
-        "\"version\": \"(?<currentValue>.*?)\","
+        "\\s\"version\": \"(?<currentValue>.*?)\",\\s"
       ],
-      "depNameTemplate": "com.openapitools:openapi-generator-cli",
+      "depNameTemplate": "org.openapitools:openapi-generator-cli",
       "datasourceTemplate": "maven"
+    },
+    {
+      "description": "Update package.json mustache devDeps",
+      "fileMatch": [
+        "package.mustache"
+      ],
+      "matchStrings": [
+        "\\s\"@types/node\": \"(?<currentValue>.*?)\",\\s"
+      ],
+      "depNameTemplate": "@types/node",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "Update package.json mustache devDeps",
+      "fileMatch": [
+        "package.mustache"
+      ],
+      "matchStrings": [
+        "\\s\"typescript\": \"(?<currentValue>.*?)\",\\s"
+      ],
+      "depNameTemplate": "typescript",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "Update package.json mustache devDeps",
+      "fileMatch": [
+        "package.mustache"
+      ],
+      "matchStrings": [
+        "\\s\"jest\": \"(?<currentValue>.*?)\",\\s"
+      ],
+      "depNameTemplate": "jest",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "Update package.json mustache devDeps",
+      "fileMatch": [
+        "package.mustache"
+      ],
+      "matchStrings": [
+        "\\s\"ts-jest\": \"(?<currentValue>.*?)\",\\s"
+      ],
+      "depNameTemplate": "ts-jest",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "Update package.json mustache devDeps",
+      "fileMatch": [
+        "package.mustache"
+      ],
+      "matchStrings": [
+        "\\s\"ts-node\": \"(?<currentValue>.*?)\",\\s"
+      ],
+      "depNameTemplate": "ts-node",
+      "datasourceTemplate": "npm"
     }
   ],
   "ignorePaths": [
-    "**/client-abtesting/**",
-    "**/algoliasearch/**",
     "**/algoliasearch-lite/**",
+    "**/client-abtesting/**",
     "**/client-analytics/**",
     "**/client-insights/**",
     "**/client-personalization/**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,7 +1439,7 @@ __metadata:
     "@experimental-api-clients-automation/client-search": 0.3.0
     "@experimental-api-clients-automation/requester-browser-xhr": 0.3.0
     "@experimental-api-clients-automation/requester-node-http": 0.3.0
-    "@types/node": 16.11.26
+    "@types/node": 16.11.38
     typescript: 4.6.3
   languageName: unknown
   linkType: soft
@@ -4444,13 +4444,6 @@ __metadata:
   version: 17.0.40
   resolution: "@types/node@npm:17.0.40"
   checksum: e3b2fe876672fbe4be84ce17773944eb2f5eaba50e2c6c0536bdf6d4972ed6488581580581f154183fdc8f2d56fa42a42e3d6e83b9b71ee25adea16a84765e92
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:16.11.26":
-  version: 16.11.26
-  resolution: "@types/node@npm:16.11.26"
-  checksum: 57757caaba3f0d95de82198cb276a1002c49b710108c932a1d02d7c91ff2fa57cfe2dd19fde60853b6dd90b0964b3cf35557981d2628e20aed6a909057aedfe6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-524

### Changes included:

This PR fixes the regex match in our renovate config, which allows us to bump `package.mustache` files and the `openapitools.json` config in our weekly PRs.

I've also removed `algoliasearch` from the ignored list, as it's not a generated package.

## 🧪 Test

CI :D 
