### PR TITLE
chore(deps): group openapi-generator deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
         "required_provider"
       ],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchPackagePatterns": [
+        "openapi-generator"
+      ],
+      "groupName": "openapi-generator"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
## 🧭 What and Why

Group `openapi-generator` and `openapi-generator-cli` to be updated at the same time by renovate.
doc: https://docs.renovatebot.com/noise-reduction/#package-grouping