### PR TITLE
fix(javascript): improve bundlesize, add check to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -225,6 +225,10 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language != 'php' }}
         run: yarn cli build clients ${{ matrix.client.language }} ${{ matrix.client.toBuild }}
 
+      - name: Test JavaScript bundle size
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
+        run: cd ${{ matrix.client.path }} && yarn test:size
+
       - name: Run JavaScript 'algoliasearch' client tests
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
         run: cd ${{ matrix.client.path }} && yarn workspace @experimental-api-clients-automation/algoliasearch test

--- a/clients/algoliasearch-client-javascript/bundlesize.config.json
+++ b/clients/algoliasearch-client-javascript/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.60KB"
+      "maxSize": "7.80KB"
     },
     {
       "path": "packages/algoliasearch/dist/lite/lite.umd.js",
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/client-insights/dist/client-insights.umd.js",
-      "maxSize": "3.80KB"
+      "maxSize": "3.75KB"
     },
     {
       "path": "packages/client-personalization/dist/client-personalization.umd.js",
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/client-search/dist/client-search.umd.js",
-      "maxSize": "6.30KB"
+      "maxSize": "6.55KB"
     },
     {
       "path": "packages/client-sources/dist/client-sources.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/createEchoRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/createEchoRequester.ts
@@ -24,7 +24,7 @@ function getUrlParams({
     host,
     algoliaAgent,
     searchParams:
-      Object.entries(searchParams).length === 0 ? undefined : searchParams,
+      Object.keys(searchParams).length === 0 ? undefined : searchParams,
   };
 }
 
@@ -39,7 +39,7 @@ export function createEchoRequester({
   ): Promise<Response> {
     const { host, searchParams, algoliaAgent } = getUrlParams(getURL(url));
     const originalData =
-      data && Object.entries(data).length > 0 ? data : undefined;
+      data && Object.keys(data).length > 0 ? data : undefined;
 
     return Promise.resolve({
       content: JSON.stringify({

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -113,19 +113,19 @@ export function createTransporter({
     };
 
     if (requestOptions?.queryParameters) {
-      for (const [key, value] of Object.entries(
-        requestOptions.queryParameters
-      )) {
+      for (const key of Object.keys(requestOptions.queryParameters)) {
         // We want to keep `undefined` and `null` values,
         // but also avoid stringifying `object`s, as they are
         // handled in the `serializeUrl` step right after.
         if (
-          !value ||
-          Object.prototype.toString.call(value) === '[object Object]'
+          !requestOptions.queryParameters[key] ||
+          Object.prototype.toString.call(
+            requestOptions.queryParameters[key]
+          ) === '[object Object]'
         ) {
-          queryParameters[key] = value;
+          queryParameters[key] = requestOptions.queryParameters[key];
         } else {
-          queryParameters[key] = value.toString();
+          queryParameters[key] = requestOptions.queryParameters[key].toString();
         }
       }
     }

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -34,23 +34,30 @@ waitForApiKey({
   ...createRetryablePromiseOptions
 }: WaitForApiKeyOptions): Promise<ApiError | Key> {
   if (operation === 'update') {
+    if (!apiKey) {
+      throw new Error(
+        '`apiKey` is required when waiting for an `update` operation.'
+      );
+    }
+
     return createRetryablePromise({
       ...createRetryablePromiseOptions,
       func: () => this.getApiKey({ key }),
-      validate: (response) =>  {
-        for (const [entry, values] of Object.entries(apiKey)) {
-          if (Array.isArray(values)) {
+      validate: (response) => {
+        for (const field of Object.keys(apiKey)) {
+          if (Array.isArray(apiKey[field])) {
             if (
-              values.length !== response[entry].length ||
-              values.some((val, index) => val !== response[entry][index])
+              apiKey[field].length !== response[field].length ||
+              (apiKey[field] as string[]).some(
+                (value, index) => value !== response[field][index]
+              )
             ) {
               return false;
             }
-          } else if (values !== response[entry]) {
+          } else if (response[field] !== apiKey[field]) {
             return false;
           }
         }
-
         return true;
       },
     });


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

In https://github.com/algolia/api-clients-automation/pull/738, I forgot to check/increase the bundlesize, which also made me realize that we use `Object.entries` in the JS client, which is not supported in some (older/IE) browsers, and had huge impact on size (~60kb in `algoliasearch`).

In this PR, we now only leverage `Object.keys`, and also check for the bundlesize in the CI, which allow us to catch those big increase issue.

## 🧪 Test

CI :D 
