### PR TITLE
fix(cts): friendly error message when a paremeter is not recognized

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
@@ -318,7 +318,10 @@ public class ParametersWithDataType {
             entry.getKey() +
             "' not found in '" +
             paramName +
-            "'. You might have a type conflict in the spec for '" +
+            "'. Available properties are: " +
+            spec.getVars().stream().map(v -> v.baseName).collect(Collectors.joining(", ")) +
+            (spec.getAdditionalPropertiesIsAnyType() ? " (and any additional properties)" : "") +
+            ". Or you might have a type conflict in the spec for '" +
             baseType +
             "'"
           );
@@ -545,6 +548,7 @@ public class ParametersWithDataType {
 
         // Somehow this is not yet enough
         if (oneOf != null && !oneOf.isEmpty()) {
+          System.out.println("Choosing the first oneOf by default: " + oneOf.get(0).name + " (this won't stay correct forever)");
           return oneOf.get(0);
         }
       }


### PR DESCRIPTION
## 🧭 What and Why

Friendly error message when a parameter is not recognized in the CTS, proposing what's accepted.
It can be confusing when it comes from a oneOf because we infer it's type before, and then display all the possibilities, it could also be a wrong match.
Also warning message for list oneOf, which are not well supported.

## 🧪 Test

Change the name of a param.