### PR TITLE
fix(specs): update model response

### DIFF
--- a/specs/predict/responses/Models.yml
+++ b/specs/predict/responses/Models.yml
@@ -30,9 +30,9 @@ modelInstance:
     lastInference:
       type: string
       description: The date and time this model instance generated its last inference.
-    error:
+    errorMessage:
       type: string
-    status:
+    modelStatus:
       type: string
       $ref: '#/getModelInstanceConfigStatus'
   required:
@@ -49,11 +49,11 @@ modelInstance:
 
 getModelInstanceConfigStatus:
   type: string
-  enum: [pending, active, invalid, error, inactive]
+  enum: [pending, active, invalid, inactive]
   description: |
     `pending` - model has just been created and the pipelines are being set up for the first train & inference. \
-    `active` - model is running and generating prediction. \
-    `invalid` - model has failed training (ex. can’t retrieve data from source). An additional error field will be set for this status. \
+    `active` - model is running and generating predictions. \
+    `invalid` - model has failed training (ex. can’t retrieve data from source). An additional `errorMessage` field will be set for this status. \
     `inactive` - model has been deactivated from the dashboard. Pipelines still exist but they are not currently running.
 
 modelMetrics:


### PR DESCRIPTION
## 🧭 What and Why
Update Predict models response properties to avoid naming conflicts

### Changes included:
- Change from `error` to `errorMessage`
- Change from `status` to `modelStatus`

## 🧪 Test
- CTS tests remain unchanged for methods
