### PR TITLE
fix(specs): make enabled nullable

### DIFF
--- a/specs/search/paths/rules/searchRules.yml
+++ b/specs/search/paths/rules/searchRules.yml
@@ -30,6 +30,7 @@ post:
               $ref: '../../../common/parameters.yml#/hitsPerPage'
             enabled:
               type: boolean
+              nullable: true
               default: null
               description: When specified, restricts matches to rules with a specific enabled status. When absent (default), all rules are retrieved, regardless of their enabled status.
             requestOptions:


### PR DESCRIPTION
## 🧭 What and Why

The `enabled` property has a default of `null` but wasn't declared `nullable`.
This PR addresses that.

🎟 JIRA Ticket: N/A

### Changes included:

- Make `enabled` nullable

## 🧪 Test
