### PR TITLE
fix(specs): wrong parameters for `searchSynonyms`

### DIFF
--- a/specs/search/paths/synonyms/searchSynonyms.yml
+++ b/specs/search/paths/synonyms/searchSynonyms.yml
@@ -8,10 +8,20 @@ post:
   description: Search or browse all synonyms, optionally filtering them by type.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: 'common/parameters.yml#/Query'
     - $ref: 'common/parameters.yml#/Type'
     - $ref: '../../../common/parameters.yml#/PageDefault0'
     - $ref: '../../../common/parameters.yml#/HitsPerPage'
+  requestBody:
+    description: The body of the the `searchSynonyms` method.
+    content:
+      application/json:
+        schema:
+          title: searchSynonymsParams
+          type: object
+          additionalProperties: false
+          properties:
+            query:
+              $ref: '../../../common/schemas/SearchParams.yml#/query'
   responses:
     '200':
       description: OK

--- a/tests/CTS/methods/requests/search/searchSynonyms.json
+++ b/tests/CTS/methods/requests/search/searchSynonyms.json
@@ -1,11 +1,36 @@
 [
   {
+    "testName": "searchSynonyms with minimal parameters",
     "parameters": {
       "indexName": "indexName"
     },
     "request": {
       "path": "/1/indexes/indexName/synonyms/search",
       "method": "POST"
+    }
+  },
+  {
+    "testName": "searchSynonyms with all parameters",
+    "parameters": {
+      "indexName": "indexName",
+      "type": "altcorrection1",
+      "page": 10,
+      "hitsPerPage": 10,
+      "searchSynonymsParams": {
+        "query": "myQuery"
+      }
+    },
+    "request": {
+      "path": "/1/indexes/indexName/synonyms/search",
+      "method": "POST",
+      "body": {
+        "query": "myQuery"
+      },
+      "queryParameters": {
+        "type": "altcorrection1",
+        "page": "10",
+        "hitsPerPage": "10"
+      }
     }
   }
 ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

`query` is a body parameter.

## 🧪 Test

CI :D 