### PR TITLE
fix(clients): list available regions when region is missing

### DIFF
--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -99,20 +99,7 @@ public class {{classname}} extends ApiClient {
     private static List<StatefulHost> getDefaultHosts(String region) throws AlgoliaRuntimeException {
       List<StatefulHost> hosts = new ArrayList<StatefulHost>();
 
-      {{^fallbackToAliasHost}}
-      boolean found = false;
-      if (region == null) {
-        throw new AlgoliaRuntimeException("`region` is missing");
-      }
-      for (String allowed : allowedRegions) {
-        if (allowed.equals(region)) {
-          found = true;
-          break;
-        }
-      }
-      {{/fallbackToAliasHost}}
-      {{#fallbackToAliasHost}}
-      boolean found = region == null;
+      boolean found = {{^fallbackToAliasHost}}false{{/fallbackToAliasHost}}{{#fallbackToAliasHost}}region == null{{/fallbackToAliasHost}};
       if (region != null) {
         for (String allowed : allowedRegions) {
           if (allowed.equals(region)) {
@@ -121,9 +108,9 @@ public class {{classname}} extends ApiClient {
           }
         }
       }
-      {{/fallbackToAliasHost}}
-      if (!found) {
-        throw new AlgoliaRuntimeException("`region` must be one of the following: {{#allowedRegions}}{{.}}{{^-last}}, {{/-last}}{{/allowedRegions}}");
+
+      if ({{^fallbackToAliasHost}}region == null || {{/fallbackToAliasHost}}!found){
+        throw new AlgoliaRuntimeException("`region` {{^fallbackToAliasHost}}is required and {{/fallbackToAliasHost}}must be one of the following: {{#allowedRegions}}{{.}}{{^-last}}, {{/-last}}{{/allowedRegions}}");
       }
 
       String url = {{#fallbackToAliasHost}}region == null ? "{{{hostWithFallback}}}" : {{/fallbackToAliasHost}} "{{{host}}}".replace("{region}", region);

--- a/templates/javascript/clients/algoliasearch/builds/initClients.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/initClients.mustache
@@ -35,17 +35,13 @@ function initAbtesting(initOptions: InitClientOptions & InitClientRegion<Abtesti
 }
 
 function initPersonalization(initOptions: InitClientOptions & Required<InitClientRegion<PersonalizationRegion>>): PersonalizationClient {
-  if (!initOptions.region) {
-    throw new Error('`region` is missing.');
-  }
-
   if (
-    initOptions.region &&
+    !initOptions.region || (initOptions.region &&
     (typeof initOptions.region !== 'string' ||
-      !personalizationRegions.includes(initOptions.region))
+      !personalizationRegions.includes(initOptions.region)))
   ) {
     throw new Error(
-      `\`region\` must be one of the following: ${personalizationRegions.join(', ')}`
+      `\`region\` is required and must be one of the following: ${personalizationRegions.join(', ')}`
     );
   }
 

--- a/templates/javascript/clients/client/builds/checkParameters.mustache
+++ b/templates/javascript/clients/client/builds/checkParameters.mustache
@@ -7,13 +7,8 @@ if (!apiKey || typeof apiKey !== 'string') {
 }
 
 {{#hasRegionalHost}}
-{{^fallbackToAliasHost}}
-if (!region) {
-  throw new Error("`region` is missing.");
-}
-{{/fallbackToAliasHost}}
   
-if (region && (typeof region !== 'string' || !REGIONS.includes(region))) {
-  throw new Error(`\`region\` must be one of the following: ${REGIONS.join(', ')}`);
+if ({{^fallbackToAliasHost}}!region || {{/fallbackToAliasHost}}(region && (typeof region !== 'string' || !REGIONS.includes(region)))) {
+  throw new Error(`\`region\` {{^fallbackToAliasHost}}is required and {{/fallbackToAliasHost}}must be one of the following: ${REGIONS.join(', ')}`);
 }
 {{/hasRegionalHost}}

--- a/templates/php/ConfigWithRegion.mustache
+++ b/templates/php/ConfigWithRegion.mustache
@@ -7,23 +7,8 @@ use Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 
 abstract class ConfigWithRegion extends Configuration
 {
-    public static function create(
-        $appId,
-        $apiKey,
-        $region = null,
-        $allowedRegions = null
-    ) {
-        if (
-            $region !== null &&
-            $allowedRegions !== null &&
-            !in_array($region, $allowedRegions, true)
-        ) {
-            throw new AlgoliaException(
-                '`region` must be one of the following: ' .
-                    implode(', ', $allowedRegions)
-            );
-        }
-
+    public static function create($appId, $apiKey, $region = null)
+    {
         $config = [
             'appId' => $appId,
             'apiKey' => $apiKey,

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -54,7 +54,7 @@ use {{invokerPackage}}\Support\Helpers;
         $allowedRegions = [{{#allowedRegions}}'{{.}}'{{^-last}},{{/-last}}{{/allowedRegions}}];
 
         if (
-            {{^fallbackToAliasHost}}$region == null ||{{/fallbackToAliasHost}}
+            {{^fallbackToAliasHost}}$region === null ||{{/fallbackToAliasHost}}
             ($region !== null && !in_array($region, $allowedRegions, true))
         ) {
             throw new AlgoliaException(

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -51,18 +51,21 @@ use {{invokerPackage}}\Support\Helpers;
      */
     public static function create($appId = null, $apiKey = null, $region = null)
     {
-        $allowedRegions = self::getAllowedRegions();
-        $config = {{configClassname}}::create($appId, $apiKey, $region, $allowedRegions);
+        $allowedRegions = [{{#allowedRegions}}'{{.}}'{{^-last}},{{/-last}}{{/allowedRegions}}];
+
+        if (
+            {{^fallbackToAliasHost}}$region == null ||{{/fallbackToAliasHost}}
+            ($region !== null && !in_array($region, $allowedRegions, true))
+        ) {
+            throw new AlgoliaException(
+                '`region` {{^fallbackToAliasHost}}is required and {{/fallbackToAliasHost}}must be one of the following: ' .
+                    implode(', ', $allowedRegions)
+            );
+        }
+
+        $config = {{configClassname}}::create($appId, $apiKey, $region);
 
         return static::createWithConfig($config);
-    }
-
-    /**
-     * Returns the allowed regions for the config
-     */
-    public static function getAllowedRegions()
-    {
-        return [{{#allowedRegions}}'{{.}}'{{^-last}},{{/-last}}{{/allowedRegions}}];
     }
     {{/hasRegionalHost}}
 

--- a/templates/php/tests/client/suite.mustache
+++ b/templates/php/tests/client/suite.mustache
@@ -37,8 +37,7 @@ class {{clientPrefix}}Test extends TestCase implements HttpClientInterface
             $config = {{clientPrefix}}Config::create(
                 $appId, 
                 $apiKey, 
-                $region,
-                {{client}}::getAllowedRegions()
+                $region
             );
             $clusterHosts = {{client}}::getClusterHosts($config);
         {{/hasRegionalHost}}

--- a/tests/CTS/client/personalization/parameters.json
+++ b/tests/CTS/client/personalization/parameters.json
@@ -1,5 +1,22 @@
 [
   {
+    "testName": "throws when region is not given",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "my-app-id",
+          "apiKey": "my-api-key",
+          "region": ""
+        },
+        "expected": {
+          "error": "`region` is required and must be one of the following: eu, us"
+        }
+      }
+    ]
+  },
+  {
     "testName": "throws when incorrect region is given",
     "autoCreateClient": false,
     "steps": [
@@ -11,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` must be one of the following: eu, us"
+          "error": "`region` is required and must be one of the following: eu, us"
         }
       }
     ]

--- a/tests/CTS/client/predict/parameters.json
+++ b/tests/CTS/client/predict/parameters.json
@@ -1,5 +1,22 @@
 [
   {
+    "testName": "throws when region is not given",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "my-app-id",
+          "apiKey": "my-api-key",
+          "region": ""
+        },
+        "expected": {
+          "error": "`region` is required and must be one of the following: ue, ew"
+        }
+      }
+    ]
+  },
+  {
     "testName": "throws when incorrect region is given",
     "autoCreateClient": false,
     "steps": [
@@ -11,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` must be one of the following: ue, ew"
+          "error": "`region` is required and must be one of the following: ue, ew"
         }
       }
     ]

--- a/tests/CTS/client/query-suggestions/parameters.json
+++ b/tests/CTS/client/query-suggestions/parameters.json
@@ -1,5 +1,22 @@
 [
   {
+    "testName": "throws when region is not given",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "my-app-id",
+          "apiKey": "my-api-key",
+          "region": ""
+        },
+        "expected": {
+          "error": "`region` is required and must be one of the following: eu, us"
+        }
+      }
+    ]
+  },
+  {
     "testName": "throws when incorrect region is given",
     "autoCreateClient": false,
     "steps": [
@@ -11,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` must be one of the following: eu, us"
+          "error": "`region` is required and must be one of the following: eu, us"
         }
       }
     ]

--- a/tests/CTS/client/sources/parameters.json
+++ b/tests/CTS/client/sources/parameters.json
@@ -11,7 +11,7 @@
           "region": ""
         },
         "expected": {
-          "error": "`region` is missing."
+          "error": "`region` is required and must be one of the following: de, us"
         }
       }
     ]
@@ -28,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` must be one of the following: de, us"
+          "error": "`region` is required and must be one of the following: de, us"
         }
       }
     ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:
- https://algolia.atlassian.net/browse/APIC-619
- https://algolia.atlassian.net/browse/APIC-620

### Changes included:

Suggested by @matthew1809

- Make missing region error include the available regions.
- Make PHP client detect missing `region` parameter when required

## 🧪 Test

CI :D 