### PR TITLE
chore: prepare release 2022-08-10

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.4.7-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.4.6-SNAPSHOT...4.4.7-SNAPSHOT)
+
+- [4c1596df](https://github.com/algolia/api-clients-automation/commit/4c1596df) fix(clients): list available regions when region is missing ([#916](https://github.com/algolia/api-clients-automation/pull/916)) by [@shortcuts](https://github.com/shortcuts/)
+- [be45fc4e](https://github.com/algolia/api-clients-automation/commit/be45fc4e) fix(specs): make `batch` body parameters required ([#917](https://github.com/algolia/api-clients-automation/pull/917)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.4.6-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.4.5-SNAPSHOT...4.4.6-SNAPSHOT)
 
 - [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.0.0-alpha.8](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.7...5.0.0-alpha.8)
+
+- [4c1596df](https://github.com/algolia/api-clients-automation/commit/4c1596df) fix(clients): list available regions when region is missing ([#916](https://github.com/algolia/api-clients-automation/pull/916)) by [@shortcuts](https://github.com/shortcuts/)
+- [be45fc4e](https://github.com/algolia/api-clients-automation/commit/be45fc4e) fix(specs): make `batch` body parameters required ([#917](https://github.com/algolia/api-clients-automation/pull/917)) by [@shortcuts](https://github.com/shortcuts/)
+- [27b78d93](https://github.com/algolia/api-clients-automation/commit/27b78d93) fix(javascript): build ([#867](https://github.com/algolia/api-clients-automation/pull/867)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.7](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.6...5.0.0-alpha.7)
 
 - [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.7"
+    "@algolia/client-common": "5.0.0-alpha.8"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.7"
+    "@algolia/client-common": "5.0.0-alpha.8"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.7"
+    "@algolia/client-common": "5.0.0-alpha.8"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.13](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.12...4.0.0-alpha.13)
+
+- [4c1596df](https://github.com/algolia/api-clients-automation/commit/4c1596df) fix(clients): list available regions when region is missing ([#916](https://github.com/algolia/api-clients-automation/pull/916)) by [@shortcuts](https://github.com/shortcuts/)
+- [be45fc4e](https://github.com/algolia/api-clients-automation/commit/be45fc4e) fix(specs): make `batch` body parameters required ([#917](https://github.com/algolia/api-clients-automation/pull/917)) by [@shortcuts](https://github.com/shortcuts/)
+- [f87ef6be](https://github.com/algolia/api-clients-automation/commit/f87ef6be) fix(php): composer dependency ([#915](https://github.com/algolia/api-clients-automation/pull/915)) by [@damcou](https://github.com/damcou/)
+
 ## [4.0.0-alpha.12](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.11...4.0.0-alpha.12)
 
 - [c2a054fa](https://github.com/algolia/api-clients-automation/commit/c2a054fa) fix(specs): allow `searchParams` in `browse` method ([#911](https://github.com/algolia/api-clients-automation/pull/911)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java-2",
     "gitRepoId": "algoliasearch-client-java-2",
-    "packageVersion": "4.4.6-SNAPSHOT",
+    "packageVersion": "4.4.7-SNAPSHOT",
     "modelFolder": "algoliasearch-core/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch-core/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.7",
+    "utilsPackageVersion": "5.0.0-alpha.8",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.12",
+    "packageVersion": "4.0.0-alpha.13",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.7"
+          "packageVersion": "5.0.0-alpha.8"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.7"
+          "packageVersion": "1.0.0-alpha.8"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.7"
+          "packageVersion": "1.0.0-alpha.8"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.7 -> **`prerelease` _(e.g. 5.0.0-alpha.8)_**
- java: 4.4.6-SNAPSHOT -> **`patch` _(e.g. 4.4.7-SNAPSHOT)_**
- php: 4.0.0-alpha.12 -> **`prerelease` _(e.g. 4.0.0-alpha.13)_**

### Skipped Commits

_(None)_