### PR TITLE
chore: fix JavaScript build

### DIFF
--- a/scripts/buildClients.ts
+++ b/scripts/buildClients.ts
@@ -24,15 +24,18 @@ async function buildClient(
       break;
     case 'javascript':
       const npmNamespace = getClientsConfigField('javascript', 'npmNamespace');
-      const toRun = gens
-        .map(({ additionalProperties: { packageName } }) =>
+      const packageNames = gens.map(
+        ({ additionalProperties: { packageName } }) =>
           packageName === 'algoliasearch'
             ? packageName
             : `${npmNamespace}/${packageName}`
-        )
-        .join(',');
+      );
+      const toRun =
+        packageNames.length === 1
+          ? packageNames[0]
+          : `'{${packageNames.join(',')}}'`;
 
-      await run(`yarn build:many '{${toRun}}'`, {
+      await run(`yarn build:many ${toRun}`, {
         verbose: true,
         cwd,
       });

--- a/scripts/buildClients.ts
+++ b/scripts/buildClients.ts
@@ -30,12 +30,8 @@ async function buildClient(
             ? packageName
             : `${npmNamespace}/${packageName}`
       );
-      const toRun =
-        packageNames.length === 1
-          ? packageNames[0]
-          : `'{${packageNames.join(',')}}'`;
 
-      await run(`yarn build:many ${toRun}`, {
+      await run(`yarn build:many '{${packageNames.join(',')},}'`, {
         verbose: true,
         cwd,
       });

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -126,12 +126,10 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
             ? packageName
             : `${npmNamespace}/${packageName}`;
         });
-        const packages =
-          packageNames.length === 1
-            ? packageNames[0]
-            : `'{${packageNames.join(',')}}'`;
 
-        buildCommand = `cd ${matrix[language].path} && yarn build:many ${packages}`;
+        buildCommand = `cd ${
+          matrix[language].path
+        } && yarn build:many '{${packageNames.join(',')},}'`;
         break;
       default:
         break;

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -116,7 +116,7 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
           'javascript',
           'npmNamespace'
         );
-        const packages = matrix[language].toRun.map((client) => {
+        const packageNames = matrix[language].toRun.map((client) => {
           const packageName =
             GENERATORS[`${language}-${client}`].additionalProperties
               .packageName;
@@ -126,10 +126,12 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
             ? packageName
             : `${npmNamespace}/${packageName}`;
         });
+        const packages =
+          packageNames.length === 1
+            ? packageNames[0]
+            : `'{${packageNames.join(',')}}'`;
 
-        buildCommand = `cd ${
-          matrix[language].path
-        } && yarn build:many '{${packages.join(',')}}'`;
+        buildCommand = `cd ${matrix[language].path} && yarn build:many ${packages}`;
         break;
       default:
         break;


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

See build error in https://github.com/algolia/api-clients-automation/pull/974

Glob pattern match does not work with single match (unless we add a trailing comma). We can use regular scope syntax when there's a single element to prevent this error.

This throw:
```
cd clients/algoliasearch-client-javascript && yarn build:many '{@algolia/predict}'
```

This does not:
```
cd clients/algoliasearch-client-javascript && yarn build:many @algolia/predict
// OR
cd clients/algoliasearch-client-javascript && yarn build:many '{@algolia/predict,}'
```
