### PR TITLE
feat(specs): attributes no longer required in model instance response

### DIFF
--- a/specs/predict/responses/Models.yml
+++ b/specs/predict/responses/Models.yml
@@ -41,7 +41,6 @@ modelInstance:
     - sourceID
     - index
     - modelAttributes
-    - contentAttributes
     - lastTrained
     - lastInference
     - modelStatus

--- a/specs/predict/responses/Models.yml
+++ b/specs/predict/responses/Models.yml
@@ -40,7 +40,6 @@ modelInstance:
     - type
     - sourceID
     - index
-    - modelAttributes
     - lastTrained
     - lastInference
     - modelStatus


### PR DESCRIPTION
## 🧭 What and Why
- Content Attributes are now optional parameters in model instance responses
- Model Attributes are now optional parameters in model instance responses

### Changes included:
- Remove `contentAttributes` from list of required parameters for model instance responses
- Remove `modelAttributes` from list of required parameters for model instance responses

## 🧪 Test
- Tests remain unchanged
