### PR TITLE
fix(specs): authenticationID is not required in source and destination

### DIFF
--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -22,7 +22,6 @@ Destination:
     - name
     - input
     - createdAt
-    - authenticationID
 
 DestinationCreate:
   type: object

--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -21,7 +21,6 @@ Source:
     - type
     - name
     - input
-    - authenticationID
     - createdAt
 
 SourceCreate:


### PR DESCRIPTION
## 🧭 What and Why
The field `authenticationID` is not required in `Source`. For example, we can setup a new Source, without authentication setup.

### Changes included:
- Remove field from required