### PR TITLE
fix(ci): only delete generated clients on release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -213,7 +213,7 @@ jobs:
           type: js_utils
 
       - name: Remove generated clients
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' && startsWith(env.head_ref, 'chore/prepare-release-') }}
         run: |
           cd ${{ matrix.client.path }}/packages
           ls | grep -v -E "(client-common|requester-*|algoliasearch)" | xargs rm -rf


### PR DESCRIPTION
## 🧭 What and Why

#787 broke the CI because it only required to rebuild `algoliasearch` and the `search` client, we should only delete generated clients when bumping version, otherwise the required packages are not present.
