### PR TITLE
fix(ci): only run size check on release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -239,7 +239,7 @@ jobs:
         run: yarn cli build clients ${{ matrix.client.language }} ${{ matrix.client.toRun }}
 
       - name: Test JavaScript bundle size
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' && startsWith(env.head_ref, 'chore/prepare-release-') }}
         run: cd ${{ matrix.client.path }} && yarn test:size
 
       - name: Run JavaScript 'algoliasearch' client tests


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

We don't always generate/build all clients, therefore we can't run `bundlesize` on every runs. I've changed the condition to only run on prepare release PRs for now, and will try to find a conditional way. Ticket added here: https://algolia.atlassian.net/browse/APIC-596

## 🧪 Test

CI :D 
