### PR TITLE
chore(scripts): always install node modules during release process

### DIFF
--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -194,10 +194,8 @@ export async function updateAPIVersions(
     if (lang === 'javascript') {
       const cwd = getLanguageFolder(lang);
 
-      if (CI) {
-        await run('yarn install', { verbose: true, cwd });
-      }
-
+      // install yarn in case some package were updated
+      await run('yarn install', { verbose: true, cwd });
       await run(`yarn release:bump ${releaseType}`, {
         verbose: CI,
         cwd,


### PR DESCRIPTION
## 🧭 What and Why

The `node_modules` inside `clients/algoliasearch-client-javascript` are required to release, but we never install them locally in reality.
