### PR TITLE
chore: prevent linting all clients for JavaScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,7 @@
-node_modules
-dist
+**/node_modules
+**/dist
 playground
-build
+**/build
 composer.json
 tsconfig.json
 vendor

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -57,6 +57,20 @@ export async function generate(
   }
 
   for (const lang of langs) {
-    await formatter(lang, getLanguageFolder(lang), verbose);
+    let folder = getLanguageFolder(lang);
+
+    // We have scoped output folder for JavaScript which allow us to
+    // avoid linting the whole client, only the part that changed
+    if (lang === 'javascript') {
+      folder = generators.reduce((folders, gen) => {
+        if (gen.language === 'javascript') {
+          return `${folders} ${gen.output}`;
+        }
+
+        return folders;
+      }, '');
+    }
+
+    await formatter(lang, folder, verbose);
   }
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

By default we lint the main folder of the client, which makes sense for all of them except JavaScript, since clients are generated in their own subfolder.

Locally it reduce the time by a lot, idk how it affects the CI but is already better for dev (especially if you don't have an M1).

On my computer, I've went from 30s to 10s for the following: 
```
yarn docker generate javascript search
```

## 🧪 Test

1. Run generate for a few clients on `main`
2. Run generate for a few clients on this branch
3. See time of formatting decreased
