### PR TITLE
fix(javascript): allow undefined object when all parameters are optional

### DIFF
--- a/clients/algoliasearch-client-javascript/bundlesize.config.json
+++ b/clients/algoliasearch-client-javascript/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.75KB"
+      "maxSize": "7.80KB"
     },
     {
       "path": "packages/algoliasearch/dist/lite/lite.umd.js",
@@ -26,7 +26,7 @@
     },
     {
       "path": "packages/client-query-suggestions/dist/client-query-suggestions.umd.js",
-      "maxSize": "3.65KB"
+      "maxSize": "3.70KB"
     },
     {
       "path": "packages/client-search/dist/client-search.umd.js",

--- a/templates/javascript/clients/client/api/operation/parameters.mustache
+++ b/templates/javascript/clients/client/api/operation/parameters.mustache
@@ -4,7 +4,7 @@
       {{#allParams}}
         {{paramName}},
       {{/allParams}}
-    }: {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props,
+    }: {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props{{^hasRequiredParams}} = {}{{/hasRequiredParams}},
   {{/x-create-wrapping-object}}
   {{#x-is-single-body-param}}
     {{#bodyParams}}
@@ -12,4 +12,4 @@
     {{/bodyParams}}
   {{/x-is-single-body-param}}
 {{/vendorExtensions}}
-requestOptions?: RequestOptions
+requestOptions{{^hasParams}}?{{/hasParams}}{{#hasParams}}{{#hasRequiredParams}}?{{/hasRequiredParams}}{{/hasParams}}: RequestOptions{{#hasParams}}{{^hasRequiredParams}} | undefined = undefined{{/hasRequiredParams}}{{/hasParams}}

--- a/tests/CTS/methods/requests/abtesting/listABTests.json
+++ b/tests/CTS/methods/requests/abtesting/listABTests.json
@@ -1,6 +1,14 @@
 [
   {
     "testName": "listABTests with minimal parameters",
+    "parameters": {},
+    "request": {
+      "path": "/2/abtests",
+      "method": "GET"
+    }
+  },
+  {
+    "testName": "listABTests with parameters",
     "parameters": {
       "offset": 42,
       "limit": 21

--- a/tests/CTS/methods/requests/search/getLogs.json
+++ b/tests/CTS/methods/requests/search/getLogs.json
@@ -1,5 +1,14 @@
 [
   {
+    "testName": "getLogs with minimal parameters",
+    "parameters": {},
+    "request": {
+      "path": "/1/logs",
+      "method": "GET"
+    }
+  },
+  {
+    "testName": "getLogs with parameters",
     "parameters": {
       "offset": 5,
       "length": 10,

--- a/tests/CTS/methods/requests/search/hasPendingMappings.json
+++ b/tests/CTS/methods/requests/search/hasPendingMappings.json
@@ -1,5 +1,14 @@
 [
   {
+    "testName": "hasPendingMappings with minimal parameters",
+    "parameters": {},
+    "request": {
+      "path": "/1/clusters/mapping/pending",
+      "method": "GET"
+    }
+  },
+  {
+    "testName": "hasPendingMappings with parameters",
     "parameters": {
       "getClusters": true
     },

--- a/tests/CTS/methods/requests/search/listIndices.json
+++ b/tests/CTS/methods/requests/search/listIndices.json
@@ -1,5 +1,14 @@
 [
   {
+    "testName": "listIndices with minimal parameters",
+    "parameters": {},
+    "request": {
+      "path": "/1/indexes",
+      "method": "GET"
+    }
+  },
+  {
+    "testName": "listIndices with parameters",
     "parameters": {
       "page": 8
     },

--- a/tests/CTS/methods/requests/search/listUserIds.json
+++ b/tests/CTS/methods/requests/search/listUserIds.json
@@ -1,5 +1,14 @@
 [
   {
+    "testName": "listUserIds with minimal parameters",
+    "parameters": {},
+    "request": {
+      "path": "/1/clusters/mapping",
+      "method": "GET"
+    }
+  },
+  {
+    "testName": "listUserIds with parameters",
     "parameters": {
       "page": 8,
       "hitsPerPage": 100


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: 
- https://algolia.atlassian.net/browse/APIC-590
- https://algolia.atlassian.net/browse/APIC-622

### Changes included:

Discovered during Crawler implementation.

Some methods only have optional parameters, but still require an empty object as a parameter, which is not an ideal DX.

## 🧪 Test

CI :D 
