### PR TITLE
fix(cts): friendly error message when test is missing

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -54,7 +54,18 @@ public class TestsRequest extends TestsGenerator {
     for (Map.Entry<String, CodegenOperation> entry : operations.entrySet()) {
       String operationId = entry.getKey();
       if (!cts.containsKey(operationId)) {
-        throw new CTSException("operationId " + operationId + " does not exist in the spec");
+        throw new CTSException(
+          "operationId '" +
+          operationId +
+          "' does not exist in the tests suite, please create the file:" +
+          " 'tests/CTS/methods/requests/" +
+          client +
+          "/" +
+          operationId +
+          ".json'.\n" +
+          "You can read more on the documentation:" +
+          " https://api-clients-automation.netlify.app/docs/contributing/testing/common-test-suite"
+        );
       }
       Request[] op = cts.get(operationId);
 


### PR DESCRIPTION
## 🧭 What and Why

When a new method is added to the spec, we check that there is a corresponding request test, but the error message was backward.
Now it's: 
`operationId 'getMachin' does not exist in the tests suite, please create the file 'tests/CTS/methods/requests/client/getMachin.json'`

## 🧪 Test

Remove a test from the CTS
