### PR TITLE
fix(specs): browseResponse, IndexSettings and searchResponse

### DIFF
--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -322,6 +322,9 @@ indexSettingsAsSearchParams:
         - Query strategy
     distinct:
       $ref: '#/distinct'
+    attributeForDistinct:
+      description: Name of the de-duplication attribute to be used with the distinct feature.
+      type: string
     synonyms:
       type: boolean
       description: Whether to take into account an index's synonyms for a particular search.

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -12,8 +12,6 @@ browseResponse:
 baseBrowseResponse:
   type: object
   additionalProperties: false
-  required:
-    - cursor
   properties:
     cursor:
       $ref: '../../../common/schemas/SearchParams.yml#/cursor'

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -37,7 +37,6 @@ baseSearchResponse:
     - hitsPerPage
     - processingTimeMS
     - exhaustiveNbHits
-    - exhaustiveTypo
     - query
     - params
   properties:

--- a/tests/CTS/methods/requests/search/setSettings.json
+++ b/tests/CTS/methods/requests/search/setSettings.json
@@ -293,6 +293,7 @@
           "exactPhrase"
         ],
         "distinct": 3,
+        "attributeForDistinct": "test",
         "synonyms": false,
         "replaceSynonymsInHighlight": true,
         "minProximity": 6,
@@ -426,6 +427,7 @@
           "exactPhrase"
         ],
         "distinct": 3,
+        "attributeForDistinct": "test",
         "synonyms": false,
         "replaceSynonymsInHighlight": true,
         "minProximity": 6,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

- The `cursor` parameter of the `browseResponse` is optional.
- `indexSettings` was missing an attribute
- `exhaustiveTypo` shouldn't be required in the `searchResponse`

## 🧪 Test

CI :D 