### PR TITLE
chore(ci): make the artifacts dynamic

### DIFF
--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -15,6 +15,9 @@ inputs:
   token:
     description: GITHUB_TOKEN from secrets (not accessible from here)
     required: false
+  runId:
+    description: The GITHUB_RUN_ID
+    required: false
 
 runs:
   using: composite
@@ -65,7 +68,7 @@ runs:
           rm -rf $(jq -r '.testToDelete' <<< $client) || true
 
           # Get the artifact id
-          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ env.GITHUB_RUN_ID }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
+          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ inputs.runId }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
           gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/$id/zip > $artifact.zip
           unzip -q -o $artifact.zip && rm $artifact.zip
         done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -57,12 +57,12 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         echo ${{ inputs.matrix }} | jq -c '.client []' | while read client; do
-          language=$(jq '.language' <<< $client)
+          language=$(jq -r '.language' <<< $client)
           artifact="clients-$language"
           echo "Downloading $artifact artifacts"
 
-          rm -rf $(jq '.path' <<< $client)
-          rm -rf $(jq '.testToDelete' <<< $client) || true
+          rm -rf $(jq -r '.path' <<< $client)
+          rm -rf $(jq -r '.testToDelete' <<< $client) || true
 
           # Get the artifact id
           id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ env.GITHUB_RUN_ID }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -9,14 +9,8 @@ inputs:
   type:
     description: Type of artifacts to restore (`all` | `specs` | `js_utils`)
     required: false
-  php:
-    description: Whether this job ran or not
-    required: false
-  java:
-    description: Whether this job ran or not
-    required: false
-  javascript:
-    description: Whether this job ran or not
+  matrix:
+    description: The matrix of language clients to download
     required: false
 
 runs:
@@ -56,7 +50,13 @@ runs:
     - name: Download clients and tests artifacts
       if: ${{ inputs.type == 'all' }}
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
       run: |
         echo "Downloading test artifact"
         gh api -H "Accept: application/vnd.github.v3+json" \
           /repos/algolia/api-clients-automation/actions/artifacts/clients-java/zip
+
+        echo ${{ inputs.matrix }} | jq -c '.client []' | while read client; do
+          echo $client
+        done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -12,6 +12,9 @@ inputs:
   matrix:
     description: The matrix of language clients to download
     required: false
+  token:
+    description: GITHUB_TOKEN from secrets (not accessible from here)
+    required: false
 
 runs:
   using: composite
@@ -51,7 +54,7 @@ runs:
       if: ${{ inputs.type == 'all' }}
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         echo "Downloading test artifact"
         gh api -H "Accept: application/vnd.github.v3+json" \

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -19,36 +19,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # Bundled specs
-    - name: specs
-      if: ${{ inputs.type == 'all' || inputs.type == 'specs' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: specs
-        path: specs/bundled/
-
-    # JavaScript utils
-    - name: client-javascript-utils-client-common
-      if: ${{ (inputs.javascript == 'true' && inputs.type == 'all') || inputs.type == 'js_utils' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: client-javascript-utils-client-common
-        path: clients/algoliasearch-client-javascript/packages/client-common/
-
-    - name: client-javascript-utils-requester-browser-xhr
-      if: ${{ (inputs.javascript == 'true' && inputs.type == 'all') || inputs.type == 'js_utils' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: client-javascript-utils-requester-browser-xhr
-        path: clients/algoliasearch-client-javascript/packages/requester-browser-xhr/
-
-    - name: client-javascript-utils-requester-node-http
-      if: ${{ (inputs.javascript == 'true' && inputs.type == 'all') || inputs.type == 'js_utils' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: client-javascript-utils-requester-node-http
-        path: clients/algoliasearch-client-javascript/packages/requester-node-http/
-
     # Clients and tests
     - name: Download clients and tests artifacts
       if: ${{ inputs.type == 'all' }}

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Download clients-java artifact
-      if: ${{ inputs.java == 'true' && inputs.type == 'all' }}
+      if: ${{ inputs.type == 'all' }}
       uses: actions/download-artifact@v3
       with:
         name: clients-java

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -19,6 +19,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Download clients-java artifact
+      if: ${{ inputs.java == 'true' && inputs.type == 'all' }}
+      uses: actions/download-artifact@v3
+      with:
+        name: clients-java
+
     # Clients and tests
     - name: Download clients and tests artifacts
       if: ${{ inputs.type == 'all' }}

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -15,9 +15,6 @@ inputs:
   token:
     description: GITHUB_TOKEN from secrets (not accessible from here)
     required: false
-  runId:
-    description: The GITHUB_RUN_ID
-    required: false
 
 runs:
   using: composite
@@ -68,7 +65,7 @@ runs:
           rm -rf $(jq -r '.testToDelete' <<< $client) || true
 
           # Get the artifact id
-          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ inputs.runId }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
+          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ github.run_id }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
           gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/$id/zip > $artifact.zip
           unzip -q -o $artifact.zip && rm $artifact.zip
         done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -52,38 +52,11 @@ runs:
         name: client-javascript-utils-requester-node-http
         path: clients/algoliasearch-client-javascript/packages/requester-node-http/
 
-    # JavaScript
-    - name: Download clients-javascript artifact
-      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: clients-javascript
-
-    - name: Unzip clients-javascript artifact
-      if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}
+    # Clients and tests
+    - name: Download clients and tests artifacts
+      if: ${{ inputs.type == 'all' }}
       shell: bash
-      run: unzip -q -o clients-javascript.zip && rm clients-javascript.zip
-
-    # PHP
-    - name: Download clients-php artifact
-      if: ${{ inputs.php == 'true' && inputs.type == 'all' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: clients-php
-
-    - name: Unzip clients-php artifact
-      if: ${{ inputs.php == 'true' && inputs.type == 'all' }}
-      shell: bash
-      run: unzip -q -o clients-php.zip && rm clients-php.zip
-
-    # Java
-    - name: Download clients-java artifact
-      if: ${{ inputs.java == 'true' && inputs.type == 'all' }}
-      uses: actions/download-artifact@v3
-      with:
-        name: clients-java
-
-    - name: Unzip clients-java artifact
-      if: ${{ inputs.java == 'true' && inputs.type == 'all' }}
-      shell: bash
-      run: unzip -q -o clients-java.zip && rm clients-java.zip
+      run: |
+        echo "Downloading test artifact"
+        gh api -H "Accept: application/vnd.github.v3+json" \
+          /repos/algolia/api-clients-automation/actions/artifacts/clients-java/zip

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -57,9 +57,18 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         echo "Downloading test artifact"
-        gh api -H "Accept: application/vnd.github.v3+json" \
-          /repos/algolia/api-clients-automation/actions/artifacts/clients-java/zip
+        gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/clients-java/zip
 
         echo ${{ inputs.matrix }} | jq -c '.client []' | while read client; do
-          echo $client
+          language=$(jq '.language' <<< $client)
+          artifact="clients-$language"
+          echo "Downloading $artifact artifacts"
+
+          rm -rf $(jq '.path' <<< $client)
+          rm -rf $(jq '.testToDelete' <<< $client) || true
+
+          # Get the artifact id
+          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ env.GITHUB_RUN_ID }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id"
+          gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/$id/zip > $artifact.zip
+          unzip -q -o $artifact.zip && rm $artifact.zip
         done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -65,7 +65,7 @@ runs:
           rm -rf $(jq '.testToDelete' <<< $client) || true
 
           # Get the artifact id
-          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ env.GITHUB_RUN_ID }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id"
+          id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ env.GITHUB_RUN_ID }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
           gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/$id/zip > $artifact.zip
           unzip -q -o $artifact.zip && rm $artifact.zip
         done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -66,6 +66,7 @@ runs:
 
           # Get the artifact id
           id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/runs/${{ github.run_id }}/artifacts -q ".artifacts [] | select(.name==\"$artifact\") | .id")
+          echo "Artifact id: $id"
           gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/$id/zip > $artifact.zip
           unzip -q -o $artifact.zip && rm $artifact.zip
         done

--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -56,9 +56,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        echo "Downloading test artifact"
-        gh api -H "Accept: application/vnd.github.v3+json" /repos/algolia/api-clients-automation/actions/artifacts/clients-java/zip
-
         echo ${{ inputs.matrix }} | jq -c '.client []' | while read client; do
           language=$(jq '.language' <<< $client)
           artifact="clients-$language"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 # Uncomment the line below to enable artifacts debugging
-# env:
-#   ACTIONS_RUNNER_DEBUG: true
+env:
+  ACTIONS_RUNNER_DEBUG: true
 
 jobs:
   setup:
@@ -58,6 +58,20 @@ jobs:
     if: ${{ needs.setup.outputs.RUN_SCRIPTS == 'true' }}
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          type: minimal
+
+      - name: Check script linting
+        run: yarn scripts:lint
+
+      - name: Test scripts
+        run: yarn scripts:test
+
+      - name: Test custom eslint plugin
+        run: yarn workspace eslint-plugin-automation-custom test
 
   specs:
     runs-on: ubuntu-20.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -245,7 +245,6 @@ jobs:
           type: all
           matrix: ${{ toJSON(needs.setup.outputs.GEN_MATRIX) }}
           token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
-          runId: ${{ env.GITHUB_RUN_ID }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -244,6 +244,7 @@ jobs:
         with:
           type: all
           matrix: ${{ toJSON(needs.setup.outputs.GEN_MATRIX) }}
+          token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -245,6 +245,7 @@ jobs:
           type: all
           matrix: ${{ toJSON(needs.setup.outputs.GEN_MATRIX) }}
           token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+          runId: ${{ env.GITHUB_RUN_ID }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,25 +35,6 @@ jobs:
         with:
           type: matrix
 
-      - name: Lint GitHub actions
-        run: yarn github-actions:lint
-
-      - name: Lint generators
-        run: |
-          yarn cli format java generators
-          diff=$(git status --porcelain ./generators | wc -l)
-
-          if [[ $diff > 0 ]]; then
-            echo "Format the generators folder by running 'yarn docker format java generators'"
-          fi
-
-          exit $diff
-
-      - name: Lint json files
-        run: |
-          yarn eslint --ext=json .
-          echo 'Use yarn fix:json to fix issues'
-
     outputs:
       RUN_SCRIPTS: ${{ steps.setup.outputs.RUN_SCRIPTS }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -209,42 +209,10 @@ jobs:
         with:
           type: js_utils
 
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Generate clients
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: yarn cli generate ${{ matrix.client.language }} ${{ matrix.client.toRun }}
-
-      - name: Build clients
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language != 'php' }}
-        run: yarn cli build clients ${{ matrix.client.language }} ${{ matrix.client.toRun }}
-
-      - name: Build JavaScript 'algoliasearch' client
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
-        run: yarn cli build clients javascript algoliasearch
-
-      - name: Run JavaScript 'algoliasearch' client tests
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
-        run: yarn workspace @experimental-api-clients-automation/algoliasearch test
-
-      - name: Clean CTS output before generate
-        run: rm -rf ${{ matrix.client.testsToDelete }} || true
-
-      - name: Generate CTS
-        run: yarn cli cts generate ${{ matrix.client.language }} ${{ matrix.client.toRun }}
-
-      - name: Update `yarn.lock` for JavaScript release
-        if: ${{ matrix.client.language == 'javascript' && (startsWith(github.head_ref, 'chore/prepare-release-') || github.ref == 'refs/heads/main') }}
-        run: YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
-
-      - name: Run CTS
-        run: yarn cli cts run ${{ matrix.client.language }}
-
       - name: Zip artifact before storing
         run:
-          zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} \
-          -x "**/node_modules**" "clients/algoliasearch-client-javascript/.yarn**" "**/.github**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
+          zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} -x \
+          "**/node_modules**" "clients/algoliasearch-client-javascript/.yarn**" "**/.github**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
 
       - name: Store ${{ matrix.client.language }} clients
         uses: actions/upload-artifact@v3
@@ -275,7 +243,7 @@ jobs:
         uses: ./.github/actions/restore-artifacts
         with:
           type: all
-          matrix: ${{ fromJSON(needs.setup.outputs.GEN_MATRIX) }}
+          matrix: ${{ toJSON(needs.setup.outputs.GEN_MATRIX) }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -242,7 +242,9 @@ jobs:
         run: yarn cli cts run ${{ matrix.client.language }}
 
       - name: Zip artifact before storing
-        run: zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} -x "**/node_modules**" "clients/algoliasearch-client-javascript/.yarn**" "**/.github**"
+        run:
+          zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} \
+          -x "**/node_modules**" "clients/algoliasearch-client-javascript/.yarn**" "**/.github**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
 
       - name: Store ${{ matrix.client.language }} clients
         uses: actions/upload-artifact@v3
@@ -273,9 +275,7 @@ jobs:
         uses: ./.github/actions/restore-artifacts
         with:
           type: all
-          javascript: ${{ needs.setup.outputs.RUN_GEN_JAVASCRIPT }}
-          php: ${{ needs.setup.outputs.RUN_GEN_PHP }}
-          java: ${{ needs.setup.outputs.RUN_GEN_JAVA }}
+          matrix: ${{ fromJSON(needs.setup.outputs.GEN_MATRIX) }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,20 +78,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup
-        uses: ./.github/actions/setup
-        with:
-          type: minimal
-
-      - name: Check script linting
-        run: yarn scripts:lint
-
-      - name: Test scripts
-        run: yarn scripts:test
-
-      - name: Test custom eslint plugin
-        run: yarn workspace eslint-plugin-automation-custom test
-
   specs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -100,30 +86,6 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX) }}
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache bundled specs
-        id: cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ matrix.client.cacheKey }}
-          path: ${{ matrix.client.bundledPath }}
-
-      - name: Setup
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/setup
-        with:
-          type: minimal
-
-      - name: Building specs
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: yarn cli build specs ${{ matrix.client.toRun }}
-
-      - name: Store bundled specs
-        uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: specs
-          path: ${{ matrix.client.bundledPath }}
 
   client_javascript_utils:
     timeout-minutes: 10
@@ -138,38 +100,6 @@ jobs:
           - requester-node-http
     steps:
       - uses: actions/checkout@v2
-
-      - name: Cache '${{ matrix.client }}' client folder
-        id: cache
-        uses: actions/cache@v3
-        with:
-          key: |
-            ${{ matrix.client }}-${{ hashFiles(
-              format('clients/algoliasearch-client-javascript/packages/{0}/**', matrix.client),
-              'yarn.lock'
-            )}}
-          path: clients/algoliasearch-client-javascript/packages/${{ matrix.client }}
-
-      - name: Setup
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/setup
-        with:
-          type: minimal
-
-      - name: Build '${{ matrix.client }}' client
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: yarn workspace algoliasearch-client-javascript build ${{ matrix.client }}
-
-      - name: Run tests for 'client-common'
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client == 'client-common' }}
-        run: yarn workspace @experimental-api-clients-automation/client-common test
-
-      - name: Store '${{ matrix.client }}' JavaScript utils package
-        uses: actions/upload-artifact@v3
-        with:
-          if-no-files-found: error
-          name: client-javascript-utils-${{ matrix.client }}
-          path: clients/algoliasearch-client-javascript/packages/${{ matrix.client }}
 
   client_gen:
     timeout-minutes: 15
@@ -195,19 +125,6 @@ jobs:
         with:
           key: ${{ matrix.client.cacheKey }}
           path: ${{ matrix.client.path }}
-
-      - name: Download specs artifacts
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: ./.github/actions/restore-artifacts
-        with:
-          type: specs
-
-        # Always download the utils for js, in case they changed we want to include them in the zip
-      - name: Download JavaScript utils artifacts
-        if: ${{ matrix.client.language == 'javascript' }}
-        uses: ./.github/actions/restore-artifacts
-        with:
-          type: js_utils
 
       - name: Zip artifact before storing
         run:

--- a/scripts/ci/husky/pre-commit.js
+++ b/scripts/ci/husky/pre-commit.js
@@ -38,9 +38,7 @@ async function preCommit() {
     }
   }
 
-  const stagedFiles = (
-    await run('git diff --name-only --cached --diff-filter=d')
-  ).split('\n');
+  const stagedFiles = (await run('git diff --name-only --cached')).split('\n');
 
   const toUnstage = micromatch.match(stagedFiles, getPatterns());
 

--- a/templates/java/model.mustache
+++ b/templates/java/model.mustache
@@ -20,6 +20,7 @@ import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 {{/jsonb}}
 
+
 {{#models}}
 {{#model}}
 {{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}

--- a/templates/java/model.mustache
+++ b/templates/java/model.mustache
@@ -20,7 +20,6 @@ import javax.json.stream.JsonParser;
 import javax.json.bind.annotation.JsonbProperty;
 {{/jsonb}}
 
-
 {{#models}}
 {{#model}}
 {{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#vendorExtensions.x-is-one-of-interface}}{{>oneof_interface}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{>pojo}}{{/vendorExtensions.x-is-one-of-interface}}{{/isEnum}}


### PR DESCRIPTION
## 🧭 What and Why

By making the artifacts download depends on the matrix, we have access to the data to remove the correct file and then apply the artifact, so the deleted files stays deleted and we don't need to push them manually anymore, cleaning the changes in PR.

### Changes included:

- Use the artifacts API from github
- Use the matrix to delete the correct files before applying the zip
- Remove deleted files from commit

## 🧪 Test

CI
