### PR TITLE
fix(javascript): helpers type options

### DIFF
--- a/playground/javascript/node/search.ts
+++ b/playground/javascript/node/search.ts
@@ -17,7 +17,9 @@ client.addAlgoliaAgent('Node playground', '0.0.1');
 
 async function testSearch() {
   try {
-    const res = await client.search<{ name: string }>({ requests: [{ indexName: searchIndex, query: searchQuery }] });
+    const res = await client.search<{ name: string }>({
+      requests: [{ indexName: searchIndex, query: searchQuery }],
+    });
 
     console.log(`[OK]`, res.results[0].hits![0].name);
   } catch (e: any) {

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -114,7 +114,7 @@ waitForApiKey(
  * @param browseObjects - The browseObjects object.
  * @param browseObjects.indexName - The index in which to perform the request.
  * @param browseObjects.browseRequest - The `browse` method parameters.
- * @param browseObjects.validate - The validator function. It receive the resolved return of the API call.
+ * @param browseObjects.validate - The validator function. It receive the resolved return of the API call. By default, stops when there is no `cursor` in the response.
  * @param browseObjects.aggregator - The function that runs right after the API call has been resolved, allows you to do anything with the response before `validate`.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `browse` method and merged with the transporter requestOptions.
  */
@@ -151,7 +151,7 @@ browseObjects<T>(
  * @param browseObjects - The browseObjects object.
  * @param browseObjects.indexName - The index in which to perform the request.
  * @param browseObjects.searchRulesParams - The `searchRules` method parameters.
- * @param browseObjects.validate - The validator function. It receive the resolved return of the API call.
+ * @param browseObjects.validate - The validator function. It receive the resolved return of the API call. By default, stops when there is less hits returned than the number of maximum hits (1000).
  * @param browseObjects.aggregator - The function that runs right after the API call has been resolved, allows you to do anything with the response before `validate`.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `searchRules` method and merged with the transporter requestOptions.
  */
@@ -194,7 +194,7 @@ browseRules(
  * @summary Helper method that iterates on the `searchSynonyms` method.
  * @param browseObjects - The browseObjects object.
  * @param browseObjects.indexName - The index in which to perform the request.
- * @param browseObjects.validate - The validator function. It receive the resolved return of the API call.
+ * @param browseObjects.validate - The validator function. It receive the resolved return of the API call. By default, stops when there is less hits returned than the number of maximum hits (1000).
  * @param browseObjects.aggregator - The function that runs right after the API call has been resolved, allows you to do anything with the response before `validate`.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `searchSynonyms` method and merged with the transporter requestOptions.
  */

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -48,10 +48,7 @@ export type BrowseOptions<T> = Partial<
 > &
   Required<Pick<CreateIterablePromise<T>, 'aggregator'>>;
 
-type WaitForOptions<T> = Omit<
-  CreateIterablePromise<T>,
-  'func' | 'timeout' | 'validate'
-> & {
+type WaitForOptions = Partial<{
   /**
    * The maximum number of retries. 50 by default.
    */
@@ -61,9 +58,9 @@ type WaitForOptions<T> = Omit<
    * The function to decide how long to wait between retries.
    */
   timeout: (retryCount: number) => number;
-};
+}>;
 
-export type WaitForTaskOptions = WaitForOptions<GetTaskResponse> & {
+export type WaitForTaskOptions = WaitForOptions & {
   /**
    * The `indexName` where the operation was performed.
    */
@@ -74,7 +71,7 @@ export type WaitForTaskOptions = WaitForOptions<GetTaskResponse> & {
   taskID: number;
 };
 
-export type WaitForApiKeyOptions = WaitForOptions<GetApiKeyResponse> & {
+export type WaitForApiKeyOptions = WaitForOptions & {
   /**
    * The API Key.
    */

--- a/website/docs/clients/installation.mdx
+++ b/website/docs/clients/installation.mdx
@@ -19,17 +19,17 @@ To get started, you first need to install `algoliasearch` (or any other availabl
 All of our clients comes with type definition, and are available for both `browser` and `node` environments.
 
 ```bash
-yarn add algoliasearch
+yarn add algoliasearch@alpha
 # or
-npm install algoliasearch
+npm install algoliasearch@alpha
 ```
 
 Or use a specific package:
 
 ```bash
-yarn add @algolia/client-search
+yarn add @algolia/client-search@alpha
 # or
-npm install @algolia/client-search
+npm install @algolia/client-search@alpha
 ```
 
 **Without a package manager**

--- a/website/docs/clients/migration-guides/javascript.md
+++ b/website/docs/clients/migration-guides/javascript.md
@@ -12,9 +12,9 @@ title: JavaScript
 To get started, first install the `algoliasearch` client.
 
 ```bash
-yarn add algoliasearch
+yarn add algoliasearch@alpha
 # or
-npm install algoliasearch
+npm install algoliasearch@alpha
 ```
 
 You can continue this guide on [our installation page](/docs/clients/installation).


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: - 

### Changes included:

- `waitFor*` types were wrong (shouldn't require `maxRetries` and `timeout`)
- State default in JSDoc for `browse*` methods
- Add `@alpha` tag to installation guides

## 🧪 Test

- `yarn docker playground javascript search` to test on the playground
