### PR TITLE
fix(ci): prevent deleting all tests, correctly run JS tasks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Build clients
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language != 'php' }}
-        run: yarn cli build clients ${{ matrix.client.language }} ${{ matrix.client.toBuild }}
+        run: yarn cli build clients ${{ matrix.client.language }} ${{ matrix.client.toRun }}
 
       - name: Test JavaScript bundle size
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
@@ -246,7 +246,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
         run: cd ${{ matrix.client.path }} && yarn workspace algoliasearch test
 
-      - name: Clean CTS output before generate
+      - name: Remove CTS output before generate
         run: rm -rf ${{ matrix.client.testsToDelete }} || true
 
       - name: Generate CTS
@@ -278,7 +278,7 @@ jobs:
         run: yarn cli cts run ${{ matrix.client.language }}
 
       - name: Zip artifact before storing
-        run: zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} -x "**/node_modules**" "**/.yarn/cache/**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
+        run: zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsRootFolder }} -x "**/node_modules**" "**/.yarn/cache/**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
 
       - name: Store ${{ matrix.client.language }} clients
         uses: actions/upload-artifact@v3

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -98,15 +98,6 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
         return `${testsOutputBase}/client/${clientName}${extension} ${testsOutputBase}/methods/requests/${clientName}${extension} ${tmpPath}`;
       })
       .join(' ');
-    let testsToStore = testsToDelete;
-
-    switch (language) {
-      case 'java':
-        testsToStore = `${testsToDelete} ${testsRootFolder}/build.gradle`;
-        break;
-      default:
-        break;
-    }
 
     clientMatrix.client.push({
       language,
@@ -120,7 +111,6 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
       ]),
       testsRootFolder,
       testsToDelete,
-      testsToStore,
     });
     console.log(`::set-output name=RUN_GEN_${language.toUpperCase()}::true`);
   }

--- a/scripts/ci/githubActions/types.ts
+++ b/scripts/ci/githubActions/types.ts
@@ -37,10 +37,6 @@ export type ClientMatrix = BaseMatrix & {
    * The test output path to delete before running the CTS generation.
    */
   testsToDelete: string;
-  /**
-   * The test output path to store in the artifact.
-   */
-  testsToStore: string;
 };
 
 export type SpecMatrix = Pick<BaseMatrix, 'cacheKey' | 'toRun'> & {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-595

### Changes included:

- JS ran all jobs instead of only the ones that changed
  - see [build step](https://github.com/algolia/api-clients-automation/runs/7521374907?check_suite_focus=true) running everything instead of `algoliasearch search` clients
- All tests are currently deleted, while we always run the CI over all specs
  - see [generation commit](https://github.com/algolia/api-clients-automation/commit/c5f14fd5502b1ee626d67895ef5573387098414c), only `search` related should run, but we've deleted everything.

## 🧪 Test
