### PR TITLE
feat(specs): add source json to ingestion client

### DIFF
--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -87,7 +87,7 @@ SourceUpdateResponse:
 
 SourceType:
   type: string
-  enum: ['bigcommerce', 'commercetools']
+  enum: ['bigcommerce', 'commercetools', 'json']
 
 SourceCommercetools:
   type: object
@@ -120,7 +120,23 @@ SourceBigCommerce:
   required:
     - store_hash
 
+MethodType:
+  type: string
+  enum: ['GET', 'POST']
+
+SourceJson:
+  type: object
+  additionalProperties: false
+  properties:
+    url:
+      type: string
+    method:
+      $ref: '#/MethodType'
+  required:
+    - url
+
 SourceInput:
   oneOf:
     - $ref: '#/SourceCommercetools'
     - $ref: '#/SourceBigCommerce'
+    - $ref: '#/SourceJson'


### PR DESCRIPTION
## 🧭 What and Why
This PR modify the `Ingestion` client.

Client will now be able to add a `JsonInput` when creating a new `Source`.

### Changes included:
- New enum value for source type
- New enum value for http method 