### PR TITLE
fix(specs): prefix Predict predictions success types

### DIFF
--- a/specs/predict/responses/UserProfile.yml
+++ b/specs/predict/responses/UserProfile.yml
@@ -59,10 +59,10 @@ error:
 
 predictionsFunnelStage:
   oneOf:
-    - $ref: '#/funnelStageSuccess'
+    - $ref: '#/predictionsFunnelStageSuccess'
     - $ref: '#/error'
 
-funnelStageSuccess:
+predictionsFunnelStageSuccess:
   type: object
   description: Prediction for the **funnel_stage** model.
   properties:
@@ -90,10 +90,10 @@ funnelStageSuccess:
 
 predictionsOrderValue:
   oneOf:
-    - $ref: '#/orderValueSuccess'
+    - $ref: '#/predictionsOrderValueSuccess'
     - $ref: '#/error'
 
-orderValueSuccess:
+predictionsOrderValueSuccess:
   type: object
   description: Prediction for the **order_value** model.
   properties:
@@ -109,10 +109,10 @@ orderValueSuccess:
 
 predictionsAffinities:
   oneOf:
-    - $ref: '#/affinitiesSuccess'
+    - $ref: '#/predictionsAffinitiesSuccess'
     - $ref: '#/error'
 
-affinitiesSuccess:
+predictionsAffinitiesSuccess:
   type: object
   description: Prediction for the **affinities** model.
   properties:


### PR DESCRIPTION
## 🧭 What and Why

This fixes an inconsistency in our types: it adds the `predictions` prefix to the predictions success responses.

You can [see the exported types on Paka](https://paka.dev/npm/@algolia/predict@1.0.0-alpha.20/api#ab81a3e8312849b0).

### Changes included:

- Prefix predictions success types with `predictions`

## 🧪 Test

None added.