### PR TITLE
chore(deps): precise version for yarn and fix java formatter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,8 +46,10 @@
         "package.mustache"
       ],
       "matchStrings": [
-        "\\s\"(?<depName>.*?)\": \"(?<currentValue>\\d.*?)\",?\\s"
+        "\"devDependencies\":\\s*{[^}]*}",
+        "\\s\"(?<depName>.*?)\": \"(?<currentValue>.*?)\",?\\s"
       ],
+      "matchStringsStrategy": "recursive",
       "datasourceTemplate": "npm"
     },
     {
@@ -61,7 +63,8 @@
         "google-java-format/releases/download/v(.*?)/google-java-format-(?<currentValue>.*?)-all-deps"
       ],
       "depNameTemplate": "google/google-java-format",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersion": "^v(?<version>.*)$"
     },
     {
       "description": "Update java packages in mustache files",


### PR DESCRIPTION
## 🧭 What and Why

Using the recursive regex matcher we can make sure that only version inside `devDependencies` are updated.
Also remove the `v` from java formatter version.