### PR TITLE
fix(specs): add renderingContent to search response

### DIFF
--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -140,6 +140,8 @@ baseSearchResponse:
       description: Actual host name of the server that processed the request.
     userData:
       $ref: '../../../common/schemas/IndexSettings.yml#/userData'
+    renderingContent:
+      $ref: '../../../common/schemas/IndexSettings.yml#/renderingContent'
 
 nbHits:
   type: integer


### PR DESCRIPTION
## 🧭 What and Why

`renderingContent` is sometimes returned in the `SearchResponse`, but not documented.