### PR TITLE
chore: prepare release 2022-12-23

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [ec370af5](https://github.com/algolia/api-clients-automation/commit/ec370af5) fix(specs): new CT source input ([#1190](https://github.com/algolia/api-clients-automation/pull/1190)) by [@shortcuts](https://github.com/shortcuts/)
+- [377e091d](https://github.com/algolia/api-clients-automation/commit/377e091d) fix(specs): Algolia Search hostnames ([#1189](https://github.com/algolia/api-clients-automation/pull/1189)) by [@kai687](https://github.com/kai687/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)
 - [2f456a45](https://github.com/algolia/api-clients-automation/commit/2f456a45) fix(specs): mistakes in the ingestion spec ([#1176](https://github.com/algolia/api-clients-automation/pull/1176)) by [@millotp](https://github.com/millotp/)
 - [1685ed08](https://github.com/algolia/api-clients-automation/commit/1685ed08) feat(specs): create ingestion specs ([#1100](https://github.com/algolia/api-clients-automation/pull/1100)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.0.0-alpha.29](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.28...5.0.0-alpha.29)
+
+- [494c2b77](https://github.com/algolia/api-clients-automation/commit/494c2b77) fix(javascript): update ingestion specs ([#1192](https://github.com/algolia/api-clients-automation/pull/1192)) by [@shortcuts](https://github.com/shortcuts/)
+- [5938b05f](https://github.com/algolia/api-clients-automation/commit/5938b05f) fix(javascript): pass with no tests ([#1191](https://github.com/algolia/api-clients-automation/pull/1191)) by [@shortcuts](https://github.com/shortcuts/)
+- [ec370af5](https://github.com/algolia/api-clients-automation/commit/ec370af5) fix(specs): new CT source input ([#1190](https://github.com/algolia/api-clients-automation/pull/1190)) by [@shortcuts](https://github.com/shortcuts/)
+- [377e091d](https://github.com/algolia/api-clients-automation/commit/377e091d) fix(specs): Algolia Search hostnames ([#1189](https://github.com/algolia/api-clients-automation/pull/1189)) by [@kai687](https://github.com/kai687/)
+
 ## [5.0.0-alpha.28](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.27...5.0.0-alpha.28)
 
 - [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.28",
+  "version": "5.0.0-alpha.29",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.28",
+  "version": "5.0.0-alpha.29",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.28"
+    "@algolia/client-common": "5.0.0-alpha.29"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.28",
+  "version": "5.0.0-alpha.29",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.28"
+    "@algolia/client-common": "5.0.0-alpha.29"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.28",
+  "version": "5.0.0-alpha.29",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.28"
+    "@algolia/client-common": "5.0.0-alpha.29"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-alpha.29](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.28...4.0.0-alpha.29)
+
+- [ec370af5](https://github.com/algolia/api-clients-automation/commit/ec370af5) fix(specs): new CT source input ([#1190](https://github.com/algolia/api-clients-automation/pull/1190)) by [@shortcuts](https://github.com/shortcuts/)
+- [377e091d](https://github.com/algolia/api-clients-automation/commit/377e091d) fix(specs): Algolia Search hostnames ([#1189](https://github.com/algolia/api-clients-automation/pull/1189)) by [@kai687](https://github.com/kai687/)
+
 ## [4.0.0-alpha.28](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.27...4.0.0-alpha.28)
 
 - [19552886](https://github.com/algolia/api-clients-automation/commit/19552886) fix(clients): replace sources client with ingestion ([#1178](https://github.com/algolia/api-clients-automation/pull/1178)) by [@millotp](https://github.com/millotp/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.28",
+    "utilsPackageVersion": "5.0.0-alpha.29",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.28",
+    "packageVersion": "4.0.0-alpha.29",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.28"
+          "packageVersion": "5.0.0-alpha.29"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.28"
+          "packageVersion": "1.0.0-alpha.29"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.2"
+          "packageVersion": "1.0.0-alpha.3"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.28 -> **`prerelease` _(e.g. 5.0.0-alpha.29)_**
- java: 4.0.0-SNAPSHOT -> **`patch` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.28 -> **`prerelease` _(e.g. 4.0.0-alpha.29)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: bump docs deps (#1180)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  
</details>