### PR TITLE
chore: prepare release 2023-02-03

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.41](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.40...5.0.0-alpha.41)
+
+- [dc5a22dd](https://github.com/algolia/api-clients-automation/commit/dc5a22dd) feat(javascript): improve on task trigger type guards ([#1286](https://github.com/algolia/api-clients-automation/pull/1286)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [5.0.0-alpha.40](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.39...5.0.0-alpha.40)
 
 - [91f21487](https://github.com/algolia/api-clients-automation/commit/91f21487) feat(javascript): add task trigger type guards ([#1280](https://github.com/algolia/api-clients-automation/pull/1280)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.40",
+  "version": "5.0.0-alpha.41",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.40",
+  "version": "5.0.0-alpha.41",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.40"
+    "@algolia/client-common": "5.0.0-alpha.41"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.40",
+  "version": "5.0.0-alpha.41",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.40"
+    "@algolia/client-common": "5.0.0-alpha.41"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.40",
+  "version": "5.0.0-alpha.41",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.40"
+    "@algolia/client-common": "5.0.0-alpha.41"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.40",
+    "utilsPackageVersion": "5.0.0-alpha.41",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.40"
+          "packageVersion": "5.0.0-alpha.41"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.40"
+          "packageVersion": "1.0.0-alpha.41"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.14"
+          "packageVersion": "1.0.0-alpha.15"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.40 -> **`prerelease` _(e.g. 5.0.0-alpha.41)_**
- ~java: 4.0.0-SNAPSHOT (no commit)~
- ~php: 4.0.0-alpha.39 (no commit)~

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 in /clients/algoliasearch-client-javascript (#1283)
- chore(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 in /tests/output/javascript (#1282)
- chore(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 (#1285)
- chore(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 in /website (#1284)
- chore(deps): bump ua-parser-js from 0.7.31 to 0.7.33 in /website (#1264)
</details>