### PR TITLE
chore: prepare release 2022-09-01

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.16](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.15...5.0.0-alpha.16)
+
+- [988040c4](https://github.com/algolia/api-clients-automation/commit/988040c4) fix(javascript): fix funnel stage type casing ([#982](https://github.com/algolia/api-clients-automation/pull/982)) by [@francoischalifour](https://github.com/francoischalifour/)
+
 ## [5.0.0-alpha.15](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.14...5.0.0-alpha.15)
 
 - [14d22254](https://github.com/algolia/api-clients-automation/commit/14d22254) fix(javascript): update Predict models error spec ([#980](https://github.com/algolia/api-clients-automation/pull/980)) by [@francoischalifour](https://github.com/francoischalifour/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.15",
+  "version": "5.0.0-alpha.16",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.15",
+  "version": "5.0.0-alpha.16",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.15"
+    "@algolia/client-common": "5.0.0-alpha.16"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.15",
+  "version": "5.0.0-alpha.16",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.15"
+    "@algolia/client-common": "5.0.0-alpha.16"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.15",
+  "version": "5.0.0-alpha.16",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.15"
+    "@algolia/client-common": "5.0.0-alpha.16"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.15",
+    "utilsPackageVersion": "5.0.0-alpha.16",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.15"
+          "packageVersion": "5.0.0-alpha.16"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.15"
+          "packageVersion": "1.0.0-alpha.16"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.15"
+          "packageVersion": "1.0.0-alpha.16"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.15 -> **`prerelease` _(e.g. 5.0.0-alpha.16)_**
- ~java: 4.0.0-SNAPSHOT (no commit)~
- ~php: 4.0.0-alpha.16 (no commit)~

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: fix `algoliasearch` run condition (#983)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  
</details>