### PR TITLE
fix(javascript): ensure requesters work as in v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -163,9 +163,9 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: cd clients/algoliasearch-client-javascript && yarn build ${{ matrix.client }}
 
-      - name: Run tests for 'client-common'
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client == 'client-common' }}
-        run: cd clients/algoliasearch-client-javascript && yarn workspace @algolia/client-common test
+      - name: Run tests for '${{ matrix.client }}'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: cd clients/algoliasearch-client-javascript && yarn workspace @algolia/${{ matrix.client }} test
 
       - name: Store '${{ matrix.client }}' JavaScript utils package
         uses: actions/upload-artifact@v3

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -180,7 +180,7 @@ export function createTransporter({
         return stackFrame;
       };
 
-      const response = await requester.send(payload, request);
+      const response = await requester.send(payload);
 
       if (isRetryable(response)) {
         const stackFrame = pushToStackTrace(response);

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
@@ -1,9 +1,15 @@
 import type { Headers, QueryParameters } from './Transporter';
 
+/**
+ * The method of the request.
+ */
 export type Method = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
 
 export type Request = {
   method: Method;
+  /**
+   * The path of the REST API to send the request to.
+   */
   path: string;
   queryParameters: QueryParameters;
   data?: Array<Record<string, any>> | Record<string, any>;
@@ -20,18 +26,34 @@ export type Request = {
   useReadTransporter?: boolean;
 };
 
-export type EndRequest = {
-  method: Method;
+export type EndRequest = Pick<Request, 'headers' | 'method'> & {
+  /**
+   * The full URL of the REST API.
+   */
   url: string;
+  /**
+   * The connection timeout, in milliseconds.
+   */
   connectTimeout: number;
+  /**
+   * The response timeout, in milliseconds.
+   */
   responseTimeout: number;
-  headers: Headers;
   data?: string;
 };
 
 export type Response = {
+  /**
+   * The body of the response.
+   */
   content: string;
+  /**
+   * Wether the API call is timed out or not.
+   */
   isTimedOut: boolean;
+  /**
+   * The status code of the response.
+   */
   status: number;
 };
 
@@ -39,7 +61,7 @@ export type Requester = {
   /**
    * Sends the given `request` to the server.
    */
-  send: (request: EndRequest, originalRequest: Request) => Promise<Response>;
+  send: (request: EndRequest) => Promise<Response>;
 };
 
 export type EchoResponse = Omit<EndRequest, 'data'> &

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
@@ -48,11 +48,11 @@ export type Response = {
    */
   content: string;
   /**
-   * Wether the API call is timed out or not.
+   * Whether the API call is timed out or not.
    */
   isTimedOut: boolean;
   /**
-   * The status code of the response.
+   * The HTTP status code of the response.
    */
   status: number;
 };

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Transporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Transporter.ts
@@ -26,7 +26,7 @@ export type RequestOptions = Pick<Request, 'cacheable'> & {
   queryParameters?: QueryParameters;
 
   /**
-   * Custom data for the request. This data are
+   * Custom data for the request. This data is
    * going to be merged the transporter data.
    */
   data?: Array<Record<string, any>> | Record<string, any>;

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/jest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  roots: ['src/__tests__'],
+  testEnvironment: 'jsdom',
+};
+
+export default config;

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -14,15 +14,20 @@
     "index.ts"
   ],
   "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf dist/"
+    "clean": "rm -rf dist/",
+    "test": "jest"
   },
   "dependencies": {
     "@algolia/client-common": "5.0.0-alpha.0"
   },
   "devDependencies": {
+    "@types/jest": "28.1.4",
     "@types/node": "16.11.45",
-    "typescript": "4.7.4"
+    "jest": "28.1.2",
+    "jest-environment-jsdom": "28.1.2",
+    "ts-jest": "28.0.5",
+    "typescript": "4.7.4",
+    "xhr-mock": "2.5.1"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/__tests__/browser-xhr-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/__tests__/browser-xhr-requester.test.ts
@@ -1,0 +1,261 @@
+import http from 'http';
+
+import type { EndRequest, Headers } from '@algolia/client-common';
+import type { MockRequest, MockResponse } from 'xhr-mock';
+import mock from 'xhr-mock';
+
+import { createXhrRequester } from '../..';
+
+const requester = createXhrRequester();
+const BASE_URL = 'https://algolia-dns.net/foo?x-algolia-header=bar';
+
+function getStringifiedBody(
+  body: Record<string, any> = { foo: 'bar' }
+): string {
+  return JSON.stringify(body);
+}
+
+const headers: Headers = {
+  'content-type': 'text/plain',
+};
+
+const timeoutRequest: EndRequest = {
+  url: 'missing-url-here',
+  data: '',
+  headers: {},
+  method: 'GET',
+  responseTimeout: 2000,
+  connectTimeout: 1000,
+};
+
+const requestStub: EndRequest = {
+  url: BASE_URL,
+  method: 'POST',
+  headers,
+  data: getStringifiedBody(),
+  responseTimeout: 1000,
+  connectTimeout: 2000,
+};
+
+describe('status code handling', () => {
+  beforeEach(() => mock.setup());
+  afterEach(() => mock.teardown());
+
+  it('sends requests', async () => {
+    mock.post(BASE_URL, (req: MockRequest, res: MockResponse): MockResponse => {
+      expect(req.method()).toEqual('POST');
+      expect(req.header('content-type')).toEqual('text/plain');
+      expect(req.body()).toEqual(JSON.stringify({ foo: 'bar' }));
+
+      return res.status(200);
+    });
+
+    await requester.send(requestStub);
+  });
+
+  it('resolves status 200', async () => {
+    const body = getStringifiedBody();
+
+    mock.post(BASE_URL, {
+      status: 200,
+      body: requestStub.data,
+    });
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(200);
+    expect(response.content).toBe(body);
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves status 300', async () => {
+    const reason = 'Multiple Choices';
+
+    mock.post(BASE_URL, {
+      status: 300,
+      reason,
+    });
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(300);
+    expect(response.content).toBe(''); // No body returned here on xhr
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves status 400', async () => {
+    const body = getStringifiedBody({
+      message: 'Invalid Application-Id or API-Key',
+    });
+
+    mock.post(BASE_URL, {
+      status: 400,
+      body,
+    });
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(400);
+    expect(response.content).toBe(body);
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('handles the protocol', async () => {
+    const body = getStringifiedBody();
+
+    mock.post('http://localhost/', {
+      status: 200,
+      body,
+    });
+
+    const response = await requester.send({
+      ...requestStub,
+      url: 'http://localhost',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.content).toBe(body);
+    expect(response.isTimedOut).toBe(false);
+  });
+});
+
+describe('timeout handling', () => {
+  let server: http.Server;
+  // setup http server to test timeout
+  beforeAll(() => {
+    server = http.createServer(function (_req, res) {
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'access-control-allow-origin': '*',
+        'x-powered-by': 'nodejs',
+      });
+
+      res.write('{"foo":');
+
+      setTimeout(() => {
+        res.write(' "bar"');
+      }, 1000);
+
+      setTimeout(() => {
+        res.write('}');
+        res.end();
+      }, 5000);
+    });
+
+    server.listen('1111');
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('connection timeouts with the given 1 seconds connection timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...timeoutRequest,
+      connectTimeout: 1000,
+      url: 'http://www.google.com:81',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Connection timeout');
+    expect(now - before).toBeGreaterThan(999);
+    expect(now - before).toBeLessThan(1200);
+  });
+
+  it('connection timeouts with the given 2 seconds connection timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...timeoutRequest,
+      connectTimeout: 2000,
+      url: 'http://www.google.com:81',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Connection timeout');
+    expect(now - before).toBeGreaterThan(1990);
+    expect(now - before).toBeLessThan(2200);
+  });
+
+  it("socket timeouts if response don't appears before the timeout with 2 seconds timeout", async () => {
+    const before = Date.now();
+
+    const response = await requester.send({
+      ...timeoutRequest,
+      responseTimeout: 2000,
+      url: 'http://localhost:1111',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Socket timeout');
+    expect(now - before).toBeGreaterThan(1990);
+    expect(now - before).toBeLessThan(2200);
+  });
+
+  it("socket timeouts if response don't appears before the timeout with 3 seconds timeout", async () => {
+    const before = Date.now();
+
+    const response = await requester.send({
+      ...timeoutRequest,
+      responseTimeout: 3000,
+      url: 'http://localhost:1111',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Socket timeout');
+    expect(now - before).toBeGreaterThan(2999);
+    expect(now - before).toBeLessThan(3200);
+  });
+
+  it('do not timeouts if response appears before the timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...requestStub,
+      responseTimeout: 6000,
+      url: 'http://localhost:1111',
+    });
+
+    const now = Date.now();
+
+    expect(response.isTimedOut).toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.content).toBe('{"foo": "bar"}');
+    expect(now - before).toBeGreaterThan(4999);
+    expect(now - before).toBeLessThan(5200);
+  }, 10000); // This is a long-running test, default server timeout is set to 5000ms
+});
+
+describe('error handling', () => {
+  it('resolves dns not found', async () => {
+    const request: EndRequest = {
+      url: 'https://this-dont-exist.algolia.com',
+      method: 'POST',
+      headers,
+      data: getStringifiedBody(),
+      responseTimeout: 2000,
+      connectTimeout: 1000,
+    };
+
+    const response = await requester.send(request);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBe('Network request failed');
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves general network errors', async () => {
+    mock.post(BASE_URL, () =>
+      Promise.reject(new Error('This is a general error'))
+    );
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBe('Network request failed');
+    expect(response.isTimedOut).toBe(false);
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "types": ["node", "jest"],
     "outDir": "dist"
   },
   "include": ["src", "index.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/__tests__"]
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/jest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  roots: ['src/__tests__'],
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -14,13 +14,18 @@
     "index.ts"
   ],
   "scripts": {
-    "clean": "rm -rf dist/"
+    "clean": "rm -rf dist/",
+    "test": "jest"
   },
   "dependencies": {
     "@algolia/client-common": "5.0.0-alpha.0"
   },
   "devDependencies": {
+    "@types/jest": "28.1.4",
     "@types/node": "16.11.45",
+    "jest": "28.1.2",
+    "nock": "13.2.8",
+    "ts-jest": "28.0.5",
     "typescript": "4.7.4"
   },
   "engines": {

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
@@ -1,0 +1,268 @@
+import http from 'http';
+import { Readable } from 'stream';
+
+import type { EndRequest, Headers } from '@algolia/client-common';
+import nock from 'nock';
+
+import { createHttpRequester } from '../..';
+
+const requester = createHttpRequester();
+const BASE_URL = 'https://algolia-dns.net/foo?x-algolia-header=bar';
+
+function getStringifiedBody(
+  body: Record<string, any> = { foo: 'bar' }
+): string {
+  return JSON.stringify(body);
+}
+
+const headers = {
+  'content-type': 'text/plain',
+};
+
+const timeoutRequest: EndRequest = {
+  url: 'missing-url-here',
+  data: '',
+  headers: {},
+  method: 'GET',
+  responseTimeout: 5000,
+  connectTimeout: 2000,
+};
+
+const requestStub: EndRequest = {
+  url: BASE_URL,
+  method: 'POST',
+  headers,
+  data: getStringifiedBody(),
+  responseTimeout: 2000,
+  connectTimeout: 1000,
+};
+
+describe('status code handling', () => {
+  const queryHeader: Headers = { 'x-algolia-header': 'bar' };
+  const queryBaseUrl = 'https://algolia-dns.net';
+
+  it('sends requests', async () => {
+    const body = getStringifiedBody();
+
+    nock(queryBaseUrl, { reqheaders: headers })
+      .post('/foo')
+      .query(queryHeader)
+      .reply(200, body);
+
+    const response = await requester.send(requestStub);
+
+    expect(response.content).toEqual(body);
+  });
+
+  it('resolves status 200', async () => {
+    const body = getStringifiedBody();
+
+    nock(queryBaseUrl, { reqheaders: headers })
+      .post('/foo')
+      .query(queryHeader)
+      .reply(200, body);
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(200);
+    expect(response.content).toBe(body);
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves status 300', async () => {
+    const reason = 'Multiple Choices';
+
+    nock(queryBaseUrl, { reqheaders: headers })
+      .post('/foo')
+      .query(queryHeader)
+      .reply(300, reason);
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(300);
+    expect(response.content).toBe(reason);
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves status 400', async () => {
+    const body = getStringifiedBody({
+      message: 'Invalid Application-Id or API-Key',
+    });
+
+    nock(queryBaseUrl, { reqheaders: headers })
+      .post('/foo')
+      .query(queryHeader)
+      .reply(400, body);
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(400);
+    expect(response.content).toBe(body);
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('handles chunked responses inside unicode character boundaries', async () => {
+    const data = Buffer.from('äöü');
+
+    // create a test response stream that is chunked inside a unicode character
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    function* generate() {
+      yield data.slice(0, 3);
+      yield data.slice(3);
+    }
+
+    const testStream = Readable.from(generate());
+
+    nock('https://algolia-dns.net', { reqheaders: headers })
+      .post('/foo')
+      .query(queryHeader)
+      .reply(200, testStream);
+
+    const response = await requester.send(requestStub);
+
+    expect(response.content).toEqual(data.toString());
+  });
+});
+
+describe('timeout handling', () => {
+  let server: http.Server;
+  // setup http server to test timeout
+  beforeAll(() => {
+    server = http.createServer(function (_req, res) {
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'access-control-allow-origin': '*',
+        'x-powered-by': 'nodejs',
+      });
+
+      res.write('{"foo":');
+
+      setTimeout(() => {
+        res.write(' "bar"');
+      }, 1000);
+
+      setTimeout(() => {
+        res.write('}');
+        res.end();
+      }, 5000);
+    });
+
+    server.listen('1111');
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('timeouts with the given 1 seconds connection timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...timeoutRequest,
+      connectTimeout: 1000,
+      url: 'http://www.google.com:81',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Connection timeout');
+    expect(now - before).toBeGreaterThan(999);
+    expect(now - before).toBeLessThan(1200);
+  });
+
+  it('connection timeouts with the given 2 seconds connection timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...timeoutRequest,
+      connectTimeout: 2000,
+      url: 'http://www.google.com:81',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Connection timeout');
+    expect(now - before).toBeGreaterThan(1999);
+    expect(now - before).toBeLessThan(2200);
+  });
+
+  it("socket timeouts if response don't appears before the timeout with 2 seconds timeout", async () => {
+    const before = Date.now();
+
+    const response = await requester.send({
+      ...timeoutRequest,
+      responseTimeout: 2000,
+      url: 'http://localhost:1111',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Socket timeout');
+    expect(now - before).toBeGreaterThan(1999);
+    expect(now - before).toBeLessThan(2200);
+  });
+
+  it("socket timeouts if response don't appears before the timeout with 3 seconds timeout", async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...timeoutRequest,
+      responseTimeout: 3000,
+      url: 'http://localhost:1111',
+    });
+
+    const now = Date.now();
+
+    expect(response.content).toBe('Socket timeout');
+    expect(now - before).toBeGreaterThan(2999);
+    expect(now - before).toBeLessThan(3200);
+  });
+
+  it('do not timeouts if response appears before the timeout', async () => {
+    const before = Date.now();
+    const response = await requester.send({
+      ...requestStub,
+      url: 'http://localhost:1111',
+      responseTimeout: 6000,
+    });
+
+    const now = Date.now();
+
+    expect(response.isTimedOut).toBe(false);
+    expect(response.status).toBe(200);
+    expect(response.content).toBe('{"foo": "bar"}');
+    expect(now - before).toBeGreaterThan(4999);
+    expect(now - before).toBeLessThan(5200);
+  }, 10000); // This is a long-running test, default server timeout is set to 5000ms
+});
+
+describe('error handling', (): void => {
+  it('resolves dns not found', async () => {
+    const request: EndRequest = {
+      url: 'https://this-dont-exist.algolia.com',
+      method: 'POST',
+      headers: {
+        'content-type': 'text/plain',
+      },
+      data: getStringifiedBody(),
+      responseTimeout: 2000,
+      connectTimeout: 1000,
+    };
+
+    const response = await requester.send(request);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toContain('');
+    expect(response.isTimedOut).toBe(false);
+  });
+
+  it('resolves general network errors', async () => {
+    nock('https://algolia-dns.net', { reqheaders: headers })
+      .post('/foo')
+      .query({ 'x-algolia-header': 'bar' })
+      .replyWithError('This is a general error');
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBe('This is a general error');
+    expect(response.isTimedOut).toBe(false);
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "types": ["node", "jest"],
     "outDir": "dist"
   },
   "include": ["src", "index.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/__tests__"]
 }

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -131,8 +131,13 @@ __metadata:
   resolution: "@algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr"
   dependencies:
     "@algolia/client-common": 5.0.0-alpha.0
+    "@types/jest": 28.1.4
     "@types/node": 16.11.45
+    jest: 28.1.2
+    jest-environment-jsdom: 28.1.2
+    ts-jest: 28.0.5
     typescript: 4.7.4
+    xhr-mock: 2.5.1
   languageName: unknown
   linkType: soft
 
@@ -141,7 +146,11 @@ __metadata:
   resolution: "@algolia/requester-node-http@workspace:packages/requester-node-http"
   dependencies:
     "@algolia/client-common": 5.0.0-alpha.0
+    "@types/jest": 28.1.4
     "@types/node": 16.11.45
+    jest: 28.1.2
+    nock: 13.2.8
+    ts-jest: 28.0.5
     typescript: 4.7.4
   languageName: unknown
   linkType: soft
@@ -1682,7 +1691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^28.1.3":
+"@jest/core@npm:^28.1.2, @jest/core@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/core@npm:28.1.3"
   dependencies:
@@ -1724,7 +1733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^28.1.3":
+"@jest/environment@npm:^28.1.2, @jest/environment@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/environment@npm:28.1.3"
   dependencies:
@@ -1755,7 +1764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^28.1.3":
+"@jest/fake-timers@npm:^28.1.2, @jest/fake-timers@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/fake-timers@npm:28.1.3"
   dependencies:
@@ -3373,6 +3382,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:28.1.4":
+  version: 28.1.4
+  resolution: "@types/jest@npm:28.1.4"
+  dependencies:
+    jest-matcher-utils: ^28.0.0
+    pretty-format: ^28.0.0
+  checksum: 97e22c600397bb4f30e39b595f8285ae92e4eb29a1ef6d1689749e4a4da683d88ecfe717b64492f6adc4c17c1c989520c3546f938c84a7d435c6ac3acf1a2bdc
+  languageName: node
+  linkType: hard
+
 "@types/jest@npm:28.1.6":
   version: 28.1.6
   resolution: "@types/jest@npm:28.1.6"
@@ -4893,6 +4912,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-walk@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "dom-walk@npm:0.1.2"
+  checksum: 19eb0ce9c6de39d5e231530685248545d9cd2bd97b2cb3486e0bfc0f2a393a9addddfd5557463a932b52fdfcf68ad2a619020cd2c74a5fe46fbecaa8e80872f3
+  languageName: node
+  linkType: hard
+
 "domexception@npm:^4.0.0":
   version: 4.0.0
   resolution: "domexception@npm:4.0.0"
@@ -5479,6 +5505,16 @@ __metadata:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 50bcdea19d8e79d8de5f460b1939ffc2b3299eac28deb502093fdca22a78efebc03e66bf54f0abc3d3d07d8134d19a32850288b7440d77e072aa55f9d33b18c5
+  languageName: node
+  linkType: hard
+
+"global@npm:^4.3.0":
+  version: 4.4.0
+  resolution: "global@npm:4.4.0"
+  dependencies:
+    min-document: ^2.19.0
+    process: ^0.11.10
+  checksum: 9c057557c8f5a5bcfbeb9378ba4fe2255d04679452be504608dd5f13b54edf79f7be1db1031ea06a4ec6edd3b9f5f17d2d172fb47e6c69dae57fd84b7e72b77f
   languageName: node
   linkType: hard
 
@@ -6137,7 +6173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^28.1.3":
+"jest-cli@npm:^28.1.2, jest-cli@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-cli@npm:28.1.3"
   dependencies:
@@ -6245,6 +6281,22 @@ __metadata:
     jest-util: ^28.1.3
     pretty-format: ^28.1.3
   checksum: 5c5b8ccb1484e58b027bea682cfa020a45e5bf5379cc7c23bdec972576c1dc3c3bf03df2b78416cefc1a58859dd33b7cf5fff54c370bc3c0f14a3e509eb87282
+  languageName: node
+  linkType: hard
+
+"jest-environment-jsdom@npm:28.1.2":
+  version: 28.1.2
+  resolution: "jest-environment-jsdom@npm:28.1.2"
+  dependencies:
+    "@jest/environment": ^28.1.2
+    "@jest/fake-timers": ^28.1.2
+    "@jest/types": ^28.1.1
+    "@types/jsdom": ^16.2.4
+    "@types/node": "*"
+    jest-mock: ^28.1.1
+    jest-util: ^28.1.1
+    jsdom: ^19.0.0
+  checksum: 73388b5cde4ce4b49cdb36746211b46c416a75b070837faefd4c907fe5095b2a7b197f753e10ee110c4b8f43571ffc277b65b3ca48f01ec0fbc74525274a19fc
   languageName: node
   linkType: hard
 
@@ -6359,7 +6411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^28.1.3":
+"jest-mock@npm:^28.1.1, jest-mock@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-mock@npm:28.1.3"
   dependencies:
@@ -6519,7 +6571,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^28.1.3":
+"jest-util@npm:^28.1.1, jest-util@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-util@npm:28.1.3"
   dependencies:
@@ -6582,6 +6634,25 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: e921c9a1b8f0909da9ea07dbf3592f95b653aef3a8bb0cbcd20fc7f9a795a1304adecac31eecb308992c167e8d7e75c522061fec38a5928ace0f9571c90169ca
+  languageName: node
+  linkType: hard
+
+"jest@npm:28.1.2":
+  version: 28.1.2
+  resolution: "jest@npm:28.1.2"
+  dependencies:
+    "@jest/core": ^28.1.2
+    "@jest/types": ^28.1.1
+    import-local: ^3.0.2
+    jest-cli: ^28.1.2
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 8ad37088c42cd5a6decb54c61dfe6a45131a50dfe4c805aef1228cae4ca91b0fc7dfe2991ea771d88118151f5f1697d113b6f45c9b0d88b2ece2aac229e77150
   languageName: node
   linkType: hard
 
@@ -6907,7 +6978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.7.0":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -7122,6 +7193,15 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"min-document@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "min-document@npm:2.19.0"
+  dependencies:
+    dom-walk: ^0.1.0
+  checksum: da6437562ea2228041542a2384528e74e22d1daa1a4ec439c165abf0b9d8a63e17e3b8a6dc6e0c731845e85301198730426932a0e813d23f932ca668340c9623
   languageName: node
   linkType: hard
 
@@ -7342,6 +7422,18 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
+  languageName: node
+  linkType: hard
+
+"nock@npm:13.2.8":
+  version: 13.2.8
+  resolution: "nock@npm:13.2.8"
+  dependencies:
+    debug: ^4.1.0
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.21
+    propagate: ^2.0.0
+  checksum: 656f696d3c1b6267b8ec366f5cc464306d2aa308ce9b41414e9992eea5b0b71e475a582945b936e16263961c3a0f9e1c388a3a36da53c1e300398a7826550f96
   languageName: node
   linkType: hard
 
@@ -8088,6 +8180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
+  languageName: node
+  linkType: hard
+
 "promise-all-reject-late@npm:^1.0.0":
   version: 1.0.1
   resolution: "promise-all-reject-late@npm:1.0.1"
@@ -8138,6 +8237,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"propagate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "propagate@npm:2.0.1"
+  checksum: c4febaee2be0979e82fb6b3727878fd122a98d64a7fa3c9d09b0576751b88514a9e9275b1b92e76b364d488f508e223bd7e1dcdc616be4cdda876072fbc2a96c
+  languageName: node
+  linkType: hard
+
 "proto-list@npm:~1.2.1":
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
@@ -8159,6 +8265,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.1":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
@@ -8170,6 +8283,13 @@ __metadata:
   version: 1.5.1
   resolution: "q@npm:1.5.1"
   checksum: 147baa93c805bc1200ed698bdf9c72e9e42c05f96d007e33a558b5fdfd63e5ea130e99313f28efc1783e90e6bdb4e48b67a36fcc026b7b09202437ae88a1fb12
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -9275,6 +9395,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-jest@npm:28.0.5":
+  version: 28.0.5
+  resolution: "ts-jest@npm:28.0.5"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^28.0.0
+    json5: ^2.2.1
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    babel-jest: ^28.0.0
+    jest: ^28.0.0
+    typescript: ">=4.3"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 53e05db5b7e1e4f4137c47594f902f5caf585ebc73dda67c4552c1ed784d4fde532c5693a61d877d9462290c7965233c2124050b0f00fd4c85cde9bb1a51c974
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:28.0.7":
   version: 28.0.7
   resolution: "ts-jest@npm:28.0.7"
@@ -9544,6 +9694,16 @@ __metadata:
   bin:
     browserslist-lint: cli.js
   checksum: 7c7da28d0fc733b17e01c8fa9385ab909eadce64b8ea644e9603867dc368c2e2a6611af8247e72612b23f9e7cb87ac7c7585a05ff94e1759e9d646cbe9bf49a7
+  languageName: node
+  linkType: hard
+
+"url@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "url@npm:0.11.0"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
   languageName: node
   linkType: hard
 
@@ -9873,6 +10033,16 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 6ceed1ca1cb800ef60c7fc8346c7d5d73d73be754228eb958765abf5d714519338efa20ffe674167039486eb3a813aae5a497f8d319e16b4d96216a31df5bd95
+  languageName: node
+  linkType: hard
+
+"xhr-mock@npm:2.5.1":
+  version: 2.5.1
+  resolution: "xhr-mock@npm:2.5.1"
+  dependencies:
+    global: ^4.3.0
+    url: ^0.11.0
+  checksum: 99ca4798a2c52d4a81165ff8b9ddbf8215b1480ed241a3902f314e9dd9a396386c79fd79f23537f89448ab1b930769852df53e1ec25476363fb46390c39afa96
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-588

### Changes included:

The goal of this PR is to import requester related tests implemented in v4 to ensure we did not broke it when refactoring.

Changes in this PR:
- Import requester tests from v4, they are 1:1 the same, except some syntax changes
  - I've kept the server logic in the test files, but it will be moved at the monorepo level later to be able to do similar tests on the CTS
  - Some of those tests should also disappear once we have the e2e CTS in place, but can be done in parallel
- Fix wrong requester.send signature that was made compliant for the `echoRequester`
- Add some type definition + re-use types

## Next

Ensure body is correct in POST and DELETE methods
  - Done in https://github.com/algolia/api-clients-automation/pull/849

## 🧪 Test

CI :D 