### PR TITLE
fix(javascript): use `exports` field to pick correct bundle

### DIFF
--- a/playground/javascript/node/search.ts
+++ b/playground/javascript/node/search.ts
@@ -1,4 +1,6 @@
 import { searchClient } from '@algolia/client-search';
+import { apiClientVersion } from '@algolia/client-search/src/searchClient';
+import { SearchQuery } from '@algolia/client-search/model';
 import { ApiError } from '@algolia/client-common';
 import dotenv from 'dotenv';
 
@@ -15,13 +17,18 @@ const client = searchClient(appId, apiKey);
 
 client.addAlgoliaAgent('Node playground', '0.0.1');
 
+const requests: SearchQuery[] = [
+  { indexName: searchIndex, query: searchQuery },
+];
+console.log('verison', apiClientVersion, 'requests', requests);
+
 async function testSearch() {
   try {
     const res = await client.search<{ name: string }>({
-      requests: [{ indexName: searchIndex, query: searchQuery }],
+      requests,
     });
 
-    console.log(`[OK]`, res.results[0].hits![0].name);
+    console.log(`[OK]`, res);
   } catch (e: any) {
     // Instance of
     if (e instanceof ApiError) {

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -25,7 +25,8 @@
         "import": "./dist/{{packageName}}.esm.browser.js",
         "default": "./dist/{{packageName}}.umd.js"
       }
-    }
+    },
+    "./src/*": "./src/*"
   },
   "files": [
     "dist",

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -6,11 +6,27 @@
   {{^isAlgoliasearchClient}}
   "name": "{{{npmNamespace}}}/{{packageName}}",
   "description": "JavaScript client for {{packageName}}",
-  "main": "index.js",
-  "jsdelivr": "dist/{{packageName}}.umd.js",
-  "unpkg": "dist/{{packageName}}.umd.js",
-  "module": "dist/{{packageName}}.esm.node.js",
-  "browser": "dist/{{packageName}}.umd.js",
+  "main": "./index.js",
+  "umd:main": "./dist/{{packageName}}.umd.js",
+  "jsdelivr": "./dist/{{packageName}}.umd.js",
+  "unpkg": "./dist/{{packageName}}.umd.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./dist/{{packageName}}.esm.node.js",
+        "module": "./dist/{{packageName}}.esm.node.js",
+        "require": "./dist/{{packageName}}.cjs.js",
+        "default": "./dist/{{packageName}}.cjs.js"
+      },
+      "default": {
+        "umd": "./dist/{{packageName}}.umd.js",
+        "module": "./dist/{{packageName}}.esm.browser.js",
+        "import": "./dist/{{packageName}}.esm.browser.js",
+        "default": "./dist/{{packageName}}.umd.js"
+      }
+    }
+  },
   "files": [
     "dist",
     "model",
@@ -44,7 +60,7 @@
         "require": "./dist/algoliasearch.cjs.js",
         "default": "./dist/algoliasearch.cjs.js"
       },
-      "browser": {
+      "default": {
         "umd": "./dist/algoliasearch.umd.js",
         "module": "./dist/algoliasearch.esm.browser.js",
         "import": "./dist/algoliasearch.esm.browser.js",
@@ -59,7 +75,7 @@
         "require": "./dist/lite/lite.cjs.js",
         "default": "./dist/lite/lite.cjs.js"
       },
-      "browser": {
+      "default": {
         "umd": "./dist/lite/lite.umd.js",
         "module": "./dist/lite/lite.esm.browser.js",
         "import": "./dist/lite/lite.esm.browser.js",

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -3,14 +3,13 @@
   "repository": "{{gitUserId}}/{{gitRepoId}}",
   "license": "MIT",
   "author": "Algolia",
+  "types": "./index.d.ts",
   {{^isAlgoliasearchClient}}
   "name": "{{{npmNamespace}}}/{{packageName}}",
   "description": "JavaScript client for {{packageName}}",
-  "main": "./index.js",
-  "umd:main": "./dist/{{packageName}}.umd.js",
   "jsdelivr": "./dist/{{packageName}}.umd.js",
   "unpkg": "./dist/{{packageName}}.umd.js",
-  "types": "./index.d.ts",
+  "browser": "./dist/{{packageName}}.umd.js",
   "exports": {
     ".": {
       "node": {
@@ -26,7 +25,8 @@
         "default": "./dist/{{packageName}}.umd.js"
       }
     },
-    "./src/*": "./src/*"
+    "./src/*": "./src/*.ts",
+    "./model": "./model/index.ts"
   },
   "files": [
     "dist",
@@ -52,6 +52,12 @@
   {{#isAlgoliasearchClient}}
   "name": "{{packageName}}",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
+  "jsdelivr": "./dist/algoliasearch.umd.js",
+  "unpkg": "./dist/algoliasearch.umd.js",
+  "browser": {
+    "./index.js": "./dist/algoliasearch.umd.js",
+    "./lite.js": "./dist/lite/lite.umd.js"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",
@@ -83,12 +89,6 @@
         "default": "./dist/lite/lite.umd.js"
       }
     }
-  },
-  "jsdelivr": "./dist/algoliasearch.umd.js",
-  "unpkg": "./dist/algoliasearch.umd.js",
-  "browser": {
-    "./index.js": "./dist/algoliasearch.umd.js",
-    "./lite.js": "./dist/lite/lite.umd.js"
   },
   "files": [
     "dist",
@@ -122,7 +122,6 @@
     "rollup": "2.78.1"
   },
   {{/isAlgoliasearchClient}}
-  "types": "index.d.ts",
   "engines": {
     "node": ">= 14.0.0"
   }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/PRED-530 https://algolia.atlassian.net/browse/APIC-625
Slack thread: https://algolia.slack.com/archives/C0341QDM3EG/p1660811425419539

This updates the clients exports to use the [`exports`](https://nodejs.org/api/packages.html#packages_main_entry_point_export) field.

There were issues in how clients were exported because the `module` assumed that it would get executed in a Node environment. This threw in multiple scenarios: Vite, Rollup, standard `<script type="module">`, etc.

We now rely on `exports` with two branches: `"node"` to load the Node ESM and `"default"` to load the browser ESM.

> When using environment branches, always include a `"default"` condition where possible. Providing a `"default"` condition ensures that any unknown JS environments are able to use this universal implementation, which helps avoid these JS environments from having to pretend to be existing environments in order to support packages with conditional exports. For this reason, using `"node"` and `"default"` condition branches is usually preferable to using `"node"` and `"browser"` condition branches.
>
> — From [Conditional exports in Node.js](https://nodejs.org/api/packages.html#packages_conditional_exports)

Using `"browser"` instead of `"default"` also fails with Rollup and [`@rollup/plugin-node-resolve`](https://github.com/rollup/plugins/tree/master/packages/node-resolve):

> (!) Plugin node-resolve: Could not resolve import "@algolia/predict" in /packages/predict-tools/dist/esm/PredictToolsSettings.js using exports defined in /node_modules/@algolia/predict/package.json.

For consistency, and to follow the Node recommendation, I also updated the `algoliasearch` browser export to use `"default"`.

### Changes included:

- Rely on `exports` with `"node"` and `"default"` for all API clients
- Rely on `"default"` instead of `"browser"` for `algoliasearch`

## 🧪 Test

No tests added, I believe the CI will do the work?