### PR TITLE
fix(specs): numberOfPendingTasks is plural

### DIFF
--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -48,9 +48,13 @@ fetchedIndex:
       description: A boolean which says whether the index has pending tasks. This value is deprecated and should not be used.
     primary:
       type: string
+      nullable: true
+      default: null
       description: Only present if the index is a replica. Contains the name of the related primary index.
     replicas:
       type: array
+      nullable: true
+      default: null
       items:
         type: string
       description: Only present if the index is a primary index with replicas. Contains the names of all linked replicas.

--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -38,11 +38,13 @@ fetchedIndex:
     lastBuildTimeS:
       type: integer
       description: Last build time.
-    numberOfPendingTask:
+    numberOfPendingTasks:
       type: integer
+      default: 0
       description: Number of pending indexing operations. This value is deprecated and should not be used.
     pendingTask:
       type: boolean
+      default: false
       description: A boolean which says whether the index has pending tasks. This value is deprecated and should not be used.
     primary:
       type: string

--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -48,13 +48,9 @@ fetchedIndex:
       description: A boolean which says whether the index has pending tasks. This value is deprecated and should not be used.
     primary:
       type: string
-      nullable: true
-      default: null
       description: Only present if the index is a replica. Contains the name of the related primary index.
     replicas:
       type: array
-      nullable: true
-      default: null
       items:
         type: string
       description: Only present if the index is a primary index with replicas. Contains the names of all linked replicas.

--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -63,3 +63,4 @@ fetchedIndex:
     - fileSize
     - lastBuildTimeS
     - pendingTask
+    - numberOfPendingTasks


### PR DESCRIPTION
## 🧭 What and Why

This PR aims to improve the specs for the `listIndicesResponse` schema.

Testing the `/1/indexes` endpoint, I found that `numberOfPendingTasks` should be plural.

This PR also adds default values for `pendingTask` (`false`) and `numberOfPendingTasks` (`0`) as both values always seem to be part of the response.

🎟 JIRA Ticket: N/A

### Changes included:

- fix name of response parameter `numberOfPendingTasks`
- Add default values for `numberOfPendingTasks` and `pendingTask`
- Make `numberOfPendingTasks` required for `listIndicesResponse`
- Make `primary` and `replicas` nullable

## 🧪 Test
