### PR TITLE
feat(java): remove predict client temporarely

### DIFF
--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -86,9 +86,6 @@
       "java-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-java-2"
       },
-      "java-predict": {
-        "output": "#{cwd}/clients/algoliasearch-client-java-2"
-      },
       "php-search": {
         "output": "#{cwd}/clients/algoliasearch-client-php"
       },


### PR DESCRIPTION
## 🧭 What and Why

The java CTS is not handling well `allOf` property, and runs into stack overflow issue.
We can disable it for now and add back the predict client once the CTS is fixed.