### PR TITLE
fix(specs): make `hits` required, `facets` count as an integer, `searchParams` as optional

### DIFF
--- a/specs/recommend/common/schemas/RecommendationsResponse.yml
+++ b/specs/recommend/common/schemas/RecommendationsResponse.yml
@@ -11,6 +11,8 @@ recommendHits:
       type: array
       items:
         $ref: '#/recommendHit'
+  required:
+    - hits
 
 recommendHit:
   type: object

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -48,7 +48,7 @@ baseSearchResponse:
       description: If a search encounters an index that is being A/B tested, abTestID reports the ongoing A/B test ID.
     abTestVariantID:
       type: integer
-      description: If a search encounters an index that is being A/B tested, abTestVariantID reports the variant ID of the index used.
+      description: If a search encounters an index that is being A/B tested, abTestVariantID reports the variant ID of the index used (starting at 1).
     aroundLatLng:
       type: string
       description: The computed geo location.

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -26,12 +26,13 @@ searchHits:
       type: array
       items:
         $ref: 'Hit.yml#/hit'
+  required:
+    - hits
 
 baseSearchResponse:
   type: object
   additionalProperties: false
   required:
-    - hits
     - nbHits
     - page
     - nbPages
@@ -70,7 +71,7 @@ baseSearchResponse:
       additionalProperties:
         type: object
         additionalProperties:
-          type: string
+          type: integer
       description: A mapping of each facet name to the corresponding facet counts.
       example:
         category:

--- a/specs/search/paths/search/searchSingleIndex.yml
+++ b/specs/search/paths/search/searchSingleIndex.yml
@@ -9,7 +9,6 @@ post:
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   requestBody:
-    required: true
     content:
       application/json:
         schema:

--- a/tests/CTS/methods/requests/search/searchSingleIndex.json
+++ b/tests/CTS/methods/requests/search/searchSingleIndex.json
@@ -2,22 +2,16 @@
   {
     "testName": "search with minimal parameters",
     "parameters": {
-      "indexName": "indexName",
-      "searchParams": {
-        "query": "myQuery"
-      }
+      "indexName": "indexName"
     },
     "request": {
       "path": "/1/indexes/indexName/query",
-      "method": "POST",
-      "body": {
-        "query": "myQuery"
-      }
+      "method": "POST"
     }
   },
   {
     "method": "search",
-    "testName": "search with facetFilters",
+    "testName": "search with searchParams",
     "parameters": {
       "indexName": "indexName",
       "searchParams": {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-590

### Changes included:

- The `required` field for `hits` was at the wrong spot
  - `hits` is required in a `SearchResponse`, but also a `RecommendationsResponse`
- The `facets` returned are a `Record<string, Record<string, number>>`
- All parameters of `searchParams` are optional, therefore we don't need to make it required.

## 🧪 Test

CI :D 
