### PR TITLE
fix(generators): change default connection timeouts

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavaScriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavaScriptGenerator.java
@@ -16,6 +16,7 @@ public class AlgoliaJavaScriptGenerator extends TypeScriptNodeClientCodegen {
 
   private String CLIENT;
   private boolean isAlgoliasearchClient;
+  private boolean isPredictClient;
 
   @Override
   public String getName() {
@@ -28,6 +29,7 @@ public class AlgoliaJavaScriptGenerator extends TypeScriptNodeClientCodegen {
 
     CLIENT = Utils.camelize((String) additionalProperties.get("client"));
     isAlgoliasearchClient = CLIENT.equals("algoliasearch");
+    isPredictClient = CLIENT.equals("predict");
 
     // generator specific options
     setSupportsES6(true);
@@ -133,6 +135,10 @@ public class AlgoliaJavaScriptGenerator extends TypeScriptNodeClientCodegen {
       additionalProperties.put("apiName", apiName);
       additionalProperties.put("capitalizedApiName", Utils.capitalize(apiName));
       additionalProperties.put("algoliaAgent", "Lite");
+    }
+
+    if (isPredictClient) {
+      additionalProperties.put("isPredictClient", true);
     }
   }
 

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -14,15 +14,15 @@ export function {{apiName}}(
   return create{{capitalizedApiName}}({
     appId,
     apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
-    timeouts: isPredictClient ? {
+    timeouts: {{#isPredictClient}}{
       connect: 10000,
       read: DEFAULT_READ_TIMEOUT_BROWSER,
       write: DEFAULT_WRITE_TIMEOUT_BROWSER,
-    } : {
+    }{{/isPredictClient}}{{^isPredictClient}}{
       connect: DEFAULT_CONNECT_TIMEOUT_BROWSER,
       read: DEFAULT_READ_TIMEOUT_BROWSER,
       write: DEFAULT_WRITE_TIMEOUT_BROWSER,
-    },
+    }{{/isPredictClient}},
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
     authMode: 'WithinQueryParameters',

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -14,7 +14,11 @@ export function {{apiName}}(
   return create{{capitalizedApiName}}({
     appId,
     apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
-    timeouts: {
+    timeouts: isPredictClient ? {
+      connect: 10000,
+      read: DEFAULT_READ_TIMEOUT_BROWSER,
+      write: DEFAULT_WRITE_TIMEOUT_BROWSER,
+    } : {
       connect: DEFAULT_CONNECT_TIMEOUT_BROWSER,
       read: DEFAULT_READ_TIMEOUT_BROWSER,
       write: DEFAULT_WRITE_TIMEOUT_BROWSER,

--- a/templates/javascript/clients/client/builds/node.mustache
+++ b/templates/javascript/clients/client/builds/node.mustache
@@ -14,10 +14,14 @@ export function {{apiName}}(
   return create{{capitalizedApiName}}({
     appId,
     apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
-    timeouts: {
-      connect: DEFAULT_CONNECT_TIMEOUT_NODE,
-      read: DEFAULT_READ_TIMEOUT_NODE,
-      write: DEFAULT_WRITE_TIMEOUT_NODE,
+    timeouts: isPredictClient ? {
+      connect: 10000,
+      read: DEFAULT_READ_TIMEOUT_BROWSER,
+      write: DEFAULT_WRITE_TIMEOUT_BROWSER,
+    } : {
+      connect: DEFAULT_CONNECT_TIMEOUT_BROWSER,
+      read: DEFAULT_READ_TIMEOUT_BROWSER,
+      write: DEFAULT_WRITE_TIMEOUT_BROWSER,
     },
     requester: createHttpRequester(),
     algoliaAgents: [{ segment: 'Node.js', version: process.versions.node }],

--- a/templates/javascript/clients/client/builds/node.mustache
+++ b/templates/javascript/clients/client/builds/node.mustache
@@ -14,15 +14,15 @@ export function {{apiName}}(
   return create{{capitalizedApiName}}({
     appId,
     apiKey,{{#hasRegionalHost}}region,{{/hasRegionalHost}}
-    timeouts: isPredictClient ? {
+    timeouts: {{#isPredictClient}}{
       connect: 10000,
       read: DEFAULT_READ_TIMEOUT_BROWSER,
       write: DEFAULT_WRITE_TIMEOUT_BROWSER,
-    } : {
+    }{{/isPredictClient}}{{^isPredictClient}}{
       connect: DEFAULT_CONNECT_TIMEOUT_BROWSER,
       read: DEFAULT_READ_TIMEOUT_BROWSER,
       write: DEFAULT_WRITE_TIMEOUT_BROWSER,
-    },
+    }{{/isPredictClient}},
     requester: createHttpRequester(),
     algoliaAgents: [{ segment: 'Node.js', version: process.versions.node }],
     responsesCache: createNullCache(),


### PR DESCRIPTION
## 🧭 What and Why

Removing the default connection timeout from Predict client to see if this resolves an issue we are experiencing on the dashboard.

The issue is where the client times out instantly first time, but then works OK if the page is refreshed.

🎟 JIRA Ticket: n/a

### Changes included:

- Override connection timeout within the Predict client

## 🧪 Test
n/a