### PR TITLE
chore: fix `algoliasearch` run condition

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -229,7 +229,7 @@ jobs:
         run: cd ${{ matrix.client.path }} && yarn test:size
 
       - name: Run JavaScript 'algoliasearch' client tests
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'javascript' && contains(matrix.client.buildCommand,'algoliasearch') }}
         run: cd ${{ matrix.client.path }} && yarn workspace algoliasearch test
 
       - name: Remove previous CTS output


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

See https://github.com/algolia/api-clients-automation/runs/8137375163?check_suite_focus=true on main

CI tries to run `algoliasearch` tests when not needed, which makes the CI fail as the client isn't built.
