### PR TITLE
chore: prepare release 2022-12-15

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)
+- [2f456a45](https://github.com/algolia/api-clients-automation/commit/2f456a45) fix(specs): mistakes in the ingestion spec ([#1176](https://github.com/algolia/api-clients-automation/pull/1176)) by [@millotp](https://github.com/millotp/)
+- [1685ed08](https://github.com/algolia/api-clients-automation/commit/1685ed08) feat(specs): create ingestion specs ([#1100](https://github.com/algolia/api-clients-automation/pull/1100)) by [@millotp](https://github.com/millotp/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [fc7f987d](https://github.com/algolia/api-clients-automation/commit/fc7f987d) feat(specs): add appropriate type to model instance type property ([#1077](https://github.com/algolia/api-clients-automation/pull/1077)) by [@writeens](https://github.com/writeens/)
 
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.0.0-alpha.28](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.27...5.0.0-alpha.28)
+
+- [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)
+- [deac88b9](https://github.com/algolia/api-clients-automation/commit/deac88b9) feat(javascript): create ingestion client ([#1101](https://github.com/algolia/api-clients-automation/pull/1101)) by [@millotp](https://github.com/millotp/)
+- [2f456a45](https://github.com/algolia/api-clients-automation/commit/2f456a45) fix(specs): mistakes in the ingestion spec ([#1176](https://github.com/algolia/api-clients-automation/pull/1176)) by [@millotp](https://github.com/millotp/)
+- [1685ed08](https://github.com/algolia/api-clients-automation/commit/1685ed08) feat(specs): create ingestion specs ([#1100](https://github.com/algolia/api-clients-automation/pull/1100)) by [@millotp](https://github.com/millotp/)
+
 ## [5.0.0-alpha.27](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.26...5.0.0-alpha.27)
 
 - [fc7f987d](https://github.com/algolia/api-clients-automation/commit/fc7f987d) feat(specs): add appropriate type to model instance type property ([#1077](https://github.com/algolia/api-clients-automation/pull/1077)) by [@writeens](https://github.com/writeens/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.27",
+  "version": "5.0.0-alpha.28",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.27",
+  "version": "5.0.0-alpha.28",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.27"
+    "@algolia/client-common": "5.0.0-alpha.28"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.27",
+  "version": "5.0.0-alpha.28",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.27"
+    "@algolia/client-common": "5.0.0-alpha.28"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.27",
+  "version": "5.0.0-alpha.28",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.27"
+    "@algolia/client-common": "5.0.0-alpha.28"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.28](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.27...4.0.0-alpha.28)
+
+- [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)
+- [2f456a45](https://github.com/algolia/api-clients-automation/commit/2f456a45) fix(specs): mistakes in the ingestion spec ([#1176](https://github.com/algolia/api-clients-automation/pull/1176)) by [@millotp](https://github.com/millotp/)
+- [1685ed08](https://github.com/algolia/api-clients-automation/commit/1685ed08) feat(specs): create ingestion specs ([#1100](https://github.com/algolia/api-clients-automation/pull/1100)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.27](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.26...4.0.0-alpha.27)
 
 - [fc7f987d](https://github.com/algolia/api-clients-automation/commit/fc7f987d) feat(specs): add appropriate type to model instance type property ([#1077](https://github.com/algolia/api-clients-automation/pull/1077)) by [@writeens](https://github.com/writeens/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.27",
+    "utilsPackageVersion": "5.0.0-alpha.28",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.27",
+    "packageVersion": "4.0.0-alpha.28",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.27"
+          "packageVersion": "5.0.0-alpha.28"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.27"
+          "packageVersion": "1.0.0-alpha.28"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.1"
+          "packageVersion": "1.0.0-alpha.2"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.27 -> **`prerelease` _(e.g. 5.0.0-alpha.28)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.27 -> **`prerelease` _(e.g. 4.0.0-alpha.28)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2022-11-28 (#1144)
- chore(deps): dependencies 2022-11-14 (#1128)
</details>