### PR TITLE
fix(javascript): expose sub `algoliasearch` client's type

### DIFF
--- a/templates/javascript/clients/algoliasearch/builds/imports.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/imports.mustache
@@ -16,5 +16,8 @@ export * from './models';
 
 export const apiClientVersion = searchClientVersion;
 
+/**
+ * The client type.
+ */
 export type Algoliasearch = ReturnType<typeof algoliasearch>;
 

--- a/templates/javascript/clients/algoliasearch/builds/models.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/models.mustache
@@ -17,6 +17,11 @@ export * from '{{{npmNamespace}}}/client-personalization/model';
 export * from '{{{npmNamespace}}}/client-analytics/model';
 export * from '{{{npmNamespace}}}/client-abtesting/model';
 
+export { SearchClient } from '{{{npmNamespace}}}/client-search';
+export { PersonalizationClient } from '{{{npmNamespace}}}/client-personalization';
+export { AnalyticsClient } from '{{{npmNamespace}}}/client-analytics';
+export { AbtestingClient } from '{{{npmNamespace}}}/client-abtesting';
+
 export { ErrorBase, PutProps, PostProps, DelProps, GetProps };
 
 export type CommonClientOptions = { requester?: Requester; hosts?: Host[] };

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -130,6 +130,9 @@ export function create{{capitalizedApiName}}({
   };
 }
 
+/**
+ * The client type.
+ */
 export type {{capitalizedApiName}} = ReturnType<typeof create{{capitalizedApiName}}>;
 
 {{/operations}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-590

### Changes included:

Sub `algoliasearch` client's type are not exposed, which can be useful in complex implementations like in the Crawler. It also help to differentiate which client does what.

## 🧪 Test

CI :D 