### PR TITLE
chore(deps): strict regex for package.json and yarn

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,11 +54,6 @@ jobs:
           yarn eslint --ext=json .
           echo 'Use yarn fix:json to fix issues'
 
-      - name: Validate renovate.json
-        uses: rinchsan/renovate-config-validator@v0.0.11
-        with:
-          pattern: renovate.json
-
     outputs:
       RUN_SCRIPTS: ${{ steps.setup.outputs.RUN_SCRIPTS }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,9 @@ jobs:
           yarn eslint --ext=json .
           echo 'Use yarn fix:json to fix issues'
 
+      - name: Validate renovate.json
+        uses: rinchsan/renovate-config-validator@v0
+
     outputs:
       RUN_SCRIPTS: ${{ steps.setup.outputs.RUN_SCRIPTS }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Validate renovate.json
         uses: rinchsan/renovate-config-validator@v0.0.11
+        with:
+          pattern: renovate.json
 
     outputs:
       RUN_SCRIPTS: ${{ steps.setup.outputs.RUN_SCRIPTS }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
           echo 'Use yarn fix:json to fix issues'
 
       - name: Validate renovate.json
-        uses: rinchsan/renovate-config-validator@v0
+        uses: rinchsan/renovate-config-validator@v0.0.11
 
     outputs:
       RUN_SCRIPTS: ${{ steps.setup.outputs.RUN_SCRIPTS }}

--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
         "package.mustache"
       ],
       "matchStrings": [
-        "\\s\"(?<depName>.*?)\": \"(?<currentValue>.*?)\",?\\s"
+        "\\s\"(?<depName>.*?)\": \"(?<currentValue>\\d.*?)\",?\\s"
       ],
       "datasourceTemplate": "npm"
     },
@@ -75,7 +75,7 @@
       "description": "Update yarn version (won't work because we need to download the script but gives an alert at least)",
       "fileMatch": ".yarnrc.yml",
       "matchStrings": [
-        "yarn/releases/yarn-(?<currentValue>.*?)"
+        "yarn/releases/yarn-(?<currentValue>.*?)\\.cjs"
       ],
       "depNameTemplate": "yarnpkg/berry",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## 🧭 What and Why

In #532 the regex for `package.mustache` and `.yarnrc.yml` are too broad and detect things that don't have versions,
this should help renovate to find only real deps.