### PR TITLE
fix(specs): example should be integer

### DIFF
--- a/specs/search/paths/advanced/getTask.yml
+++ b/specs/search/paths/advanced/getTask.yml
@@ -13,7 +13,7 @@ get:
       schema:
         type: integer
         format: int64
-        example: '13235'
+        example: 13235
   responses:
     '200':
       description: OK


### PR DESCRIPTION
## 🧭 What and Why

This PR fixes the type of the example of the `taskID` path parameter. It should be an integer, not a string.

🎟 JIRA Ticket: N/A

### Changes included:

- Change type of example of `taskID` to integer

## 🧪 Test
