### PR TITLE
chore: prepare release 2022-07-05

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.4.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.3.0-SNAPSHOT...4.4.0-SNAPSHOT)
+
+- [5a499849](https://github.com/algolia/api-clients-automation/commit/5a499849) fix(specs): add renderingContent to search response ([#787](https://github.com/algolia/api-clients-automation/pull/787)) by [Pierre Millot](pierre.millot@algolia.com)
+- [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult ([#783](https://github.com/algolia/api-clients-automation/pull/783)) by [Pierre Millot](pierre.millot@algolia.com)
+- [a11e84da](https://github.com/algolia/api-clients-automation/commit/a11e84da) fix(specs): fix missing params and types ([#772](https://github.com/algolia/api-clients-automation/pull/772)) by [@shortcuts](https://github.com/shortcuts/)
+- [bc14a8c5](https://github.com/algolia/api-clients-automation/commit/bc14a8c5) feat(specs): Add tags to the settings and search params ([#768](https://github.com/algolia/api-clients-automation/pull/768)) by [Clément Denoix](flydesigned@gmail.com)
+- [ce95833f](https://github.com/algolia/api-clients-automation/commit/ce95833f) fix(java): rename one of methods for better dx APIC-539 ([#763](https://github.com/algolia/api-clients-automation/pull/763)) by [Pierre Millot](pierre.millot@algolia.com)
+
 ## [4.3.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.2.4-SNAPSHOT...4.3.0-SNAPSHOT)
 
 - [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult (#783)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.9.0](https://github.com/algolia/algoliasearch-client-javascript/compare/0.8.0...0.9.0)
+
+- [5a499849](https://github.com/algolia/api-clients-automation/commit/5a499849) fix(specs): add renderingContent to search response ([#787](https://github.com/algolia/api-clients-automation/pull/787)) by [Pierre Millot](pierre.millot@algolia.com)
+- [6b50ef0b](https://github.com/algolia/api-clients-automation/commit/6b50ef0b) feat(javascript): add `abtesting` client, better `init` usage ([#784](https://github.com/algolia/api-clients-automation/pull/784)) by [@shortcuts](https://github.com/shortcuts/)
+- [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult ([#783](https://github.com/algolia/api-clients-automation/pull/783)) by [Pierre Millot](pierre.millot@algolia.com)
+- [a11e84da](https://github.com/algolia/api-clients-automation/commit/a11e84da) fix(specs): fix missing params and types ([#772](https://github.com/algolia/api-clients-automation/pull/772)) by [@shortcuts](https://github.com/shortcuts/)
+- [bc14a8c5](https://github.com/algolia/api-clients-automation/commit/bc14a8c5) feat(specs): Add tags to the settings and search params ([#768](https://github.com/algolia/api-clients-automation/pull/768)) by [Clément Denoix](flydesigned@gmail.com)
+- [77c80e20](https://github.com/algolia/api-clients-automation/commit/77c80e20) fix(javascript): add class-proposal plugin for `client-common` ([#765](https://github.com/algolia/api-clients-automation/pull/765)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [0.8.0](https://github.com/algolia/algoliasearch-client-javascript/compare/0.7.2...0.8.0)
 
 - [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult (#783)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/client-common",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/requester-browser-xhr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist/"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.8.0"
+    "@experimental-api-clients-automation/client-common": "0.9.0"
   },
   "devDependencies": {
     "@types/node": "16.11.43",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@experimental-api-clients-automation/requester-node-http",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist/"
   },
   "dependencies": {
-    "@experimental-api-clients-automation/client-common": "0.8.0"
+    "@experimental-api-clients-automation/client-common": "0.9.0"
   },
   "devDependencies": {
     "@types/node": "16.11.43",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0-alpha.6](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.5...4.0.0-alpha.6)
+
+- [5a499849](https://github.com/algolia/api-clients-automation/commit/5a499849) fix(specs): add renderingContent to search response ([#787](https://github.com/algolia/api-clients-automation/pull/787)) by [Pierre Millot](pierre.millot@algolia.com)
+- [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult ([#783](https://github.com/algolia/api-clients-automation/pull/783)) by [Pierre Millot](pierre.millot@algolia.com)
+- [a11e84da](https://github.com/algolia/api-clients-automation/commit/a11e84da) fix(specs): fix missing params and types ([#772](https://github.com/algolia/api-clients-automation/pull/772)) by [@shortcuts](https://github.com/shortcuts/)
+- [bc14a8c5](https://github.com/algolia/api-clients-automation/commit/bc14a8c5) feat(specs): Add tags to the settings and search params ([#768](https://github.com/algolia/api-clients-automation/pull/768)) by [Clément Denoix](flydesigned@gmail.com)
+
 ## [4.0.0-alpha.5](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.4...4.0.0-alpha.5)
 
 - [23a72c39](https://github.com/algolia/api-clients-automation/commit/23a72c39) fix(specs): correct type for highlightResult and snippetResult (#783)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java-2",
     "gitRepoId": "algoliasearch-client-java-2",
-    "packageVersion": "4.3.0-SNAPSHOT",
+    "packageVersion": "4.4.0-SNAPSHOT",
     "modelFolder": "algoliasearch-core/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch-core/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@experimental-api-clients-automation",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "0.8.0",
+    "utilsPackageVersion": "0.9.0",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.5",
+    "packageVersion": "4.0.0-alpha.6",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-predict",
         "additionalProperties": {
-          "packageVersion": "0.8.0"
+          "packageVersion": "0.9.0"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 0.8.0 -> **`minor` _(e.g. 0.9.0)_**
- java: 4.3.0-SNAPSHOT -> **`minor` _(e.g. 4.4.0-SNAPSHOT)_**
- php: 4.0.0-alpha.5 -> **`prerelease` _(e.g. 4.0.0-alpha.6)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: release 2022-07-05 [skip ci]
- chore: prepare release 2022-07-05 (#786)
- chore: release 2022-06-30 [skip ci]
- chore: prepare release 2022-06-30 (#770)
- chore: prepare release 2022-06-29 (#767)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - fix(ci): only delete generated clients on release (#788)
- fix(deps): add back datasourceTemplate for renovate (#782)
- chore(scripts): dependencies 2022-07-04 (#773)
- docs(cts): update doc and client test doc (#766)
- fix(scripts): correctly check for release commit (#769)
</details>