### PR TITLE
chore(deps): use latest version of renovate-automatic-branch action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Renovate Automatic Branch
-        uses: bodinsamuel/renovate-automatic-branch@v1
+        uses: bodinsamuel/renovate-automatic-branch@latest
         with:
           github-token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           repo-owner: algolia


### PR DESCRIPTION
## 🧭 What and Why

Github seems to use a cached version when using tag like `@v1`, and never updates.
We want to use the latest feature (like `pull-request-title`) so we use the `latest` tag, as long as @bodinsamuel doesn't sabotage his action

Wait until next friday to try it out !