### PR TITLE
feat(java): remove default and strict test APIC-536

### DIFF
--- a/templates/java/pojo.mustache
+++ b/templates/java/pojo.mustache
@@ -24,10 +24,10 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
   @SerializedName("{{baseName}}")
   {{/gson}}
   {{#isContainer}}
-  private {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
+  private {{{datatypeWithEnum}}} {{name}};
   {{/isContainer}}
   {{^isContainer}}
-  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}};
   {{/isContainer}}
 
   {{/vars}}

--- a/templates/java/tests/requests/requests.mustache
+++ b/templates/java/tests/requests/requests.mustache
@@ -64,7 +64,7 @@ class {{client}}RequestsTests {
 
         {{#request.body}}
         assertDoesNotThrow(() -> {
-            JSONAssert.assertEquals("{{#lambda.escapeQuotes}}{{{request.body}}}{{/lambda.escapeQuotes}}", req.body, JSONCompareMode.STRICT_ORDER);
+            JSONAssert.assertEquals("{{#lambda.escapeQuotes}}{{{request.body}}}{{/lambda.escapeQuotes}}", req.body, JSONCompareMode.STRICT);
         });
         {{/request.body}}
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [APIC-536](https://algolia.atlassian.net/browse/APIC-536)

Remove default from models and let the algolia api set them.
This allows to use `STRICT` Json assertions in our test, before that we could have more properties than expected.

## 🧪 Test

CI
