### PR TITLE
feat(javascript): add error to APIError if possible

### DIFF
--- a/clients/algoliasearch-client-javascript/bundlesize.config.json
+++ b/clients/algoliasearch-client-javascript/bundlesize.config.json
@@ -2,47 +2,47 @@
   "files": [
     {
       "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-      "maxSize": "7.80KB"
+      "maxSize": "8.00KB"
     },
     {
       "path": "packages/algoliasearch/dist/lite/lite.umd.js",
-      "maxSize": "3.50KB"
-    },
-    {
-      "path": "packages/client-abtesting/dist/client-abtesting.umd.js",
-      "maxSize": "3.65KB"
-    },
-    {
-      "path": "packages/client-analytics/dist/client-analytics.umd.js",
-      "maxSize": "4.30KB"
-    },
-    {
-      "path": "packages/client-insights/dist/client-insights.umd.js",
-      "maxSize": "3.50KB"
-    },
-    {
-      "path": "packages/client-personalization/dist/client-personalization.umd.js",
-      "maxSize": "3.60KB"
-    },
-    {
-      "path": "packages/client-query-suggestions/dist/client-query-suggestions.umd.js",
       "maxSize": "3.70KB"
     },
     {
+      "path": "packages/client-abtesting/dist/client-abtesting.umd.js",
+      "maxSize": "3.85KB"
+    },
+    {
+      "path": "packages/client-analytics/dist/client-analytics.umd.js",
+      "maxSize": "4.50KB"
+    },
+    {
+      "path": "packages/client-insights/dist/client-insights.umd.js",
+      "maxSize": "3.65KB"
+    },
+    {
+      "path": "packages/client-personalization/dist/client-personalization.umd.js",
+      "maxSize": "3.80KB"
+    },
+    {
+      "path": "packages/client-query-suggestions/dist/client-query-suggestions.umd.js",
+      "maxSize": "3.85KB"
+    },
+    {
       "path": "packages/client-search/dist/client-search.umd.js",
-      "maxSize": "6.35KB"
+      "maxSize": "6.55KB"
     },
     {
       "path": "packages/ingestion/dist/ingestion.umd.js",
-      "maxSize": "3.50KB"
+      "maxSize": "4.30KB"
     },
     {
       "path": "packages/predict/dist/predict.umd.js",
-      "maxSize": "3.50KB"
+      "maxSize": "4.20KB"
     },
     {
       "path": "packages/recommend/dist/recommend.umd.js",
-      "maxSize": "3.50KB"
+      "maxSize": "3.70KB"
     }
   ]
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -71,6 +71,7 @@ export type DetailedError = {
   details?: DetailedErrorWithMessage[] | DetailedErrorWithTypeID[];
 };
 
+// DetailedApiError is only used by the ingestion client to return more informative error, other clients will use ApiClient.
 export class DetailedApiError extends ApiError {
   error: DetailedError;
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -55,11 +55,20 @@ export class DeserializationError extends AlgoliaError {
   }
 }
 
-type DetailedError = {
+export type DetailedErrorWithMessage = {
+  message: string;
+  label: string;
+};
+
+export type DetailedErrorWithTypeID = {
+  id: string;
+  type: string;
+  name?: string;
+};
+
+export type DetailedError = {
   code: string;
-  details?:
-    | Array<{ id: string; type: string; name?: string }>
-    | Array<{ message: string; label: string }>;
+  details?: DetailedErrorWithMessage[] | DetailedErrorWithTypeID[];
 };
 
 export class DetailedApiError extends ApiError {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -35,8 +35,13 @@ export class RetryError extends ErrorWithStackTrace {
 export class ApiError extends ErrorWithStackTrace {
   status: number;
 
-  constructor(message: string, status: number, stackTrace: StackFrame[]) {
-    super(message, stackTrace, 'ApiError');
+  constructor(
+    message: string,
+    status: number,
+    stackTrace: StackFrame[],
+    name = 'ApiError'
+  ) {
+    super(message, stackTrace, name);
     this.status = status;
   }
 }
@@ -47,5 +52,26 @@ export class DeserializationError extends AlgoliaError {
   constructor(message: string, response: Response) {
     super(message, 'DeserializationError');
     this.response = response;
+  }
+}
+
+type DetailedError = {
+  code: string;
+  details?:
+    | Array<{ id: string; type: string; name?: string }>
+    | Array<{ message: string; label: string }>;
+};
+
+export class DetailedApiError extends ApiError {
+  error: DetailedError;
+
+  constructor(
+    message: string,
+    status: number,
+    error: DetailedError,
+    stackTrace: StackFrame[]
+  ) {
+    super(message, status, stackTrace, 'DetailedApiError');
+    this.error = error;
   }
 }


### PR DESCRIPTION
## 🧭 What and Why

Create new error type `DetailedApiError` that will be used if an `error` is present in the response, mostly used by the ingestion API.