### PR TITLE
fix(javascript): encode query parameters

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.test.ts
@@ -28,7 +28,7 @@ describe('api', () => {
     })) as unknown as EchoResponse;
 
     expect(req.algoliaAgent).toMatchInlineSnapshot(
-      `"Algolia%20for%20JavaScript%20(${apiClientVersion});%20Search%20(${apiClientVersion});%20Node.js%20(${process.versions.node})"`
+      `"Algolia%20for%20JavaScript%20(${apiClientVersion})%3B%20Search%20(${apiClientVersion})%3B%20Node.js%20(${process.versions.node})"`
     );
   });
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/createEchoRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/createEchoRequester.ts
@@ -44,7 +44,7 @@ export function createEchoRequester({
       data: request.data ? JSON.parse(request.data) : undefined,
       path,
       host,
-      algoliaAgent: encodeURI(algoliaAgent),
+      algoliaAgent: encodeURIComponent(algoliaAgent),
       searchParams,
     };
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
@@ -49,11 +49,11 @@ export function serializeQueryParameters(parameters: QueryParameters): string {
   return Object.keys(parameters)
     .map(
       (key) =>
-        `${key}=${
+        `${key}=${encodeURIComponent(
           isObjectOrArray(parameters[key])
             ? JSON.stringify(parameters[key])
             : parameters[key]
-        }`
+        )}`
     )
     .join('&');
 }

--- a/playground/javascript/node/predict.ts
+++ b/playground/javascript/node/predict.ts
@@ -7,8 +7,7 @@ dotenv.config({ path: '../../.env' });
 const appId = process.env.ALGOLIA_PREDICT_APP_ID || '**** APP_ID *****';
 const apiKey =
   process.env.ALGOLIA_PREDICT_API_KEY || '**** PREDICT_API_KEY *****';
-
-const userId = 'user1';
+const userId = process.env.ALGOLIA_PREDICT_USER_ID || 'user1';
 
 // Init client with appId and apiKey
 const client = predictClient(appId, apiKey, 'ew');

--- a/templates/javascript/tests/client/suite.mustache
+++ b/templates/javascript/tests/client/suite.mustache
@@ -32,7 +32,7 @@ describe('{{testType}}', () => {
         {{> client/step}}
 
         {{#testUserAgent}}
-          expect(decodeURI(result.algoliaAgent)).toMatch(/{{{match}}}/);
+          expect(decodeURIComponent(result.algoliaAgent)).toMatch(/{{{match}}}/);
         {{/testUserAgent}}
         {{#testTimeouts}}
           expect(result).toEqual(expect.objectContaining({{{match.parameters}}}));

--- a/tests/output/javascript/yarn.lock
+++ b/tests/output/javascript/yarn.lock
@@ -3663,7 +3663,7 @@ __metadata:
 
 "typescript@patch:typescript@4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=f456af"
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-629

### Changes included:

_Reported by the Predict team_

The query parameters were serialized but not encoded, I'm not sure when it has been removed since this piece of code comes from the current implementation.

It seems that on the Search API side, it either does not require the parameters to be encoded, or silently fails. Either way, it should now behave like in the current JavaScript client.

echoRequester: use same encoding/decoding than client

## 🧪 Test

search requests work:
- `yarn docker playground javascript search`

predict requests work:
- set predict hack month creds in `.env`
- `yarn docker playground javascript predict`