### PR TITLE
fix(javascript): order type first in legacy mapping

### DIFF
--- a/templates/javascript/api/operation/legacySearchCompatible/implementation.mustache
+++ b/templates/javascript/api/operation/legacySearchCompatible/implementation.mustache
@@ -3,9 +3,9 @@ if (searchMethodParams && Array.isArray(searchMethodParams)) {
     requests: searchMethodParams.map(({ params, ...legacyRequest }) => {
       if (legacyRequest.type === 'facet') {
         return {
+          type: 'facet',
           ...legacyRequest,
           ...params,
-          type: 'facet',
         };
       }
 


### PR DESCRIPTION
This is based on an assumption, but if I'd implement this endpoint in the search engine, I would shortcut to the facet search as soon as I see `type: facet`, so this has a chance to be imperceptually faster

## 🧭 What and Why

🎟 JIRA Ticket: /

### Changes included:

- type is listed first in type facet request

## 🧪 Test

Nothing should have changed, except possibly a very small performance improvement
