### PR TITLE
chore: prepare release 2022-09-01

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [80724c1f](https://github.com/algolia/api-clients-automation/commit/80724c1f) feat(specs): create new methods ([#974](https://github.com/algolia/api-clients-automation/pull/974)) by [@bengreenbank](https://github.com/bengreenbank/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [fbe774da](https://github.com/algolia/api-clients-automation/commit/fbe774da) docs(java): document browse and waitForApiKey ([#956](https://github.com/algolia/api-clients-automation/pull/956)) by [@millotp](https://github.com/millotp/)
 - [68ff7ee4](https://github.com/algolia/api-clients-automation/commit/68ff7ee4) feat(java): browse objects/synonyms/rules ([#952](https://github.com/algolia/api-clients-automation/pull/952)) by [@millotp](https://github.com/millotp/)
 - [a54e901f](https://github.com/algolia/api-clients-automation/commit/a54e901f) fix(java): freeze snapshot version to 4.0.0 ([#955](https://github.com/algolia/api-clients-automation/pull/955)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0-alpha.15](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.14...5.0.0-alpha.15)
+
+- [14d22254](https://github.com/algolia/api-clients-automation/commit/14d22254) fix(javascript): update Predict models error spec ([#980](https://github.com/algolia/api-clients-automation/pull/980)) by [@francoischalifour](https://github.com/francoischalifour/)
+- [80724c1f](https://github.com/algolia/api-clients-automation/commit/80724c1f) feat(specs): create new methods ([#974](https://github.com/algolia/api-clients-automation/pull/974)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [5.0.0-alpha.14](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.13...5.0.0-alpha.14)
 
 - [0df4fb28](https://github.com/algolia/api-clients-automation/commit/0df4fb28) fix(javascript): encode query parameters ([#973](https://github.com/algolia/api-clients-automation/pull/973)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.14",
+  "version": "5.0.0-alpha.15",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.14",
+  "version": "5.0.0-alpha.15",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.14"
+    "@algolia/client-common": "5.0.0-alpha.15"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.14",
+  "version": "5.0.0-alpha.15",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.14"
+    "@algolia/client-common": "5.0.0-alpha.15"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.14",
+  "version": "5.0.0-alpha.15",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.14"
+    "@algolia/client-common": "5.0.0-alpha.15"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.16](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.15...4.0.0-alpha.16)
+
+- [80724c1f](https://github.com/algolia/api-clients-automation/commit/80724c1f) feat(specs): create new methods ([#974](https://github.com/algolia/api-clients-automation/pull/974)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [4.0.0-alpha.15](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.14...4.0.0-alpha.15)
 
 - [1a24f336](https://github.com/algolia/api-clients-automation/commit/1a24f336) feat(php): add iterator helper methods ([#936](https://github.com/algolia/api-clients-automation/pull/936)) by [@damcou](https://github.com/damcou/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.14",
+    "utilsPackageVersion": "5.0.0-alpha.15",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.15",
+    "packageVersion": "4.0.0-alpha.16",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.14"
+          "packageVersion": "5.0.0-alpha.15"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.14"
+          "packageVersion": "1.0.0-alpha.15"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.14"
+          "packageVersion": "1.0.0-alpha.15"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.14 -> **`prerelease` _(e.g. 5.0.0-alpha.15)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.15 -> **`prerelease` _(e.g. 4.0.0-alpha.16)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: add CODEOWNERS (#979)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - fix(cts): friendly error message when a paremeter is not recognized (#978)
</details>