### PR TITLE
feat(php): Change environment variables loading in the playground

### DIFF
--- a/playground/php/loadEnv.php
+++ b/playground/php/loadEnv.php
@@ -1,0 +1,14 @@
+<?php
+require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+
+// Gets the vars from local environment
+$env = getenv();
+
+// If the script has been run from docker's playground, fetches the vars from .env file instead
+if (isset($env['DOCKER']) && $env['DOCKER'] === "true") {
+    $dotenv = Dotenv\Dotenv::createImmutable('../..');
+    $dotenv->load();
+    $env = $_ENV;
+}
+
+return $env;

--- a/playground/php/src/abtesting.php
+++ b/playground/php/src/abtesting.php
@@ -1,10 +1,10 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\AbtestingClient;
 
-$client = AbtestingClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_ANALYTICS_KEY'));
+$client = AbtestingClient::create($env['ALGOLIA_APPLICATION_ID'], $env['ALGOLIA_ANALYTICS_KEY']);
 
 $abTest = [
     'name' => 'testing',

--- a/playground/php/src/analytics.php
+++ b/playground/php/src/analytics.php
@@ -1,11 +1,11 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\AnalyticsClient;
 
-$client = AnalyticsClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_ANALYTICS_KEY'));
-$indexName = getenv('ANALYTICS_INDEX');
+$client = AnalyticsClient::create($env['ALGOLIA_APPLICATION_ID'], $env['ALGOLIA_ANALYTICS_KEY']);
+$indexName = $env['ANALYTICS_INDEX'];
 
 var_dump(
     $client->getTopFilterForAttribute(

--- a/playground/php/src/insights.php
+++ b/playground/php/src/insights.php
@@ -1,11 +1,11 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\InsightsClient;
 
-$client = InsightsClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_ADMIN_KEY'));
-$indexName = getenv('SEARCH_INDEX');
+$client = InsightsClient::create($env['ALGOLIA_APPLICATION_ID'], $env['ALGOLIA_ADMIN_KEY']);
+$indexName = $env['SEARCH_INDEX'];
 
 $twoDaysAgoMs = (time() - (2 * 24 * 60 * 60)) * 1000;
 

--- a/playground/php/src/personalization.php
+++ b/playground/php/src/personalization.php
@@ -1,10 +1,10 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\PersonalizationClient;
 
-$client = PersonalizationClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_RECOMMENDATION_KEY'));
+$client = PersonalizationClient::create($env['ALGOLIA_APPLICATION_ID'], $env['ALGOLIA_RECOMMENDATION_KEY']);
 
 var_dump(
     $client->deleteUserProfile('userToken')

--- a/playground/php/src/query-suggestions.php
+++ b/playground/php/src/query-suggestions.php
@@ -1,9 +1,9 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\QuerySuggestionsClient;
 
-$client = QuerySuggestionsClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('QUERY_SUGGESTIONS_KEY'));
+$client = QuerySuggestionsClient::create($env['ALGOLIA_APPLICATION_ID'], $env['QUERY_SUGGESTIONS_KEY']);
 
 var_dump($client->getAllConfigs());

--- a/playground/php/src/recommend.php
+++ b/playground/php/src/recommend.php
@@ -1,12 +1,12 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\RecommendClient;
 
-$client = RecommendClient::create(getenv('ALGOLIA_APPLICATION_ID'), getenv('ALGOLIA_ADMIN_KEY'));
-$indexName = getenv('SEARCH_INDEX');
-$query = getenv('SEARCH_QUERY');
+$client = RecommendClient::create($env['ALGOLIA_APPLICATION_ID'], $env['ALGOLIA_ADMIN_KEY']);
+$indexName = $env['SEARCH_INDEX'];
+$query = $env['SEARCH_QUERY'];
 
 var_dump($client->getRecommendations(
     [

--- a/playground/php/src/search.php
+++ b/playground/php/src/search.php
@@ -1,19 +1,19 @@
 <?php
 
-require '../../../clients/algoliasearch-client-php/vendor/autoload.php';
+$env = require_once('../loadEnv.php');
 
 use Algolia\AlgoliaSearch\Api\SearchClient;
 
 $client = SearchClient::create(
-    getenv('ALGOLIA_APPLICATION_ID'),
-    getenv('ALGOLIA_ADMIN_KEY')
+    $env['ALGOLIA_APPLICATION_ID'],
+    $env['ALGOLIA_ADMIN_KEY']
 );
-$indexName = getenv('SEARCH_INDEX');
+$indexName = $env['SEARCH_INDEX'];
 
 
 $response = $client->saveObject(
     $indexName,
-    ['objectID' => "111", 'name' => getenv('SEARCH_QUERY')],
+    ['objectID' => "111", 'name' => $env['SEARCH_QUERY']],
 );
 
 var_dump($response);
@@ -23,7 +23,7 @@ $client->waitForTask($indexName, $response['taskID']);
 var_dump(
     $client->search([
         'requests' => [
-            ['indexName' => $indexName, 'query' => getenv('SEARCH_QUERY')],
+            ['indexName' => $indexName, 'query' => $env['SEARCH_QUERY']],
         ],
     ])
 );

--- a/templates/php/composer.mustache
+++ b/templates/php/composer.mustache
@@ -36,7 +36,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "vlucas/phpdotenv": "^5.4"
     },
     "autoload": {
         "psr-4": { "{{escapedInvokerPackage}}\\" : "{{srcBasePath}}/" },


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: APIC-487

### Changes included:

- Change environment variables loading in the PHP playground, now you can either use `yarn docker playground php search` which loads the .env file or directly run `php search.php` if you prefer use your local environment variables located in your .bashrc or whatever.

## 🧪 Test
 `yarn docker playground php search`