### PR TITLE
feat(specs): add modelID as part of getModelMetrics response

### DIFF
--- a/specs/predict/paths/models/getModelMetrics.yml
+++ b/specs/predict/paths/models/getModelMetrics.yml
@@ -13,9 +13,16 @@ get:
         application/json:
           schema:
             title: getModelMetricsResponse
-            type: array
-            items:
-              $ref: '../../responses/Models.yml#/modelMetrics'
+            type: object
+            additionalProperties: false
+            properties:
+              modelID:
+                type: string
+                description: The ID of the model.
+              metrics:
+                type: array
+                items:
+                  $ref: '../../responses/Models.yml#/modelMetrics'
     '401':
       $ref: '../../responses/InvalidCredentials.yml'
     '404':


### PR DESCRIPTION
## 🧭 What and Why
 add `modelID` as part of `getModelMetrics` response
 [Please find spec here](https://docs.google.com/document/d/1ZiVXPqq7OzUhNQUN6gHm1bDZemGBs5I_UTPrNe__3B8/edit#heading=h.xtpurwy7k1mk)

### Changes included:
- Changing the structure of the `getModelMetrics` response (within Predict client) from
```
object[]
```
to
```
{modelID:string, metrics:object[]}
```

## 🧪 Test
CTS tests remain unchanged
