### PR TITLE
chore: prepare release 2022-10-03

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [0ef2eab9](https://github.com/algolia/api-clients-automation/commit/0ef2eab9) fix(specs): update predict model endpoint modelAttributes type ([#1063](https://github.com/algolia/api-clients-automation/pull/1063)) by [@writeens](https://github.com/writeens/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [09a235cd](https://github.com/algolia/api-clients-automation/commit/09a235cd) fix(specs): update model response ([#1034](https://github.com/algolia/api-clients-automation/pull/1034)) by [@writeens](https://github.com/writeens/)
 
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.24](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.23...5.0.0-alpha.24)
+
+- [0ef2eab9](https://github.com/algolia/api-clients-automation/commit/0ef2eab9) fix(specs): update predict model endpoint modelAttributes type ([#1063](https://github.com/algolia/api-clients-automation/pull/1063)) by [@writeens](https://github.com/writeens/)
+
 ## [5.0.0-alpha.23](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.22...5.0.0-alpha.23)
 
 - [6ba25e25](https://github.com/algolia/api-clients-automation/commit/6ba25e25) chore(specs): setup revised predict model spec ([#1045](https://github.com/algolia/api-clients-automation/pull/1045)) by [@writeens](https://github.com/writeens/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.23",
+  "version": "5.0.0-alpha.24",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.23",
+  "version": "5.0.0-alpha.24",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.23"
+    "@algolia/client-common": "5.0.0-alpha.24"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.23",
+  "version": "5.0.0-alpha.24",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.23"
+    "@algolia/client-common": "5.0.0-alpha.24"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.23",
+  "version": "5.0.0-alpha.24",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.23"
+    "@algolia/client-common": "5.0.0-alpha.24"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.24](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.23...4.0.0-alpha.24)
+
+- [0ef2eab9](https://github.com/algolia/api-clients-automation/commit/0ef2eab9) fix(specs): update predict model endpoint modelAttributes type ([#1063](https://github.com/algolia/api-clients-automation/pull/1063)) by [@writeens](https://github.com/writeens/)
+
 ## [4.0.0-alpha.23](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.22...4.0.0-alpha.23)
 
 - [6ba25e25](https://github.com/algolia/api-clients-automation/commit/6ba25e25) chore(specs): setup revised predict model spec ([#1045](https://github.com/algolia/api-clients-automation/pull/1045)) by [@writeens](https://github.com/writeens/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.23",
+    "utilsPackageVersion": "5.0.0-alpha.24",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.23",
+    "packageVersion": "4.0.0-alpha.24",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.23"
+          "packageVersion": "5.0.0-alpha.24"
         }
       },
       "javascript-sources": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-sources",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.23"
+          "packageVersion": "1.0.0-alpha.24"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.23"
+          "packageVersion": "1.0.0-alpha.24"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.23 -> **`prerelease` _(e.g. 5.0.0-alpha.24)_**
- java: 4.0.0-SNAPSHOT -> **`patch` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.23 -> **`prerelease` _(e.g. 4.0.0-alpha.24)_**

### Skipped Commits

_(None)_