### PR TITLE
fix(ci): make CTS only run generated tests

### DIFF
--- a/.github/actions/restore-artifacts/action.yml
+++ b/.github/actions/restore-artifacts/action.yml
@@ -71,8 +71,6 @@ runs:
       shell: bash
       run: |
         rm -rf clients/algoliasearch-client-javascript
-        rm -rf tests/output/javascript/src/client || true
-        rm -rf tests/output/javascript/src/methods || true
         unzip -q -o clients-javascript.zip && rm clients-javascript.zip
 
     # PHP
@@ -87,8 +85,6 @@ runs:
       shell: bash
       run: |
         rm -rf clients/algoliasearch-client-php
-        rm -rf tests/output/php/src/client || true
-        rm -rf tests/output/php/src/methods || true
         unzip -q -o clients-php.zip && rm clients-php.zip
 
     # Java
@@ -103,6 +99,4 @@ runs:
       shell: bash
       run: |
         rm -rf clients/algoliasearch-client-java-2
-        rm -rf tests/output/java/src/test/java/com/algolia/client || true
-        rm -rf tests/output/java/src/test/java/com/algolia/methods || true
         unzip -q -o clients-java.zip && rm clients-java.zip

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -246,7 +246,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
         run: cd ${{ matrix.client.path }} && yarn workspace algoliasearch test
 
-      - name: Remove CTS output before generate
+      - name: Remove previous CTS output
         run: rm -rf ${{ matrix.client.testsToDelete }} || true
 
       - name: Generate CTS
@@ -278,7 +278,7 @@ jobs:
         run: yarn cli cts run ${{ matrix.client.language }}
 
       - name: Zip artifact before storing
-        run: zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsRootFolder }} -x "**/node_modules**" "**/.yarn/cache/**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
+        run: zip -r -y clients-${{ matrix.client.language }}.zip ${{ matrix.client.path }} ${{ matrix.client.testsToStore }} -x "**/node_modules**" "**/.yarn/cache/**" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/vendor/**"
 
       - name: Store ${{ matrix.client.language }} clients
         uses: actions/upload-artifact@v3

--- a/scripts/ci/githubActions/types.ts
+++ b/scripts/ci/githubActions/types.ts
@@ -37,6 +37,10 @@ export type ClientMatrix = BaseMatrix & {
    * The test output path to delete before running the CTS generation.
    */
   testsToDelete: string;
+  /**
+   * The test output path to store in the artifact.
+   */
+  testsToStore: string;
 };
 
 export type SpecMatrix = Pick<BaseMatrix, 'cacheKey' | 'toRun'> & {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Follow up of https://github.com/algolia/api-clients-automation/pull/869

The CTS runs everything present in the client CTS folder, as our CI only run tasks for clients that have changed, we need to:
1. delete every tests present
2. generate tests for clients that have changed
3. store tests of clients that have changed

## 🧪 Test

CI :D 
