### PR TITLE
fix(javascript): provide `requestOptions` to helper methods

### DIFF
--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -5,15 +5,16 @@
  * @param waitForTaskOptions - The waitForTaskOptions object.
  * @param waitForTaskOptions.indexName - The `indexName` where the operation was performed.
  * @param waitForTaskOptions.taskID - The `taskID` returned in the method response.
+ * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
 waitForTask({
   indexName,
   taskID,
   ...createRetryablePromiseOptions
-}: WaitForTaskOptions): Promise<GetTaskResponse> {
+}: WaitForTaskOptions, requestOptions?: RequestOptions): Promise<GetTaskResponse> {
   return createRetryablePromise({
     ...createRetryablePromiseOptions,
-    func: () => this.getTask({ indexName, taskID }),
+    func: () => this.getTask({ indexName, taskID }, requestOptions),
     validate: (response) => response.status === 'published',
   });
 },
@@ -26,13 +27,14 @@ waitForTask({
  * @param waitForApiKeyOptions.operation - The `operation` that was done on a `key`.
  * @param waitForApiKeyOptions.key - The `key` that has been added, deleted or updated.
  * @param waitForApiKeyOptions.apiKey - Necessary to know if an `update` operation has been processed, compare fields of the response with it.
+ * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getApikey` method and merged with the transporter requestOptions.
  */
 waitForApiKey({
   operation,
   key,
   apiKey,
   ...createRetryablePromiseOptions
-}: WaitForApiKeyOptions): Promise<ApiError | Key> {
+}: WaitForApiKeyOptions, requestOptions?: RequestOptions): Promise<ApiError | Key> {
   if (operation === 'update') {
     if (!apiKey) {
       throw new Error(
@@ -42,7 +44,7 @@ waitForApiKey({
 
     return createRetryablePromise({
       ...createRetryablePromiseOptions,
-      func: () => this.getApiKey({ key }),
+      func: () => this.getApiKey({ key }, requestOptions),
       validate: (response) => {
         for (const field of Object.keys(apiKey)) {
           if (Array.isArray(apiKey[field])) {
@@ -65,7 +67,7 @@ waitForApiKey({
 
   return createRetryablePromise({
     ...createRetryablePromiseOptions,
-    func: () => this.getApiKey({ key }).catch((error) => error),
+    func: () => this.getApiKey({ key }, requestOptions).catch((error) => error),
     validate: (error: ApiError) =>
       operation === 'add' ? error.status !== 404 : error.status === 404,
   });


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

[We've agreed on providing the `requestOptions`](https://github.com/algolia/api-clients-automation/pull/792#discussion_r914751300) to the helper methods, but JavaScript was missing it

## 🧪 Test

CI :D