### PR TITLE
fix(specs): remove input from auth list

### DIFF
--- a/specs/ingestion/common/schemas/authentication.yml
+++ b/specs/ingestion/common/schemas/authentication.yml
@@ -150,7 +150,6 @@ AuthOAuth:
     - url
     - client_id
     - client_secret
-    - scope
 
 AuthAlgolia:
   type: object

--- a/specs/ingestion/common/schemas/authentication.yml
+++ b/specs/ingestion/common/schemas/authentication.yml
@@ -10,8 +10,6 @@ Authentication:
       type: string
     platform:
       $ref: '#/PlatformType'
-    input:
-      $ref: '#/AuthInput'
     createdAt:
       $ref: './common.yml#/createdAt'
     updatedAt:
@@ -22,6 +20,18 @@ Authentication:
     - name
     - input
     - createdAt
+
+AuthenticationWithInput:
+  allOf:
+    - $ref: '#/Authentication'
+    - type: object
+      title: authenticationInput
+      additionalProperties: false
+      properties:
+        input:
+          $ref: '#/AuthInput'
+      required:
+        - input
 
 AuthenticationCreate:
   type: object

--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -98,10 +98,10 @@ SourceCommercetools:
         type: string
     locales:
       type: array
+      description: >
+        Array of locales that must match the following pattern: ^[a-z]{2}(-[A-Z]{2})?$. For example ["fr-FR", "en"].
       items:
         type: string
-        description: >
-          The string must match the following pattern: ^[a-z]{2}(-[A-Z]{2})?$. For example "fr-FR" or "en".
     url:
       type: string
     projectKey:

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -39,7 +39,7 @@ TaskCreate:
     destinationID:
       type: string
     trigger:
-      $ref: '#/Trigger'
+      $ref: '#/TriggerInput'
     action:
       $ref: '#/ActionType'
     enabled:
@@ -72,7 +72,7 @@ TaskUpdate:
     destinationID:
       type: string
     trigger:
-      $ref: '#/Trigger'
+      $ref: '#/TriggerInput'
     enabled:
       type: boolean
 
@@ -91,6 +91,17 @@ TaskUpdateResponse:
 ActionType:
   type: string
   enum: ['replace', 'save', 'delete']
+
+TriggerInput:
+  type: object
+  additionalProperties: false
+  properties:
+    type:
+      $ref: '#/TriggerType'
+    cron:
+      type: string
+  required:
+    - type
 
 Trigger:
   type: object

--- a/specs/ingestion/paths/authentications/authenticationID.yml
+++ b/specs/ingestion/paths/authentications/authenticationID.yml
@@ -12,7 +12,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: '../../common/schemas/authentication.yml#/Authentication'
+            $ref: '../../common/schemas/authentication.yml#/AuthenticationWithInput'
     '400':
       $ref: '../../../common/responses/BadRequest.yml'
 


### PR DESCRIPTION
## 🧭 What and Why

The auth list endpoint doesn't return the `input` field.
Fixed the `description` for locales.
Make `scope` not required.