### PR TITLE
chore: prepare release 2022-08-09

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.4.6-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.4.5-SNAPSHOT...4.4.6-SNAPSHOT)
+
+- [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.4.5-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.4.4-SNAPSHOT...4.4.5-SNAPSHOT)
 
 - [07c169f5](https://github.com/algolia/api-clients-automation/commit/07c169f5) fix(specs): browseResponse, IndexSettings and searchResponse ([#900](https://github.com/algolia/api-clients-automation/pull/900)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.7](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.6...5.0.0-alpha.7)
+
+- [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.6](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.5...5.0.0-alpha.6)
 
 - [07c169f5](https://github.com/algolia/api-clients-automation/commit/07c169f5) fix(specs): browseResponse, IndexSettings and searchResponse ([#900](https://github.com/algolia/api-clients-automation/pull/900)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.6",
+  "version": "5.0.0-alpha.7",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.6",
+  "version": "5.0.0-alpha.7",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.6"
+    "@algolia/client-common": "5.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.6",
+  "version": "5.0.0-alpha.7",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.6"
+    "@algolia/client-common": "5.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.6",
+  "version": "5.0.0-alpha.7",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.6"
+    "@algolia/client-common": "5.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.12](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.11...4.0.0-alpha.12)
+
+- [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.11](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.10...4.0.0-alpha.11)
 
 - [07c169f5](https://github.com/algolia/api-clients-automation/commit/07c169f5) fix(specs): browseResponse, IndexSettings and searchResponse ([#900](https://github.com/algolia/api-clients-automation/pull/900)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java-2",
     "gitRepoId": "algoliasearch-client-java-2",
-    "packageVersion": "4.4.5-SNAPSHOT",
+    "packageVersion": "4.4.6-SNAPSHOT",
     "modelFolder": "algoliasearch-core/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch-core/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.6",
+    "utilsPackageVersion": "5.0.0-alpha.7",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.11",
+    "packageVersion": "4.0.0-alpha.12",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.6"
+          "packageVersion": "5.0.0-alpha.7"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.6"
+          "packageVersion": "1.0.0-alpha.7"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.6"
+          "packageVersion": "1.0.0-alpha.7"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.6 -> **`prerelease` _(e.g. 5.0.0-alpha.7)_**
- java: 4.4.5-SNAPSHOT -> **`patch` _(e.g. 4.4.6-SNAPSHOT)_**
- php: 4.0.0-alpha.11 -> **`prerelease` _(e.g. 4.0.0-alpha.12)_**

### Skipped Commits

_(None)_