### PR TITLE
fix(clients): make POST body related to the endpoint, assert body in tests

### DIFF
--- a/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/ApiClient.java
+++ b/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/ApiClient.java
@@ -239,7 +239,11 @@ public abstract class ApiClient {
 
     if (obj != null) {
       try {
-        content = json.writeValueAsString(obj);
+        if (obj.getClass().getName().equals("java.lang.Object")) {
+          content = "{}";
+        } else {
+          content = json.writeValueAsString(obj);
+        }
       } catch (JsonProcessingException e) {
         throw new AlgoliaRuntimeException(e);
       }

--- a/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/ApiClient.java
+++ b/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/ApiClient.java
@@ -244,7 +244,8 @@ public abstract class ApiClient {
         throw new AlgoliaRuntimeException(e);
       }
     } else {
-      content = null;
+      // We can't send a null body with okhttp, so we default it to an empty string
+      content = "";
     }
 
     return RequestBody.create(content, MediaType.parse(this.contentType));
@@ -343,16 +344,10 @@ public abstract class ApiClient {
     processHeaderParams(headerParams, hasRequestOptions ? requestOptions.getExtraHeaders() : null, reqBuilder);
 
     RequestBody reqBody;
-    if (!HttpMethod.permitsRequestBody(method)) {
+    // We rely on `permitsRequestBody` to tell us if we should provide a body
+    // but also set it for DELETE methods
+    if (!HttpMethod.permitsRequestBody(method) || (method.equals("DELETE") && body == null)) {
       reqBody = null;
-    } else if (body == null) {
-      if ("DELETE".equals(method)) {
-        // allow calling DELETE without sending a request body
-        reqBody = null;
-      } else {
-        // use an empty request body (for POST, PUT and PATCH)
-        reqBody = RequestBody.create("", MediaType.parse(this.contentType));
-      }
     } else {
       reqBody = serialize(body);
     }

--- a/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/utils/JSONBuilder.java
+++ b/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/utils/JSONBuilder.java
@@ -23,6 +23,9 @@ public class JSONBuilder {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+
+    // Allow defaulting a POST body property to an empty Object instance
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     return mapper;
   }
 }

--- a/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/utils/JSONBuilder.java
+++ b/clients/algoliasearch-client-java-2/algoliasearch-core/src/main/java/com/algolia/utils/JSONBuilder.java
@@ -23,9 +23,6 @@ public class JSONBuilder {
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-
-    // Allow defaulting a POST body property to an empty Object instance
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     return mapper;
   }
 }

--- a/clients/algoliasearch-client-javascript/bundlesize.config.json
+++ b/clients/algoliasearch-client-javascript/bundlesize.config.json
@@ -2,11 +2,11 @@
   "files": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "8.35KB"
+      "maxSize": "8.30KB"
     },
     {
       "path": "packages/algoliasearch/dist/lite/lite.umd.js",
-      "maxSize": "3.90KB"
+      "maxSize": "3.85KB"
     },
     {
       "path": "packages/client-abtesting/dist/client-abtesting.umd.js",
@@ -18,15 +18,15 @@
     },
     {
       "path": "packages/client-insights/dist/client-insights.umd.js",
-      "maxSize": "3.85KB"
+      "maxSize": "3.80KB"
     },
     {
       "path": "packages/client-personalization/dist/client-personalization.umd.js",
-      "maxSize": "4.00KB"
+      "maxSize": "3.95KB"
     },
     {
       "path": "packages/client-query-suggestions/dist/client-query-suggestions.umd.js",
-      "maxSize": "4.05KB"
+      "maxSize": "4.00KB"
     },
     {
       "path": "packages/client-search/dist/client-search.umd.js",
@@ -34,15 +34,15 @@
     },
     {
       "path": "packages/client-sources/dist/client-sources.umd.js",
-      "maxSize": "3.85KB"
+      "maxSize": "3.80KB"
     },
     {
       "path": "packages/predict/dist/predict.umd.js",
-      "maxSize": "3.90KB"
+      "maxSize": "3.85KB"
     },
     {
       "path": "packages/recommend/dist/recommend.umd.js",
-      "maxSize": "3.85KB"
+      "maxSize": "3.80KB"
     }
   ]
 }

--- a/clients/algoliasearch-client-javascript/bundlesize.config.json
+++ b/clients/algoliasearch-client-javascript/bundlesize.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "packages/client-sources/dist/client-sources.umd.js",
-      "maxSize": "3.80KB"
+      "maxSize": "3.85KB"
     },
     {
       "path": "packages/predict/dist/predict.umd.js",
@@ -42,7 +42,7 @@
     },
     {
       "path": "packages/recommend/dist/recommend.umd.js",
-      "maxSize": "3.80KB"
+      "maxSize": "3.85KB"
     }
   ]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -85,17 +85,20 @@ export function createTransporter({
 
   async function retryableRequest<TResponse>(
     request: Request,
-    requestOptions: RequestOptions
+    requestOptions: RequestOptions,
+    isRead = true
   ): Promise<TResponse> {
     const stackTrace: StackFrame[] = [];
-    const isRead = request.useReadTransporter || request.method === 'GET';
 
     /**
      * First we prepare the payload that do not depend from hosts.
      */
     const data = serializeData(request, requestOptions);
-    const headers = serializeHeaders(baseHeaders, requestOptions);
-    const method = request.method;
+    const headers = serializeHeaders(
+      baseHeaders,
+      request.headers,
+      requestOptions.headers
+    );
 
     // On `GET`, the data is proxied to query parameters.
     const dataQueryParameters: QueryParameters =
@@ -109,6 +112,7 @@ export function createTransporter({
     const queryParameters: QueryParameters = {
       'x-algolia-agent': algoliaAgent.value,
       ...baseQueryParameters,
+      ...request.queryParameters,
       ...dataQueryParameters,
     };
 
@@ -152,7 +156,7 @@ export function createTransporter({
       const payload: EndRequest = {
         data,
         headers,
-        method,
+        method: request.method,
         url: serializeUrl(host, request.path, queryParameters),
         connectTimeout: getTimeout(timeoutsCount, timeouts.connect),
         responseTimeout: getTimeout(timeoutsCount, responseTimeout),
@@ -236,41 +240,23 @@ export function createTransporter({
   }
 
   function createRequest<TResponse>(
-    baseRequest: Request,
-    baseRequestOptions: RequestOptions = {}
+    request: Request,
+    requestOptions: RequestOptions = {}
   ): Promise<TResponse> {
-    const mergedData: Request['data'] = Array.isArray(baseRequest.data)
-      ? baseRequest.data
-      : {
-          ...baseRequest.data,
-          ...baseRequestOptions.data,
-        };
-    const request: Request = {
-      ...baseRequest,
-      data: mergedData,
-    };
-    const requestOptions: RequestOptions = {
-      cacheable: baseRequestOptions.cacheable,
-      timeout: baseRequestOptions.timeout,
-      queryParameters: {
-        ...baseRequest.queryParameters,
-        ...baseRequestOptions.queryParameters,
-      },
-      headers: {
-        Accept: 'application/json',
-        ...baseRequest.headers,
-        ...baseRequestOptions.headers,
-      },
-    };
-
-    const isRead = request.useReadTransporter || request.method === 'GET';
+    /**
+     * A read request is either a `GET` request, or a request that we make
+     * via the `read` transporter (e.g. `search`).
+     */
+    const isRead = Boolean(
+      request.useReadTransporter || request.method === 'GET'
+    );
 
     if (!isRead) {
       /**
        * On write requests, no cache mechanisms are applied, and we
        * proxy the request immediately to the requester.
        */
-      return retryableRequest<TResponse>(request, requestOptions);
+      return retryableRequest<TResponse>(request, requestOptions, isRead);
     }
 
     const createRetryableRequest = (): Promise<TResponse> => {
@@ -306,8 +292,8 @@ export function createTransporter({
       request,
       requestOptions,
       transporter: {
-        queryParameters: requestOptions.queryParameters,
-        headers: requestOptions.headers,
+        queryParameters: baseQueryParameters,
+        headers: baseHeaders,
       },
     };
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -247,10 +247,7 @@ export function createTransporter({
      * A read request is either a `GET` request, or a request that we make
      * via the `read` transporter (e.g. `search`).
      */
-    const isRead = Boolean(
-      request.useReadTransporter || request.method === 'GET'
-    );
-
+    const isRead = request.useReadTransporter || request.method === 'GET';
     if (!isRead) {
       /**
        * On write requests, no cache mechanisms are applied, and we
@@ -273,7 +270,7 @@ export function createTransporter({
      * request is "cacheable" - should be cached. Note that, once again,
      * the user can force this option.
      */
-    const cacheable = Boolean(requestOptions.cacheable || request.cacheable);
+    const cacheable = requestOptions.cacheable || request.cacheable;
 
     /**
      * If is not "cacheable", we immediately trigger the retryable request, no

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
@@ -78,11 +78,14 @@ export function serializeData(
 
 export function serializeHeaders(
   baseHeaders: Headers,
-  requestOptions: RequestOptions
+  requestHeaders: Headers,
+  requestOptionsHeaders?: Headers
 ): Headers {
   const headers: Headers = {
+    Accept: 'application/json',
     ...baseHeaders,
-    ...requestOptions.headers,
+    ...requestHeaders,
+    ...requestOptionsHeaders,
   };
   const serializedHeaders: Headers = {};
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/Requester.ts
@@ -42,11 +42,9 @@ export type Requester = {
   send: (request: EndRequest, originalRequest: Request) => Promise<Response>;
 };
 
-export type EchoResponse = Request & {
-  connectTimeout: number;
-  host: string;
-  headers: Headers;
-  responseTimeout: number;
-  algoliaAgent: string;
-  searchParams?: Record<string, string>;
-};
+export type EchoResponse = Omit<EndRequest, 'data'> &
+  Pick<Request, 'data' | 'path'> & {
+    host: string;
+    algoliaAgent: string;
+    searchParams?: Record<string, string>;
+  };

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/echoRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/echoRequester.ts
@@ -1,6 +1,6 @@
 import { createEchoRequester } from '@algolia/client-common';
-import type { EchoRequester } from '@algolia/client-common';
+import type { Requester } from '@algolia/client-common';
 
-export function echoRequester(status: number = 200): EchoRequester {
+export function echoRequester(status: number = 200): Requester {
   return createEchoRequester({ getURL: (url: string) => new URL(url), status });
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/echoRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/echoRequester.ts
@@ -1,8 +1,8 @@
 import { URL } from 'url';
 
 import { createEchoRequester } from '@algolia/client-common';
-import type { EchoRequester } from '@algolia/client-common';
+import type { Requester } from '@algolia/client-common';
 
-export function echoRequester(status: number = 200): EchoRequester {
+export function echoRequester(status: number = 200): Requester {
   return createEchoRequester({ getURL: (url: string) => new URL(url), status });
 }

--- a/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
+++ b/clients/algoliasearch-client-php/lib/RequestOptions/RequestOptionsFactory.php
@@ -50,7 +50,8 @@ final class RequestOptionsFactory
             'headers' => [
                 'x-algolia-application-id' => $this->config->getAppId(),
                 'x-algolia-api-key' => $this->config->getAlgoliaApiKey(),
-                'User-Agent' => $this->config->getAlgoliaAgent() !== null
+                'User-Agent' =>
+                    $this->config->getAlgoliaAgent() !== null
                         ? $this->config->getAlgoliaAgent()
                         : AlgoliaAgent::get($this->config->getClientName()),
                 'Content-Type' => 'application/json',

--- a/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapper.php
+++ b/clients/algoliasearch-client-php/lib/RetryStrategy/ApiWrapper.php
@@ -79,15 +79,10 @@ final class ApiWrapper implements ApiWrapperInterface
          */
         $isRead = $useReadTransporter || 'GET' === mb_strtoupper($method);
 
-        if ($isRead) {
+        if ($isRead || 'DELETE' === mb_strtoupper($method)) {
             $requestOptions = $this->requestOptionsFactory->createBodyLess(
                 $requestOptions
             );
-        } elseif ('DELETE' === mb_strtoupper($method)) {
-            $requestOptions = $this->requestOptionsFactory->createBodyLess(
-                $requestOptions
-            );
-            $data = [];
         } else {
             $requestOptions = $this->requestOptionsFactory->create(
                 $requestOptions
@@ -139,7 +134,9 @@ final class ApiWrapper implements ApiWrapperInterface
             ->withQuery($requestOptions->getBuiltQueryParameters())
             ->withScheme('https');
 
-        $body = array_merge($data, $requestOptions->getBody());
+        $body = isset($data)
+            ? array_merge($data, $requestOptions->getBody())
+            : $data;
 
         $logParams = [
             'body' => $body,
@@ -277,10 +274,9 @@ final class ApiWrapper implements ApiWrapperInterface
         $protocolVersion = '1.1'
     ) {
         if (is_array($body)) {
-            // Send an empty body instead of "[]" in case there are
-            // no content/params to send
+            // Send an empty valid JSON object
             if (empty($body)) {
-                $body = '';
+                $body = '{}';
             } else {
                 $body = \json_encode($body, $this->jsonOptions);
                 if (JSON_ERROR_NONE !== json_last_error()) {

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -60,6 +60,22 @@ public class TestsRequest extends TestsGenerator {
         test.put("method", operationId);
         test.put("testName", req.testName == null ? operationId : req.testName);
         test.put("testIndex", i);
+
+        CodegenOperation ope = entry.getValue();
+
+        // We check on the spec if body parameters should be present in the CTS
+        // If so, we change the `null` default to an empty object, so we know if
+        // tests are properly written
+        if (ope.bodyParams.size() != 0 && req.request.body == null) {
+          req.request.body = "{}";
+        }
+
+        // In a case of a `GET` or `DELETE` request, we want to assert if the body
+        // is correctly parsed (absent from the payload)
+        if (req.request.method.equals("GET") || req.request.method.equals("DELETE")) {
+          test.put("assertNullBody", true);
+        }
+
         test.put("request", req.request);
         test.put("hasParameters", req.parameters.size() != 0);
 
@@ -80,7 +96,6 @@ public class TestsRequest extends TestsGenerator {
           test.put("requestOptions", requestOptions);
         }
 
-        CodegenOperation ope = entry.getValue();
         paramsType.enhanceParameters(req.parameters, test, ope);
         tests.add(test);
       }

--- a/playground/javascript/node/search.ts
+++ b/playground/javascript/node/search.ts
@@ -1,6 +1,7 @@
 import { searchClient } from '@algolia/client-search';
-import { ApiError } from '@algolia/client-common';
+import { ApiError, EchoResponse } from '@algolia/client-common';
 import dotenv from 'dotenv';
+import { echoRequester } from '@algolia/requester-node-http';
 
 dotenv.config({ path: '../../.env' });
 
@@ -11,21 +12,15 @@ const searchIndex = process.env.SEARCH_INDEX || 'test_index';
 const searchQuery = process.env.SEARCH_QUERY || 'test_query';
 
 // Init client with appId and apiKey
-const client = searchClient(appId, apiKey);
+const client = searchClient(appId, apiKey, { requester: echoRequester() });
 
 client.addAlgoliaAgent('Node playground', '0.0.1');
 
 async function testSearch() {
   try {
-    const res = await client.search({
-      requests: [
-        {
-          indexName: searchIndex,
-          query: searchQuery,
-          hitsPerPage: 50,
-        },
-      ],
-    });
+    const res = (await client.post({
+      path: '/test/minimal',
+    })) as unknown as EchoResponse;
 
     console.log(`[OK]`, res);
   } catch (e: any) {

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -204,7 +204,7 @@ public class {{classname}} extends ApiClient {
     }
     {{/required}}{{/allParams}}
 
-    Object bodyObj = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+    Object bodyObj = {{#bodyParam}}{{paramName}}{{^required}} != null ? {{paramName}} : new Object(){{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
 
     // create path and map variables
     String requestPath = "{{{path}}}"{{#vendorExtensions}}{{#pathParams}}.replaceAll(

--- a/templates/java/tests/requests/requests.mustache
+++ b/templates/java/tests/requests/requests.mustache
@@ -1,6 +1,7 @@
 package com.algolia.methods.requests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -66,11 +67,18 @@ class {{client}}RequestsTests {
 
         assertEquals(req.path, "{{{request.path}}}");
         assertEquals(req.method, "{{{request.method}}}");
-
         {{#request.body}}
         assertDoesNotThrow(() -> {
             JSONAssert.assertEquals("{{#lambda.escapeQuotes}}{{{request.body}}}{{/lambda.escapeQuotes}}", req.body, JSONCompareMode.STRICT);
         });
+        {{/request.body}}
+        {{^request.body}}
+          {{#assertNullBody}}
+            assertNull(req.body);
+          {{/assertNullBody}}
+          {{^assertNullBody}}
+            assertEquals(req.body, "");
+          {{/assertNullBody}}
         {{/request.body}}
 
         {{#request.queryParameters}}

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -90,7 +90,7 @@ export function create{{capitalizedApiName}}({
       ){{/pathParams}};
       {{/vendorExtensions}}
       const headers: Headers = {};
-      const queryParameters: QueryParameters = {{#vendorExtensions.x-is-custom-request}}parameters || {{/vendorExtensions.x-is-custom-request}}{};
+      const queryParameters: QueryParameters = {{#vendorExtensions.x-is-custom-request}}parameters ? parameters : {{/vendorExtensions.x-is-custom-request}}{};
 
       {{^vendorExtensions.x-is-custom-request}}{{#queryParams}}
       if ({{paramName}} !== undefined) {
@@ -111,7 +111,7 @@ export function create{{capitalizedApiName}}({
         queryParameters,
         headers,
         {{#bodyParam}}
-        data: {{paramName}},
+        data: {{paramName}}{{^required}}? {{paramName}} : {}{{/required}},
         {{/bodyParam}}
         {{#vendorExtensions}}
           {{#x-use-read-transporter}}

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -181,7 +181,7 @@ use {{invokerPackage}}\Support\Helpers;
         {{#allParams}}
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
-        if (${{paramName}} === null) {
+        if (!isset(${{paramName}})) {
             throw new \InvalidArgumentException(
                 'Parameter `{{paramName}}` is required when calling `{{operationId}}`.'
             );
@@ -230,7 +230,7 @@ use {{invokerPackage}}\Support\Helpers;
         $resourcePath = '{{{path}}}';
         $queryParameters = [];
         $headers = [];
-        $httpBody = [];
+        $httpBody = {{#bodyParam}}{{#required}}${{paramName}}{{/required}}{{^required}} isset(${{paramName}}) ? ${{paramName}} : []{{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#vendorExtensions}}{{#queryParams}}
 
         {{#isExplode}}
@@ -268,11 +268,6 @@ use {{invokerPackage}}\Support\Helpers;
         }
         {{/pathParams}}{{/vendorExtensions}}
 
-        {{#bodyParams}}
-        if (isset(${{paramName}})) { 
-            $httpBody = ${{paramName}};
-        } 
-        {{/bodyParams}}
         {{#headerParams}}
             $headers['{{baseName}}'] = ${{paramName}};
         {{/headerParams}}

--- a/tests/output/java/src/test/java/com/algolia/EchoInterceptor.java
+++ b/tests/output/java/src/test/java/com/algolia/EchoInterceptor.java
@@ -66,7 +66,7 @@ public class EchoInterceptor {
       final Request copy = request.newBuilder().build();
       final Buffer buffer = new Buffer();
       if (copy.body() == null) {
-        return "";
+        return null;
       }
       copy.body().writeTo(buffer);
       return buffer.readUtf8();

--- a/tests/output/javascript/yarn.lock
+++ b/tests/output/javascript/yarn.lock
@@ -35,12 +35,6 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@algolia/client-predict@link:../../../clients/algoliasearch-client-javascript/packages/client-predict::locator=javascript-tests%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@algolia/client-predict@link:../../../clients/algoliasearch-client-javascript/packages/client-predict::locator=javascript-tests%40workspace%3A."
-  languageName: node
-  linkType: soft
-
 "@algolia/client-query-suggestions@link:../../../clients/algoliasearch-client-javascript/packages/client-query-suggestions::locator=javascript-tests%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@algolia/client-query-suggestions@link:../../../clients/algoliasearch-client-javascript/packages/client-query-suggestions::locator=javascript-tests%40workspace%3A."
@@ -56,6 +50,12 @@ __metadata:
 "@algolia/client-sources@link:../../../clients/algoliasearch-client-javascript/packages/client-sources::locator=javascript-tests%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@algolia/client-sources@link:../../../clients/algoliasearch-client-javascript/packages/client-sources::locator=javascript-tests%40workspace%3A."
+  languageName: node
+  linkType: soft
+
+"@algolia/predict@link:../../../clients/algoliasearch-client-javascript/packages/predict::locator=javascript-tests%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@algolia/predict@link:../../../clients/algoliasearch-client-javascript/packages/predict::locator=javascript-tests%40workspace%3A."
   languageName: node
   linkType: soft
 
@@ -2120,10 +2120,10 @@ __metadata:
     "@algolia/client-common": "link:../../../clients/algoliasearch-client-javascript/packages/client-common"
     "@algolia/client-insights": "link:../../../clients/algoliasearch-client-javascript/packages/client-insights"
     "@algolia/client-personalization": "link:../../../clients/algoliasearch-client-javascript/packages/client-personalization"
-    "@algolia/client-predict": "link:../../../clients/algoliasearch-client-javascript/packages/client-predict"
     "@algolia/client-query-suggestions": "link:../../../clients/algoliasearch-client-javascript/packages/client-query-suggestions"
     "@algolia/client-search": "link:../../../clients/algoliasearch-client-javascript/packages/client-search"
     "@algolia/client-sources": "link:../../../clients/algoliasearch-client-javascript/packages/client-sources"
+    "@algolia/predict": "link:../../../clients/algoliasearch-client-javascript/packages/predict"
     "@algolia/recommend": "link:../../../clients/algoliasearch-client-javascript/packages/recommend"
     "@algolia/requester-node-http": "link:../../../clients/algoliasearch-client-javascript/packages/requester-node-http"
     "@types/jest": 28.1.1

--- a/website/docs/contributing/testing/common-test-suite.md
+++ b/website/docs/contributing/testing/common-test-suite.md
@@ -106,6 +106,7 @@ When writing your template, here is a list of variables accessible from `mustach
           "testName": "the descriptive name test (default to `method`)",
           "testIndex": "the index of the test to avoid duplicate function name",
           "hasParameters": "true if the method has parameters, useful for `GET` requests",
+          "assertNullBody": "true if the method does not have a body, useful to assert if `GET` and `DELETE` requests are correctly parsed",
           "parameters": {
             // Object of all parameters with their name, to be used for languages that require the parameter name
             "parameterName": "value"
@@ -165,7 +166,7 @@ When writing your template, here is a list of variables accessible from `mustach
               "parametersWithDataType": [],
               // map of enhance parameters
               "parametersWithDataTypeMap": {}
-            },
+            }
           },
           "request": {
             "path": "the expected path of the request",
@@ -190,25 +191,27 @@ When writing your template, here is a list of variables accessible from `mustach
 ```
 
 As well as lambdas to transform strings:
- - `escapeQuotes` - Escapes double quotes characters, replaces `"` with `\"`.
- - `escapeSlash` - Escapes backward slash characters, replaces `\` with `\\`.
- - `lowercase` - Converts all of the characters in this fragment to lower case using the rules of the ROOT locale.
- - `uppercase` - Converts all of the characters in this fragment to upper case using the rules of the ROOT locale.
- - `titlecase` - Converts text in a fragment to title case. For example once upon a time to Once Upon A Time.
- - `camelcase` - Converts text in a fragment to camelCase. For example Input-text to inputText.
- - `indented` - Prepends 4 spaces indention from second line of a fragment on. First line will be indented by Mustache.
- - `indented_8` - Prepends 8 spaces indention from second line of a fragment on. First line will be indented by Mustache.
- - `indented_12` - Prepends 12 spaces indention from second line of a fragment on. First line will be indented by Mustache.
- - `indented_16` - Prepends 16 spaces indention from second line of a fragment on. First line will be indented by Mustache.
+
+- `escapeQuotes` - Escapes double quotes characters, replaces `"` with `\"`.
+- `escapeSlash` - Escapes backward slash characters, replaces `\` with `\\`.
+- `lowercase` - Converts all of the characters in this fragment to lower case using the rules of the ROOT locale.
+- `uppercase` - Converts all of the characters in this fragment to upper case using the rules of the ROOT locale.
+- `titlecase` - Converts text in a fragment to title case. For example once upon a time to Once Upon A Time.
+- `camelcase` - Converts text in a fragment to camelCase. For example Input-text to inputText.
+- `indented` - Prepends 4 spaces indention from second line of a fragment on. First line will be indented by Mustache.
+- `indented_8` - Prepends 8 spaces indention from second line of a fragment on. First line will be indented by Mustache.
+- `indented_12` - Prepends 12 spaces indention from second line of a fragment on. First line will be indented by Mustache.
+- `indented_16` - Prepends 16 spaces indention from second line of a fragment on. First line will be indented by Mustache.
 
 If specific values are needed for a specific languages, or custom generated files, they can be added using a custom CTS manager:
- - [javascript](https://github.com/algolia/api-clients-automation/blob/main/generators/src/main/java/com/algolia/codegen/cts/manager/JavaScriptCTSManager.java)
-   - `npmNamespace`: the npm namespace
-   - `utilsPackageVersion`: the utils version to import
-   - `import`: the name of the package or library to import
- - [java](https://github.com/algolia/api-clients-automation/blob/main/generators/src/main/java/com/algolia/codegen/cts/manager/JavaCTSManager.java)
-   - `packageVersion`: the version of the Java client
-   - `import`: the name of the client package to import from
+
+- [javascript](https://github.com/algolia/api-clients-automation/blob/main/generators/src/main/java/com/algolia/codegen/cts/manager/JavaScriptCTSManager.java)
+  - `npmNamespace`: the npm namespace
+  - `utilsPackageVersion`: the utils version to import
+  - `import`: the name of the package or library to import
+- [java](https://github.com/algolia/api-clients-automation/blob/main/generators/src/main/java/com/algolia/codegen/cts/manager/JavaCTSManager.java)
+  - `packageVersion`: the version of the Java client
+  - `import`: the name of the client package to import from
 
 ### Clients tests
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-321

The issue was discovered in https://github.com/algolia/api-clients-automation/pull/823, but I've moved the fix for the clients here.

### Changes included:

The goal of this PR is to assert the body of each requests in the CTS even when we don't expect to have one.

On some `POST` requests, the body can be optional (e.g. `browse`), but needs to be a valid JSON object, when no body is expected at all (e.g. `clearAllSynonyms`), an empty string is considered as valid. ~In any case, an empty object (`'{}'`) is considered as valid.~ Some endpoints **do not expect a body at all**, so we need to move that logic at the method level since it can't be factorized.

### Issue

1. Calling the `browse` method with only an `indexName` throws an empty body error
2. Calling the `clearRules` method with a body throws an unexpected body error

### Next

Fix `null` body for `GET` and `DELETE` methods on the PHP client, once @damcou is back: https://algolia.atlassian.net/browse/APIC-591

## 🧪 Test

- CI
- Playground:
  - `deleteApiKey` for the `DELETE` method change
  - `browse` with empty object only for the `POST` method change
