### PR TITLE
fix(specs): wrong body parameter name

### DIFF
--- a/specs/search/paths/objects/partialUpdate.yml
+++ b/specs/search/paths/objects/partialUpdate.yml
@@ -3,6 +3,7 @@ post:
     - Records
   operationId: partialUpdateObject
   summary: Partially update an object.
+  x-codegen-request-body-name: attributesToUpdate
   description: >
     Update one or more attributes of an existing object.
 
@@ -22,16 +23,14 @@ post:
         default: true
   requestBody:
     required: true
-    description: List of attributes to update.
+    description: Map of attribute(s) to update.
     content:
       application/json:
         schema:
-          type: array
-          items:
-            type: object
-            description: Attribute to update.
-            additionalProperties:
-              $ref: 'common/schemas.yml#/attributeToUpdate'
+          type: object
+          description: Attribute(s) to update.
+          additionalProperties:
+            $ref: 'common/schemas.yml#/attributeToUpdate'
   responses:
     '200':
       $ref: '../../../common/responses/UpdatedAtWithObjectId.yml'

--- a/specs/search/paths/rules/common/schemas.yml
+++ b/specs/search/paths/rules/common/schemas.yml
@@ -1,9 +1,3 @@
-rules:
-  type: array
-  description: Rules to add.
-  items:
-    $ref: '#/rule'
-
 rule:
   type: object
   description: Rule object.

--- a/specs/search/paths/rules/saveRules.yml
+++ b/specs/search/paths/rules/saveRules.yml
@@ -4,6 +4,7 @@ post:
   operationId: saveRules
   summary: Save a batch of rules.
   description: Create/update multiple rules objects at once.
+  x-codegen-request-body-name: rules
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'
@@ -13,7 +14,10 @@ post:
     content:
       application/json:
         schema:
-          $ref: 'common/schemas.yml#/rules'
+          type: array
+          description: Rules to add.
+          items:
+            $ref: 'common/schemas.yml#/rule'
   responses:
     '200':
       $ref: '../../../common/responses/UpdatedAt.yml'

--- a/tests/CTS/methods/requests/search/partialUpdateObject.json
+++ b/tests/CTS/methods/requests/search/partialUpdateObject.json
@@ -3,29 +3,25 @@
     "parameters": {
       "indexName": "theIndexName",
       "objectID": "uniqueID",
-      "attributeToUpdate": [
-        {
-          "id1": "test",
-          "id2": {
-            "_operation": "AddUnique",
-            "value": "test2"
-          }
+      "attributesToUpdate": {
+        "id1": "test",
+        "id2": {
+          "_operation": "AddUnique",
+          "value": "test2"
         }
-      ],
+      },
       "createIfNotExists": true
     },
     "request": {
       "path": "/1/indexes/theIndexName/uniqueID/partial",
       "method": "POST",
-      "body": [
-        {
-          "id1": "test",
-          "id2": {
-            "_operation": "AddUnique",
-            "value": "test2"
-          }
+      "body": {
+        "id1": "test",
+        "id2": {
+          "_operation": "AddUnique",
+          "value": "test2"
         }
-      ],
+      },
       "queryParameters": {
         "createIfNotExists": "true"
       }

--- a/tests/CTS/methods/requests/search/saveRules.json
+++ b/tests/CTS/methods/requests/search/saveRules.json
@@ -3,7 +3,7 @@
     "testName": "saveRules with minimal parameters",
     "parameters": {
       "indexName": "indexName",
-      "rule": [
+      "rules": [
         {
           "objectID": "a-rule-id",
           "conditions": [
@@ -53,7 +53,7 @@
     "testName": "saveRules with all parameters",
     "parameters": {
       "indexName": "indexName",
-      "rule": [
+      "rules": [
         {
           "objectID": "id1",
           "conditions": [


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Fixes https://github.com/algolia/api-clients-automation/issues/891

↑ The full details are in the issue ↑

We now leverage the built-in `x-codegen-request-body-name` property in the spec to override the automatically guessed `requestBody`. 

I'll update the contributing guide in the docs in the next PR.

## 🧪 Test

CI :D 
