### PR TITLE
chore: prepare release 2022-08-23

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.11](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.10...5.0.0-alpha.11)
+
+- [3b85c763](https://github.com/algolia/api-clients-automation/commit/3b85c763) fix(javascript): use `exports` field to pick correct bundle ([#947](https://github.com/algolia/api-clients-automation/pull/947)) by [@francoischalifour](https://github.com/francoischalifour/)
+
 ## [5.0.0-alpha.10](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.9...5.0.0-alpha.10)
 
 - [51002048](https://github.com/algolia/api-clients-automation/commit/51002048) fix(javascript): allow undefined object when all parameters are optional ([#922](https://github.com/algolia/api-clients-automation/pull/922)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.10",
+  "version": "5.0.0-alpha.11",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.10",
+  "version": "5.0.0-alpha.11",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.10"
+    "@algolia/client-common": "5.0.0-alpha.11"
   },
   "devDependencies": {
     "@types/jest": "28.1.7",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.10",
+  "version": "5.0.0-alpha.11",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.10"
+    "@algolia/client-common": "5.0.0-alpha.11"
   },
   "devDependencies": {
     "@types/jest": "28.1.7",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.10",
+  "version": "5.0.0-alpha.11",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.10"
+    "@algolia/client-common": "5.0.0-alpha.11"
   },
   "devDependencies": {
     "@types/jest": "28.1.7",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.15](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.14...4.0.0-alpha.15)
+
+- [1a24f336](https://github.com/algolia/api-clients-automation/commit/1a24f336) feat(php): add iterator helper methods ([#936](https://github.com/algolia/api-clients-automation/pull/936)) by [@damcou](https://github.com/damcou/)
+
 ## [4.0.0-alpha.14](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.13...4.0.0-alpha.14)
 
 - [7d518b21](https://github.com/algolia/api-clients-automation/commit/7d518b21) docs(php): update migration guide for PHP ([#935](https://github.com/algolia/api-clients-automation/pull/935)) by [@damcou](https://github.com/damcou/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.10",
+    "utilsPackageVersion": "5.0.0-alpha.11",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.14",
+    "packageVersion": "4.0.0-alpha.15",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.10"
+          "packageVersion": "5.0.0-alpha.11"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.10"
+          "packageVersion": "1.0.0-alpha.11"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.10"
+          "packageVersion": "1.0.0-alpha.11"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.10 -> **`prerelease` _(e.g. 5.0.0-alpha.11)_**
- ~java: 4.4.7-SNAPSHOT (no commit)~
- php: 4.0.0-alpha.14 -> **`prerelease` _(e.g. 4.0.0-alpha.15)_**

### Skipped Commits

_(None)_