### PR TITLE
fix(templates): simplify JavaScript mustache templates

### DIFF
--- a/templates/javascript/api-single.mustache
+++ b/templates/javascript/api-single.mustache
@@ -1,90 +1,9 @@
-import {
-  createAuth,
-  createTransporter,
-  getAlgoliaAgent,
-  shuffle,
-  {{#isSearchClient}}
-  createRetryablePromise,
-  {{/isSearchClient}}
-} from '@experimental-api-clients-automation/client-common';
-import type {
-  CreateClientOptions,
-  Headers,
-  Host,
-  Request,
-  RequestOptions,
-  QueryParameters,
-  {{#isSearchClient}}
-  CreateRetryablePromiseOptions,
-  {{/isSearchClient}}
-} from '@experimental-api-clients-automation/client-common';
-
-{{#imports}}
-import { {{classname}} } from '{{filename}}';
-{{/imports}}
-
-{{#operations}}
-import type {
-{{#operation}}
-{{#vendorExtensions.x-create-wrapping-object}}
-{{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props,
-{{/vendorExtensions.x-create-wrapping-object}}
-{{/operation}}
-} from '../model/clientMethodProps';
-{{/operations}}
+{{> api/imports}}
 
 export const apiClientVersion = '{{packageVersion}}';
 
 {{#operations}}
-{{#hasRegionalHost}}
-export const REGIONS = [{{#allowedRegions}}'{{.}}'{{^-last}},{{/-last}}{{/allowedRegions}}] as const;
-export type Region = typeof REGIONS[number];
-{{/hasRegionalHost}}
-
-{{^hasRegionalHost}}
-function getDefaultHosts(appId: string): Host[] {
-  return (
-    [
-      {
-        url: `${appId}-dsn.algolia.net`,
-        accept: 'read',
-        protocol: 'https',
-      },
-      {
-        url: `${appId}.algolia.net`,
-        accept: 'write',
-        protocol: 'https',
-      },
-    ] as Host[]
-  ).concat(
-    shuffle([
-      {
-        url: `${appId}-1.algolianet.com`,
-        accept: 'readWrite',
-        protocol: 'https',
-      },
-      {
-        url: `${appId}-2.algolianet.com`,
-        accept: 'readWrite',
-        protocol: 'https',
-      },
-      {
-        url: `${appId}-3.algolianet.com`,
-        accept: 'readWrite',
-        protocol: 'https',
-      },
-    ])
-  );
-}
-{{/hasRegionalHost}}
-
-{{#hasRegionalHost}}
-function getDefaultHosts(region{{#fallbackToAliasHost}}?{{/fallbackToAliasHost}}: Region): Host[] {
-  const url = {{#fallbackToAliasHost}}!region ? '{{{hostWithFallback}}}' : {{/fallbackToAliasHost}} '{{{host}}}'.replace('{region}', region);
-
-  return [{ url, accept: 'readWrite', protocol: 'https' }];
-}
-{{/hasRegionalHost}}
+{{> api/hosts}}
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function create{{capitalizedApiName}}({
@@ -147,45 +66,8 @@ export function create{{capitalizedApiName}}({
     },
     {{/isSearchClient}}
     {{#operation}}
-    /**
-    {{#notes}}
-    * {{&notes}}
-    {{/notes}}
-    {{#summary}}
-    * @summary {{&summary}}
-    {{/summary}}
-    {{#vendorExtensions}}
-      {{#x-create-wrapping-object}}
-      * @param {{nickname}} - The {{nickname}} object.
-      {{#allParams}}
-      * @param {{nickname}}.{{paramName}} - {{^description}}The {{paramName}} object.{{/description}}{{#description}}{{{description}}}{{/description}}
-      {{/allParams}}
-      {{/x-create-wrapping-object}}
-      {{#x-is-single-body-param}}
-        {{#bodyParams}}
-          * @param {{paramName}} - {{^description}}The {{paramName}} object.{{/description}}{{#description}}{{{description}}}{{/description}}
-        {{/bodyParams}}
-      {{/x-is-single-body-param}}
-    {{/vendorExtensions}}
-    * @param requestOptions - The requestOptions to send along with the query, they will be merged with the transporter requestOptions.
-    */
-    {{nickname}}(
-      {{#vendorExtensions}}
-        {{#x-create-wrapping-object}}
-          {
-            {{#allParams}}
-              {{paramName}},
-            {{/allParams}}
-          }: {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props,
-        {{/x-create-wrapping-object}}
-        {{#x-is-single-body-param}}
-          {{#bodyParams}}
-            {{paramName}}: {{{dataType}}},
-          {{/bodyParams}}
-        {{/x-is-single-body-param}}
-      {{/vendorExtensions}}
-      requestOptions?: RequestOptions
-        ) : Promise<{{{returnType}}}> {
+    {{> api/operation/jsdoc}}
+    {{nickname}}( {{> api/operation/parameters}} ) : Promise<{{{returnType}}}> {
       {{#allParams}}
       {{#required}}
       if ({{#isBoolean}}{{paramName}} === null || {{paramName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}{{/isBoolean}}) {
@@ -203,9 +85,16 @@ export function create{{capitalizedApiName}}({
       {{/required}}
       {{/allParams}}
 
-      const requestPath = '{{{path}}}'{{#vendorExtensions}}{{#pathParams}}.replace(
-      {{=<% %>=}}'{<%baseName%>}'<%={{ }}=%>,{{#x-is-custom-request}}{{paramName}}{{/x-is-custom-request}}{{^x-is-custom-request}}encodeURIComponent({{paramName}}){{/x-is-custom-request}}
-      ){{/pathParams}}{{/vendorExtensions}};
+      {{#vendorExtensions}}
+      const requestPath = '{{{path}}}'{{#pathParams}}.replace({{=<% %>=}}'{<%baseName%>}'<%={{ }}=%>,
+        {{#x-is-custom-request}}
+          {{paramName}}
+        {{/x-is-custom-request}}
+        {{^x-is-custom-request}}
+          encodeURIComponent({{paramName}})
+        {{/x-is-custom-request}}
+      ){{/pathParams}};
+      {{/vendorExtensions}}
       const headers: Headers = {};
       const queryParameters: QueryParameters = {{#vendorExtensions.x-is-custom-request}}parameters || {{/vendorExtensions.x-is-custom-request}}{};
 
@@ -230,12 +119,14 @@ export function create{{capitalizedApiName}}({
         {{#bodyParam}}
         data: {{paramName}},
         {{/bodyParam}}
-        {{#vendorExtensions.x-use-read-transporter}}
-        useReadTransporter: true,
-        {{/vendorExtensions.x-use-read-transporter}}
-        {{#vendorExtensions.x-cacheable}}
-        cacheable: true,
-        {{/vendorExtensions.x-cacheable}}
+        {{#vendorExtensions}}
+          {{#x-use-read-transporter}}
+            useReadTransporter: true,
+          {{/x-use-read-transporter}}
+          {{#x-cacheable}}
+            cacheable: true,
+          {{/x-cacheable}}
+        {{/vendorExtensions}}
       };
 
       return transporter.request(request, requestOptions);

--- a/templates/javascript/api/builds/checkParameters.mustache
+++ b/templates/javascript/api/builds/checkParameters.mustache
@@ -1,0 +1,19 @@
+if (!appId || typeof appId !== 'string') {
+  throw new Error("`appId` is missing.");
+}
+
+if (!apiKey || typeof apiKey !== 'string') {
+  throw new Error("`apiKey` is missing.");
+}
+
+{{#hasRegionalHost}}
+{{^fallbackToAliasHost}}
+if (!region) {
+  throw new Error("`region` is missing.");
+}
+{{/fallbackToAliasHost}}
+  
+if (region && (typeof region !== 'string' || !REGIONS.includes(region))) {
+  throw new Error(`\`region\` must be one of the following: ${REGIONS.join(', ')}`);
+}
+{{/hasRegionalHost}}

--- a/templates/javascript/api/builds/imports.mustache
+++ b/templates/javascript/api/builds/imports.mustache
@@ -1,0 +1,16 @@
+import type { InitClientOptions } from '@experimental-api-clients-automation/client-common';
+import { createMemoryCache, createFallbackableCache, createBrowserLocalStorageCache, createNullCache } from '@experimental-api-clients-automation/client-common';
+
+import { create{{capitalizedApiName}}, apiClientVersion } from '../src/{{apiName}}';
+import type { {{capitalizedApiName}} } from '../src/{{apiName}}';
+
+{{#hasRegionalHost}}
+import { Region, REGIONS } from '../src/{{apiName}}';
+{{/hasRegionalHost}}
+
+{{! We don't use `export *` to prevent exposing the factory, to avoid confusion for the user }}
+export {
+  apiClientVersion,
+  {{capitalizedApiName}},
+} from '../src/{{apiName}}';
+export * from '../model';

--- a/templates/javascript/api/hosts.mustache
+++ b/templates/javascript/api/hosts.mustache
@@ -1,0 +1,49 @@
+{{#hasRegionalHost}}
+export const REGIONS = [{{#allowedRegions}}'{{.}}'{{^-last}},{{/-last}}{{/allowedRegions}}] as const;
+export type Region = typeof REGIONS[number];
+{{/hasRegionalHost}}
+
+{{^hasRegionalHost}}
+function getDefaultHosts(appId: string): Host[] {
+  return (
+    [
+      {
+        url: `${appId}-dsn.algolia.net`,
+        accept: 'read',
+        protocol: 'https',
+      },
+      {
+        url: `${appId}.algolia.net`,
+        accept: 'write',
+        protocol: 'https',
+      },
+    ] as Host[]
+  ).concat(
+    shuffle([
+      {
+        url: `${appId}-1.algolianet.com`,
+        accept: 'readWrite',
+        protocol: 'https',
+      },
+      {
+        url: `${appId}-2.algolianet.com`,
+        accept: 'readWrite',
+        protocol: 'https',
+      },
+      {
+        url: `${appId}-3.algolianet.com`,
+        accept: 'readWrite',
+        protocol: 'https',
+      },
+    ])
+  );
+}
+{{/hasRegionalHost}}
+
+{{#hasRegionalHost}}
+function getDefaultHosts(region{{#fallbackToAliasHost}}?{{/fallbackToAliasHost}}: Region): Host[] {
+  const url = {{#fallbackToAliasHost}}!region ? '{{{hostWithFallback}}}' : {{/fallbackToAliasHost}} '{{{host}}}'.replace('{region}', region);
+
+  return [{ url, accept: 'readWrite', protocol: 'https' }];
+}
+{{/hasRegionalHost}}

--- a/templates/javascript/api/imports.mustache
+++ b/templates/javascript/api/imports.mustache
@@ -1,0 +1,36 @@
+import {
+  createAuth,
+  createTransporter,
+  getAlgoliaAgent,
+  shuffle,
+  {{#isSearchClient}}
+  createRetryablePromise,
+  {{/isSearchClient}}
+} from '@experimental-api-clients-automation/client-common';
+import type {
+  CreateClientOptions,
+  Headers,
+  Host,
+  Request,
+  RequestOptions,
+  QueryParameters,
+  {{#isSearchClient}}
+  CreateRetryablePromiseOptions,
+  {{/isSearchClient}}
+} from '@experimental-api-clients-automation/client-common';
+
+{{#imports}}
+import { {{classname}} } from '{{filename}}';
+{{/imports}}
+
+{{#operations}}
+import type {
+  {{#operation}}
+    {{#vendorExtensions}}
+      {{#x-create-wrapping-object}}
+        {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props,
+      {{/x-create-wrapping-object}}
+    {{/vendorExtensions}}
+  {{/operation}}
+} from '../model/clientMethodProps';
+{{/operations}}

--- a/templates/javascript/api/operation/jsdoc.mustache
+++ b/templates/javascript/api/operation/jsdoc.mustache
@@ -1,0 +1,22 @@
+/**
+{{#notes}}
+ * {{&notes}}
+{{/notes}}
+{{#summary}}
+ * @summary {{&summary}}
+{{/summary}}
+{{#vendorExtensions}}
+  {{#x-create-wrapping-object}}
+    * @param {{nickname}} - The {{nickname}} object.
+    {{#allParams}}
+      * @param {{nickname}}.{{paramName}} - {{^description}}The {{paramName}} object.{{/description}}{{#description}}{{{description}}}{{/description}}
+    {{/allParams}}
+  {{/x-create-wrapping-object}}
+  {{#x-is-single-body-param}}
+    {{#bodyParams}}
+      * @param {{paramName}} - {{^description}}The {{paramName}} object.{{/description}}{{#description}}{{{description}}}{{/description}}
+    {{/bodyParams}}
+  {{/x-is-single-body-param}}
+{{/vendorExtensions}}
+ * @param requestOptions - The requestOptions to send along with the query, they will be merged with the transporter requestOptions.
+*/

--- a/templates/javascript/api/operation/parameters.mustache
+++ b/templates/javascript/api/operation/parameters.mustache
@@ -1,0 +1,15 @@
+{{#vendorExtensions}}
+  {{#x-create-wrapping-object}}
+    {
+      {{#allParams}}
+        {{paramName}},
+      {{/allParams}}
+    }: {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props,
+  {{/x-create-wrapping-object}}
+  {{#x-is-single-body-param}}
+    {{#bodyParams}}
+      {{paramName}}: {{{dataType}}},
+    {{/bodyParams}}
+  {{/x-is-single-body-param}}
+{{/vendorExtensions}}
+requestOptions?: RequestOptions

--- a/templates/javascript/browser.mustache
+++ b/templates/javascript/browser.mustache
@@ -1,46 +1,13 @@
-import type { InitClientOptions } from '@experimental-api-clients-automation/client-common';
-import { DEFAULT_CONNECT_TIMEOUT_BROWSER, DEFAULT_READ_TIMEOUT_BROWSER, DEFAULT_WRITE_TIMEOUT_BROWSER } from '@experimental-api-clients-automation/client-common';
-import { createMemoryCache, createFallbackableCache, createBrowserLocalStorageCache } from '@experimental-api-clients-automation/client-common';
 import { createXhrRequester } from '@experimental-api-clients-automation/requester-browser-xhr';
-
-import { create{{capitalizedApiName}}, apiClientVersion } from '../src/{{apiName}}';
-import type { {{capitalizedApiName}} } from '../src/{{apiName}}';
-
-{{#hasRegionalHost}}
-import { Region, REGIONS } from '../src/{{apiName}}';
-{{/hasRegionalHost}}
-
-{{! We don't use `export *` to prevent exposing the factory, to avoid confusion for the user }}
-export { 
-  apiClientVersion,
-  {{capitalizedApiName}},
-} from '../src/{{apiName}}';
-export * from '../model';
+import { DEFAULT_CONNECT_TIMEOUT_BROWSER, DEFAULT_READ_TIMEOUT_BROWSER, DEFAULT_WRITE_TIMEOUT_BROWSER } from '@experimental-api-clients-automation/client-common';
+{{> api/builds/imports}}
 
 export function {{apiName}}(
   appId: string,
   apiKey: string,{{#hasRegionalHost}}region{{#fallbackToAliasHost}}?{{/fallbackToAliasHost}}: Region,{{/hasRegionalHost}}
   options?: InitClientOptions
 ): {{capitalizedApiName}} {
-  if (!appId || typeof appId !== 'string') {
-    throw new Error("`appId` is missing.");
-  }
-
-  if (!apiKey || typeof apiKey !== 'string') {
-    throw new Error("`apiKey` is missing.");
-  }
-
-  {{#hasRegionalHost}}
-  {{^fallbackToAliasHost}}
-  if (!region) {
-    throw new Error("`region` is missing.");
-  }
-  {{/fallbackToAliasHost}}
-  
-  if (region && (typeof region !== 'string' || !REGIONS.includes(region))) {
-    throw new Error(`\`region\` must be one of the following: ${REGIONS.join(', ')}`);
-  }
-  {{/hasRegionalHost}}
+  {{> api/builds/checkParameters}}
 
   return create{{capitalizedApiName}}({
     appId,

--- a/templates/javascript/node.mustache
+++ b/templates/javascript/node.mustache
@@ -1,46 +1,13 @@
-import type { InitClientOptions } from '@experimental-api-clients-automation/client-common';
-import { DEFAULT_CONNECT_TIMEOUT_NODE, DEFAULT_READ_TIMEOUT_NODE, DEFAULT_WRITE_TIMEOUT_NODE } from '@experimental-api-clients-automation/client-common';
-import { createMemoryCache, createNullCache } from '@experimental-api-clients-automation/client-common';
 import { createHttpRequester } from '@experimental-api-clients-automation/requester-node-http';
-
-import { create{{capitalizedApiName}} } from '../src/{{apiName}}';
-import type { {{capitalizedApiName}} } from '../src/{{apiName}}';
-
-{{#hasRegionalHost}}
-import { Region, REGIONS } from '../src/{{apiName}}';
-{{/hasRegionalHost}}
-
-{{! We don't use `export *` to prevent exposing the factory, to avoid confusion for the user }}
-export { 
-  apiClientVersion,
-  {{capitalizedApiName}},
-} from '../src/{{apiName}}';
-export * from '../model';
+import { DEFAULT_CONNECT_TIMEOUT_NODE, DEFAULT_READ_TIMEOUT_NODE, DEFAULT_WRITE_TIMEOUT_NODE } from '@experimental-api-clients-automation/client-common';
+{{> api/builds/imports}}
 
 export function {{apiName}}(
   appId: string,
   apiKey: string,{{#hasRegionalHost}}region{{#fallbackToAliasHost}}?{{/fallbackToAliasHost}}: Region,{{/hasRegionalHost}}
   options?: InitClientOptions
 ): {{capitalizedApiName}} {
-  if (!appId || typeof appId !== 'string') {
-    throw new Error("`appId` is missing.");
-  }
-
-  if (!apiKey || typeof apiKey !== 'string') {
-    throw new Error("`apiKey` is missing.");
-  }
-
-  {{#hasRegionalHost}}
-  {{^fallbackToAliasHost}}
-  if (!region) {
-    throw new Error("`region` is missing.");
-  }
-  {{/fallbackToAliasHost}}
-  
-  if (region && (typeof region !== 'string' || !REGIONS.includes(region))) {
-    throw new Error(`\`region\` must be one of the following: ${REGIONS.join(', ')}`);
-  }
-  {{/hasRegionalHost}}
+  {{> api/builds/checkParameters}}
 
   return create{{capitalizedApiName}}({
     appId,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

I've struggled in https://github.com/algolia/api-clients-automation/pull/665 to navigate in our template logic, and saw that there was redundant stuff between `node` and `browser` build templates.

There is no code change, we just leverage the partial template to make iteration easier.

## 🧪 Test

CI :D 
