### PR TITLE
fix(specs): update predict model endpoint modelAttributes type

### DIFF
--- a/specs/predict/responses/Models.yml
+++ b/specs/predict/responses/Models.yml
@@ -16,7 +16,9 @@ modelInstance:
     index:
       type: string
     modelAttributes:
-      $ref: '#/modelAttributes'
+      type: array
+      items:
+        $ref: '#/modelAttributes'
     contentAttributes:
       type: array
       items:


### PR DESCRIPTION
## 🧭 What and Why
- set `modelAttributes` as array of objects

### Changes included:
- set `modelAttributes` as array of objects

## 🧪 Test
- CTS tests remain unchanged for methods
