### PR TITLE
chore(ci): run js utils without immutable installation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -154,6 +154,8 @@ jobs:
         with:
           type: minimal
           language: javascript
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Build '${{ matrix.client }}' client
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## 🧭 What and Why

When upgrading a deps we need to run yarn install to update the lock

## 🧪 Test

CI
