### PR TITLE
chore(deps): fix version of bodinsamuel/renovate-automatic-branch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Renovate Automatic Branch
-        uses: bodinsamuel/renovate-automatic-branch@latest
+        uses: bodinsamuel/renovate-automatic-branch@1.0.8
         with:
           github-token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           repo-owner: algolia


### PR DESCRIPTION
## 🧭 What and Why

The `latest` tag seems to not be automatically generated, so we fix it to the current latest `1.0.8`.
