### PR TITLE
fix(specs): Algolia Search hostnames

### DIFF
--- a/specs/search/spec.yml
+++ b/specs/search/spec.yml
@@ -10,7 +10,7 @@ components:
     apiKey:
       $ref: '../common/securitySchemes.yml#/apiKey'
 servers:
-  - url: https://{appId}.algolianet.com
+  - url: https://{appId}.algolia.net
     variables:
       appId:
         default: myAppId
@@ -26,7 +26,7 @@ servers:
     variables:
       appId:
         default: myAppId
-  - url: https://{appId}-dsn.algolianet.com
+  - url: https://{appId}-dsn.algolia.net
     variables:
       appId:
         default: myAppId


### PR DESCRIPTION
## 🧭 What and Why

This PR fixes two hostnames in the Search API spec.
This brings the API spec in line with what's used by the API clients and what's in the current documentation.

🎟 JIRA Ticket: N/A

### Changes included:

- `https://{appId}.algolianet.com` -> `https://{appId}.algolia.net`
- `https://{appId}-dsn.algolianet.com` -> `https://{appId}-dsn.algolia.net`

## 🧪 Test

N/A