### PR TITLE
fix(javascript): do not send user-agent for Predict

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -110,11 +110,14 @@ export function createTransporter({
         : {};
 
     const queryParameters: QueryParameters = {
-      'x-algolia-agent': algoliaAgent.value,
       ...baseQueryParameters,
       ...request.queryParameters,
       ...dataQueryParameters,
     };
+
+    if (algoliaAgent.value) {
+      queryParameters['x-algolia-agent'] = algoliaAgent.value;
+    }
 
     if (requestOptions && requestOptions.queryParameters) {
       for (const key of Object.keys(requestOptions.queryParameters)) {

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavaScriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavaScriptGenerator.java
@@ -121,6 +121,9 @@ public class AlgoliaJavaScriptGenerator extends TypeScriptNodeClientCodegen {
     additionalProperties.put("isSearchClient", CLIENT.equals("search"));
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
 
+    // PRED-523 - tmp addition until the predict client supports user-agent in their API
+    additionalProperties.put("isPredictClient", CLIENT.equals("predict"));
+
     if (isAlgoliasearchClient) {
       // Files used to create the package.json of the algoliasearch package
       additionalProperties.put("analyticsVersion", Utils.getOpenApiToolsField("javascript", "analytics", "packageVersion"));

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
@@ -19,13 +19,22 @@ public class TestsClient extends TestsGenerator {
 
   @Override
   public boolean available() {
-    // no `lite` client test for now
+    // no `algoliasearch` client tests for now, only `lite`.
     if (language.equals("javascript") && client.equals("algoliasearch")) {
       return false;
     }
 
     File templates = new File("templates/" + language + "/tests/client/suite.mustache");
     return templates.exists();
+  }
+
+  public boolean isTestAvailable(String testName) {
+    // PRED-523 - tmp addition until the predict client supports user-agent in their API
+    if (client.equals("predict") && testName.equals("calls api with correct user agent")) {
+      return false;
+    }
+
+    return true;
   }
 
   @Override
@@ -50,6 +59,11 @@ public class TestsClient extends TestsGenerator {
       for (ClientTestData test : blockEntry.getValue()) {
         Map<String, Object> testOut = new HashMap<>();
         List<Object> steps = new ArrayList<>();
+
+        if (!isTestAvailable(test.testName)) {
+          continue;
+        }
+
         testOut.put("testName", test.testName);
         testOut.put("testIndex", testIndex++);
         testOut.put("autoCreateClient", test.autoCreateClient);

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -19,11 +19,14 @@ export function create{{capitalizedApiName}}({
   const transporter = createTransporter({
     hosts: getDefaultHosts({{^hasRegionalHost}}appIdOption{{/hasRegionalHost}}{{#hasRegionalHost}}regionOption{{/hasRegionalHost}}),
     ...options,
-    algoliaAgent: getAlgoliaAgent({
-      algoliaAgents,
-      client: '{{{algoliaAgent}}}',
-      version: apiClientVersion,
-    }),
+    {{! // PRED-523 - tmp addition until the predict client supports user-agent in their API }}
+    algoliaAgent: 
+      {{#isPredictClient}}
+        {...getAlgoliaAgent({ algoliaAgents, client: '{{{algoliaAgent}}}', version: apiClientVersion }), value: '' },
+      {{/isPredictClient}}
+      {{^isPredictClient}}
+        getAlgoliaAgent({ algoliaAgents, client: '{{{algoliaAgent}}}', version: apiClientVersion }),
+      {{/isPredictClient}}
     baseHeaders: {
       'content-type': 'text/plain',
       ...auth.headers(),


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-621

See https://algolia.atlassian.net/browse/PRED-523 for context

### Changes included:

The Predict API does not yet support user-agent query parameters, which makes every requests being rejected for unknown/non-parsable query parameter.

This is a not-really-pretty patch until it gets implemented, I've tried to minimize the footprint on the other clients but they all use the same requester. LMK if you have alternatives.

- JavaScript: We now send an empty string to the factory, which is not forwarded by the transporter.
- Tests: Small condition to skip the generation of the user-agent test for the Predict client.

I've added the Jira ticket in a comment near the patches until it gets resolved, to avoid forgetting to remove it.

The fix is only applied for JavaScript, as it's the only client that is recommended from the Predict team.

## 🧪 Test

`yarn docker playground javascript predict` should show an empty `algoliaAgent`, which gets removed if you do a real request (screenshot is with the `echoRequester`)

![Screenshot 2022-08-10 at 18 46 48](https://user-images.githubusercontent.com/20689156/183967383-3ef91559-9427-422d-95e6-4be264e224e4.png)

