### PR TITLE
feat(specs): update predict client API URL

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
@@ -106,7 +106,7 @@ public class AlgoliaCTSGenerator extends DefaultCodegen {
       bundle.put("client", Utils.createClientName(importClientName, language) + "Client");
       bundle.put("clientPrefix", Utils.createClientName(importClientName, language));
       bundle.put("hasRegionalHost", hasRegionalHost);
-      bundle.put("defaultRegion", client.equals("predict") ? "ew" : "us");
+      bundle.put("defaultRegion", client.equals("predict") ? "eu" : "us");
       bundle.put("lambda", lambda);
 
       ctsManager.addDataToBundle(bundle);

--- a/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
@@ -88,9 +88,16 @@ public class AlgoliaCTSGenerator extends DefaultCodegen {
 
       Object lambda = objs.get("lambda");
       List<CodegenServer> servers = (List<CodegenServer>) objs.get("servers");
-      boolean hasRegionalHost = servers
-        .stream()
-        .anyMatch(server -> server.variables.stream().anyMatch(variable -> variable.name.equals("region")));
+      CodegenServerVariable regionVariable = null;
+      outerLoop:for (CodegenServer server : servers) {
+        for (CodegenServerVariable var : server.variables) {
+          if (var.name.equals("region")) {
+            regionVariable = var;
+            break outerLoop;
+          }
+        }
+      }
+      boolean hasRegionalHost = regionVariable != null;
 
       Map<String, Object> bundle = objs;
       bundle.clear();
@@ -106,7 +113,9 @@ public class AlgoliaCTSGenerator extends DefaultCodegen {
       bundle.put("client", Utils.createClientName(importClientName, language) + "Client");
       bundle.put("clientPrefix", Utils.createClientName(importClientName, language));
       bundle.put("hasRegionalHost", hasRegionalHost);
-      bundle.put("defaultRegion", client.equals("predict") ? "eu" : "us");
+      if (hasRegionalHost) {
+        bundle.put("defaultRegion", regionVariable.defaultValue);
+      }
       bundle.put("lambda", lambda);
 
       ctsManager.addDataToBundle(bundle);

--- a/playground/javascript/node/predict.ts
+++ b/playground/javascript/node/predict.ts
@@ -10,7 +10,7 @@ const apiKey =
 const userId = process.env.ALGOLIA_PREDICT_USER_ID || 'user1';
 
 // Init client with appId and apiKey
-const client = predictClient(appId, apiKey, 'ew');
+const client = predictClient(appId, apiKey, 'eu');
 
 async function testPredict() {
   try {

--- a/specs/predict/spec.yml
+++ b/specs/predict/spec.yml
@@ -20,7 +20,7 @@ servers:
         description: >
           Region where your Predict data is stored and processed:
             * `eu` - Europe
-            * `us` - United States
+            * `us` - United States.
 security:
   - appId: []
     apiKey: []

--- a/specs/predict/spec.yml
+++ b/specs/predict/spec.yml
@@ -10,17 +10,17 @@ components:
     apiKey:
       $ref: '../common/securitySchemes.yml#/apiKey'
 servers:
-  - url: https://predict-api-432xa6wemq-{region}.a.run.app
+  - url: https://predict-{region}.algolia
     variables:
       region:
         enum:
-          - ue
-          - ew
-        default: ew
+          - us
+          - eu
+        default: eu
         description: >
           Region where your Predict data is stored and processed:
-            * `ew` - europe-west
-            * `ue` - us-east.
+            * `eu` - Europe
+            * `us` - United States
 security:
   - appId: []
     apiKey: []

--- a/specs/predict/spec.yml
+++ b/specs/predict/spec.yml
@@ -14,8 +14,8 @@ servers:
     variables:
       region:
         enum:
-          - us
           - eu
+          - us
         default: eu
         description: >
           Region where your Predict data is stored and processed:

--- a/specs/predict/spec.yml
+++ b/specs/predict/spec.yml
@@ -10,7 +10,7 @@ components:
     apiKey:
       $ref: '../common/securitySchemes.yml#/apiKey'
 servers:
-  - url: https://predict-{region}.algolia.com
+  - url: https://predict.{region}.algolia.com
     variables:
       region:
         enum:

--- a/specs/predict/spec.yml
+++ b/specs/predict/spec.yml
@@ -10,7 +10,7 @@ components:
     apiKey:
       $ref: '../common/securitySchemes.yml#/apiKey'
 servers:
-  - url: https://predict-{region}.algolia
+  - url: https://predict-{region}.algolia.com
     variables:
       region:
         enum:

--- a/tests/CTS/client/predict/parameters.json
+++ b/tests/CTS/client/predict/parameters.json
@@ -11,7 +11,7 @@
           "region": ""
         },
         "expected": {
-          "error": "`region` is required and must be one of the following: ue, ew"
+          "error": "`region` is required and must be one of the following: us, eu"
         }
       }
     ]
@@ -28,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` is required and must be one of the following: ue, ew"
+          "error": "`region` is required and must be one of the following: us, eu"
         }
       }
     ]
@@ -42,7 +42,7 @@
         "parameters": {
           "appId": "my-app-id",
           "apiKey": "my-api-key",
-          "region": "ew"
+          "region": "eu"
         },
         "expected": {}
       }

--- a/tests/CTS/client/predict/parameters.json
+++ b/tests/CTS/client/predict/parameters.json
@@ -11,7 +11,7 @@
           "region": ""
         },
         "expected": {
-          "error": "`region` is required and must be one of the following: us, eu"
+          "error": "`region` is required and must be one of the following: eu, us"
         }
       }
     ]
@@ -28,7 +28,7 @@
           "region": "not_a_region"
         },
         "expected": {
-          "error": "`region` is required and must be one of the following: us, eu"
+          "error": "`region` is required and must be one of the following: eu, us"
         }
       }
     ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [PRED-560](https://algolia.atlassian.net/browse/PRED-560)
Related PR: https://github.com/algolia/doc/pull/7336

### Changes included:

- Update Predict Client API URL


## 🧪 Test

New URL should be https://predict.us.algolia.com/ or https://predict.eu.algolia.com/ depending on region.