### PR TITLE
feat(javascript): add `requester-fetch`

### DIFF
--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -52,6 +52,13 @@ runs:
         name: client-javascript-utils-requester-node-http
         path: clients/algoliasearch-client-javascript/packages/requester-node-http/
 
+    - name: client-javascript-utils-requester-fetch
+      if: ${{ (inputs.javascript == 'true' && inputs.type == 'all') || inputs.type == 'js_utils' }}
+      uses: actions/download-artifact@v3
+      with:
+        name: client-javascript-utils-requester-fetch
+        path: clients/algoliasearch-client-javascript/packages/requester-fetch/
+
     # JavaScript
     - name: Download clients-javascript artifact
       if: ${{ inputs.javascript == 'true' && inputs.type == 'all' }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,6 +134,7 @@ jobs:
           - client-common
           - requester-browser-xhr
           - requester-node-http
+          - requester-fetch
     steps:
       - uses: actions/checkout@v2
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -19,8 +19,9 @@ This folder hosts the generated clients.
 - [@algolia/client-query-suggestions](./algoliasearch-client-javascript/packages/client-query-suggestions/): The Algolia query suggestions client.
 - [@algolia/client-search](./algoliasearch-client-javascript/packages/client-search/): The Algolia search client.
 - [@algolia/recommend](./algoliasearch-client-javascript/packages/recommend/): The Algolia recommend client.
-- [@algolia/sources](./algoliasearch-client-javascript/packages/client-sources/): The Algolia sources client.
+- [@algolia/client-sources](./algoliasearch-client-javascript/packages/client-sources/): The Algolia sources client.
 - [@algolia/predict](./algoliasearch-client-javascript/packages/predict/): The Algolia predict client.
 - [@algolia/client-common](./algoliasearch-client-javascript/packages/client-common/): The JavaScript clients common files.
 - [@algolia/requester-browser-xhr](./algoliasearch-client-javascript/packages/requester-browser-xhr/): Browser XHR requester for the Algolia JavaScript clients.
+- [@algolia/requester-fetch](./algoliasearch-client-javascript/packages/requester-fetch/): Requester for the Algolia JavaScript clients using Fetch.
 - [@algolia/requester-node-http](./algoliasearch-client-javascript/packages/requester-node-http/): Node.js HTTP requester for the Algolia JavaScript clients.

--- a/clients/algoliasearch-client-javascript/base.rollup.config.js
+++ b/clients/algoliasearch-client-javascript/base.rollup.config.js
@@ -16,6 +16,10 @@ const UTILS = {
     external: ['dom'],
     dependencies: [`${NPM_ORG}client-common`],
   },
+  'requester-fetch': {
+    external: ['dom'],
+    dependencies: [`${NPM_ORG}client-common`],
+  },
   'requester-node-http': {
     external: ['https', 'http', 'url'],
     dependencies: [`${NPM_ORG}client-common`],

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -9,7 +9,7 @@
     "build:all": "./scripts/build_all.sh",
     "build:utils": "yarn build utils",
     "clean": "rm -rf packages/*/dist || true",
-    "clean:utils": "yarn workspace @algolia/client-common clean && yarn workspace @algolia/requester-node-http clean && yarn workspace @algolia/requester-browser-xhr clean",
+    "clean:utils": "yarn workspace @algolia/client-common clean && yarn workspace @algolia/requester-node-http clean && yarn workspace @algolia/requester-browser-xhr clean && yarn workspace @algolia/requester-fetch clean",
     "release:bump": "lerna version ${0:-patch} --no-changelog --no-git-tag-version --no-push --exact --force-publish --yes",
     "release:publish": "ts-node --project tsconfig.script.json scripts/publish.ts",
     "test:lint": "eslint . --ext .js,.ts",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/index.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/index.ts
@@ -1,0 +1,1 @@
+export * from './src/createFetchRequester';

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/jest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  roots: ['src/__tests__'],
+  testEnvironment: 'jsdom',
+};
+
+export default config;

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@algolia/requester-fetch",
+  "version": "5.0.0-alpha.0",
+  "description": "Promise-based request library using Fetch.",
+  "repository": "algolia/algoliasearch-client-javascript",
+  "license": "MIT",
+  "author": "Algolia",
+  "main": "dist/requester-fetch.cjs.js",
+  "module": "dist/requester-fetch.esm.node.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "index.ts"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist/",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@algolia/client-common": "5.0.0-alpha.0"
+  },
+  "devDependencies": {
+    "@types/jest": "28.1.4",
+    "@types/node": "16.11.45",
+    "cross-fetch": "3.1.5",
+    "jest": "28.1.2",
+    "nock": "13.2.8",
+    "ts-jest": "28.0.5",
+    "typescript": "4.7.4"
+  },
+  "engines": {
+    "node": ">= 14.0.0"
+  }
+}

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
@@ -1,0 +1,81 @@
+import type {
+  EndRequest,
+  Requester,
+  Response as AlgoliaResponse,
+} from '@algolia/client-common';
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function getErrorMessage(error: unknown, abortContent: string): string {
+  if (isAbortError(error)) {
+    return abortContent;
+  }
+  return error instanceof Error ? error.message : 'Network request failed';
+}
+
+export type FetchRequesterOptions = {
+  readonly requesterOptions?: RequestInit;
+};
+
+export function createFetchRequester({
+  requesterOptions = {},
+}: FetchRequesterOptions = {}): Requester {
+  async function send(request: EndRequest): Promise<AlgoliaResponse> {
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    const createTimeout = (timeout: number): NodeJS.Timeout => {
+      return setTimeout(() => {
+        abortController.abort();
+      }, timeout);
+    };
+
+    const connectTimeout = createTimeout(request.connectTimeout);
+
+    let fetchRes: Response;
+    try {
+      fetchRes = await fetch(request.url, {
+        method: request.method,
+        body: request.data || null,
+        mode: 'cors',
+        redirect: 'manual',
+        signal,
+        ...requesterOptions,
+        headers: {
+          ...requesterOptions.headers,
+          ...request.headers,
+        },
+      });
+    } catch (error) {
+      return {
+        status: 0,
+        content: getErrorMessage(error, 'Connection timeout'),
+        isTimedOut: isAbortError(error),
+      };
+    }
+
+    clearTimeout(connectTimeout);
+
+    createTimeout(request.responseTimeout);
+
+    try {
+      const content = await fetchRes.text();
+
+      return {
+        content,
+        isTimedOut: false,
+        status: fetchRes.status,
+      };
+    } catch (error) {
+      return {
+        status: 0,
+        content: getErrorMessage(error, 'Socket timeout'),
+        isTimedOut: isAbortError(error),
+      };
+    }
+  }
+
+  return { send };
+}

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "outDir": "dist"
+  },
+  "include": ["src", "index.ts"],
+  "exclude": ["dist", "node_modules", "src/__tests__"]
+}

--- a/clients/algoliasearch-client-javascript/tests/utils.ts
+++ b/clients/algoliasearch-client-javascript/tests/utils.ts
@@ -1,0 +1,75 @@
+import http from 'http';
+
+import type { EndRequest, Headers } from '@algolia/client-common';
+
+/**
+ * Base URL in tests.
+ */
+export const BASE_URL = 'https://algolia-dns.net/foo?x-algolia-header=bar';
+
+/**
+ * Default headers for tests.
+ */
+export const headers: Headers = {
+  'content-type': 'text/plain',
+};
+
+/**
+ * Default timeout request used for tests.
+ */
+export const timeoutRequest: EndRequest = {
+  url: 'missing-url-here',
+  data: '',
+  headers: {},
+  method: 'GET',
+  responseTimeout: 5000,
+  connectTimeout: 2000,
+};
+
+/**
+ * Default request used for tests.
+ */
+export const requestStub: EndRequest = {
+  url: BASE_URL,
+  method: 'POST',
+  headers,
+  data: getStringifiedBody(),
+  responseTimeout: 2000,
+  connectTimeout: 1000,
+};
+
+export const testQueryHeader: Headers = { 'x-algolia-header': 'bar' };
+export const testQueryBaseUrl = 'https://algolia-dns.net';
+
+/**
+ * Returns a JSON strigified body.
+ */
+export function getStringifiedBody(
+  body: Record<string, any> = { foo: 'bar' }
+): string {
+  return JSON.stringify(body);
+}
+
+/**
+ * Creates a test server.
+ */
+export function createTestServer(): http.Server {
+  return http.createServer(function (_req, res) {
+    res.writeHead(200, {
+      'content-type': 'text/plain',
+      'access-control-allow-origin': '*',
+      'x-powered-by': 'nodejs',
+    });
+
+    res.write('{"foo":');
+
+    setTimeout(() => {
+      res.write(' "bar"');
+    }, 1000);
+
+    setTimeout(() => {
+      res.write('}');
+      res.end();
+    }, 5000);
+  });
+}

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -141,6 +141,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@algolia/requester-fetch@workspace:packages/requester-fetch":
+  version: 0.0.0-use.local
+  resolution: "@algolia/requester-fetch@workspace:packages/requester-fetch"
+  dependencies:
+    "@algolia/client-common": 5.0.0-alpha.0
+    "@types/jest": 28.1.4
+    "@types/node": 16.11.45
+    cross-fetch: 3.1.5
+    jest: 28.1.2
+    nock: 13.2.8
+    ts-jest: 28.0.5
+    typescript: 4.7.4
+  languageName: unknown
+  linkType: soft
+
 "@algolia/requester-node-http@5.0.0-alpha.0, @algolia/requester-node-http@workspace:packages/requester-node-http":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-node-http@workspace:packages/requester-node-http"
@@ -4688,6 +4703,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:3.1.5":
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
+  dependencies:
+    node-fetch: 2.6.7
+  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -7437,7 +7461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:

--- a/config/generation.config.js
+++ b/config/generation.config.js
@@ -21,6 +21,7 @@ module.exports = {
     '!clients/algoliasearch-client-javascript/.github/**',
     '!clients/algoliasearch-client-javascript/.yarn/**',
     '!clients/algoliasearch-client-javascript/scripts/**',
+    '!clients/algoliasearch-client-javascript/tests/**',
     '!clients/algoliasearch-client-javascript/packages/requester-*/**',
     '!clients/algoliasearch-client-javascript/packages/client-common/**',
     '!clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/**',

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -70,6 +70,7 @@ export const CLIENTS = [
 export const CLIENTS_JS_UTILS = [
   'client-common',
   'requester-browser-xhr',
+  'requester-fetch',
   'requester-node-http',
 ];
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-572

### Changes included:

Import `fetch` requester from the community implementation: https://github.com/algolia/algoliasearch-client-javascript/pull/1411

Only changes that were added from the first implementation are:
- Use ms for timeouts
- Allow overriding default `requesterOptions`

### Side changes

I've also moved the test utils to their own folder as it was becoming redundant

## 🧪 Test

CI :D 
