### PR TITLE
fix(scripts): add `yarn.lock` to cache key deps

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -134,9 +134,6 @@ outputs:
   RUN_JS_UTILS:
     description: Whether to build JS client common folders when RUN_JS is false
     value: ${{ steps.js-utils.outputs.RUN_JS_UTILS }}
-  RUN_JS_TESTS:
-    description: Determine if the `client_javascript_tests` job should run
-    value: ${{ steps.diff.outputs.JS_COMMON_TESTS_CHANGED > 0 }}
 
   RUN_CODEGEN:
     description: Determine if the `codegen` job should run

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,6 @@ jobs:
       RUN_GEN_PHP: ${{ steps.setup.outputs.RUN_GEN_PHP }}
 
       RUN_JS_UTILS: ${{ steps.setup.outputs.RUN_JS_UTILS }}
-      RUN_JS_TESTS: ${{ steps.setup.outputs.RUN_JS_TESTS }}
 
       RUN_CODEGEN: ${{ steps.setup.outputs.RUN_CODEGEN }}
 
@@ -162,10 +161,7 @@ jobs:
         run: yarn workspace algoliasearch-client-javascript build ${{ matrix.client }}
 
       - name: Run tests for 'client-common'
-        if: ${{
-          steps.cache.outputs.cache-hit != 'true' &&
-          needs.setup.outputs.RUN_JS_TESTS == 'true' &&
-          matrix.client == 'client-common' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client == 'client-common' }}
         run: yarn workspace @experimental-api-clients-automation/client-common test
 
       - name: Store '${{ matrix.client }}' JavaScript utils package

--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -45,9 +45,6 @@ export const COMMON_DEPENDENCIES = {
  */
 export const DEPENDENCIES = {
   ...COMMON_DEPENDENCIES,
-  JS_COMMON_TESTS_CHANGED: [
-    `${JS_CLIENT_FOLDER}/packages/client-common/src/__tests__`,
-  ],
   JAVASCRIPT_UTILS_CHANGED: CLIENTS_JS_UTILS.map(
     (clientName) => `${JS_CLIENT_FOLDER}/packages/${clientName}`
   ),

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -24,12 +24,16 @@ const commonCacheKey = (async function (): Promise<string> {
     folders: { include: ['config'] },
     files: { include: ['openapitools.json', 'clients.config.json'] },
   });
+  const depsHash = await hashElement(toAbsolutePath('.'), {
+    encoding: 'hex',
+    files: { include: ['yarn.lock'] },
+  });
 
-  return `${ghHash.hash}-${scriptsHash.hash}-${configHash.hash}`;
+  return `${ghHash.hash}-${scriptsHash.hash}-${configHash.hash}-${depsHash}`;
 })();
 
 /**
- * Compute a cache key based on the changes in the `paths` array of dependenciy.
+ * Compute a cache key based on the changes in the `paths` array of dependency.
  *
  * The `paths` parameter is an array of string, that needs to be treated as dependencies.
  */


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

**add `yarn.lock` to computed cache key**:

Now that we have renovate on, we need to ensure cache is invalidated when the lock file changes.

**remove RUN_JS_TESTS cond**:

Those tests take like ~5 seconds but their dependencies are pretty hard to compute (deps, other clients, etc.). For the sake of simplicity, we can run them every time the `client-common` needs to run

## 🧪 Test

CI :D 