### PR TITLE
fix(specs): fix funnel stage type casing

### DIFF
--- a/specs/predict/responses/UserProfile.yml
+++ b/specs/predict/responses/UserProfile.yml
@@ -10,7 +10,7 @@ userProfile:
       title: predictions
       properties:
         funnel_stage:
-          $ref: '#/predictionsfunnelStage'
+          $ref: '#/predictionsFunnelStage'
         order_value:
           $ref: '#/predictionsOrderValue'
         affinities:
@@ -57,7 +57,7 @@ error:
   required:
     - error
 
-predictionsfunnelStage:
+predictionsFunnelStage:
   oneOf:
     - $ref: '#/funnelStageSuccess'
     - $ref: '#/error'


### PR DESCRIPTION
## 🧭 What and Why

In #980 I forgot a capital letter for `predictionsFunnelStage`, which gets exported as the `PredictionsFunnelStage` type.

## 🧪 Test

None added.