### PR TITLE
fix(specs): make `batch` body parameters required

### DIFF
--- a/specs/search/paths/objects/batch.yml
+++ b/specs/search/paths/objects/batch.yml
@@ -28,6 +28,11 @@ post:
                   body:
                     type: object
                     description: arguments to the operation (depends on the type of the operation).
+                required:
+                  - action
+                  - body
+          required:
+            - requests
   responses:
     '200':
       description: OK


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

`batch` body parameters are all required to be sent.

## 🧪 Test

CI :D
