### PR TITLE
fix(specs): make enabled nullable

### DIFF
--- a/specs/search/paths/rules/searchRules.yml
+++ b/specs/search/paths/rules/searchRules.yml
@@ -30,6 +30,7 @@ post:
               $ref: '../../../common/parameters.yml#/hitsPerPage'
             enabled:
               type: boolean
+              nullable: true
               default: null
               description: When specified, restricts matches to rules with a specific enabled status. When absent (default), all rules are retrieved, regardless of their enabled status.
             requestOptions:


### PR DESCRIPTION
## 🧭 What and Why

This PR adds the nullable property to the `enabled` field of the search rule.
The default value is `null` but the type is `boolean`.
According to [the spec](https://spec.openapis.org/oas/v3.0.2#properties) (see _default_):

> Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if type is string, then default can be "foo" but cannot be 1. 

🎟 JIRA Ticket: N/A

### Changes included:

- Add `nullable` to the `enabled` property in the `searchRulesParams` schema

## 🧪 Test
