### PR TITLE
fix(specs): browse pagination params

### DIFF
--- a/specs/common/schemas/SearchParams.yml
+++ b/specs/common/schemas/SearchParams.yml
@@ -2,6 +2,7 @@ searchParams:
   oneOf:
     - $ref: '#/searchParamsString'
     - $ref: '#/searchParamsObject'
+    - $ref: '#/paginationParams'
 
 searchParamsObject:
   allOf:
@@ -19,6 +20,25 @@ searchParamsQuery:
   properties:
     query:
       $ref: '#/query'
+
+paginationParams:
+  type: object
+  additionalProperties: false
+  properties:
+    page:
+      $ref: '#/components/schemas/page'
+    offset:
+      type: integer
+      description: Specify the offset of the first hit to return.
+      x-categories:
+        - Pagination
+    length:
+      type: integer
+      description: Set the number of hits to retrieve (used only with offset).
+      minimum: 1
+      maximum: 1000
+      x-categories:
+        - Pagination
 
 baseSearchParamsWithoutQuery:
   type: object
@@ -72,20 +92,6 @@ baseSearchParamsWithoutQuery:
       default: count
       x-categories:
         - Faceting
-    page:
-      $ref: '#/page'
-    offset:
-      type: integer
-      description: Specify the offset of the first hit to return.
-      x-categories:
-        - Pagination
-    length:
-      type: integer
-      description: Set the number of hits to retrieve (used only with offset).
-      minimum: 1
-      maximum: 1000
-      x-categories:
-        - Pagination
     aroundLatLng:
       $ref: '#/aroundLatLng'
     aroundLatLngViaIP:

--- a/specs/common/schemas/SearchParams.yml
+++ b/specs/common/schemas/SearchParams.yml
@@ -26,7 +26,7 @@ paginationParams:
   additionalProperties: false
   properties:
     page:
-      $ref: '#/components/schemas/page'
+      $ref: '#/page'
     offset:
       type: integer
       description: Specify the offset of the first hit to return.

--- a/specs/search/paths/rules/common/schemas.yml
+++ b/specs/search/paths/rules/common/schemas.yml
@@ -85,6 +85,7 @@ consequence:
 consequenceParams:
   allOf:
     - $ref: '../../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery'
+    - $ref: '../../../../common/schemas/SearchParams.yml#/paginationParams'
     - $ref: '../../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams'
     - $ref: '#/params'
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DEX-228

### Changes included:

- List changes

Remove pagination parameters from `baseSearchParamsWithoutQuery` in order to remove them from `browseParamsObject`
Pagination options aren't available for browse

## 🧪 Test
