### PR TITLE
fix(specs): rename task type to `onDemand`

### DIFF
--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -137,10 +137,10 @@ TriggerType:
   type: string
   description: >
     The type of the task reflect how it can be used:
-      - on_demand: a task that runs manually
+      - onDemand: a task that runs manually
       - schedule: a task that runs regularly, following a given cron expression
       - subscription: a task that runs after a subscription event is received from an integration (e.g. Webhook).
-  enum: ['on_demand', 'schedule', 'subscription']
+  enum: ['onDemand', 'schedule', 'subscription']
 
 # schedule trigger
 
@@ -195,7 +195,7 @@ ScheduleTrigger:
 OnDemandTriggerType:
   type: string
   description: A task which is manually executed via the run task endpoint.
-  enum: ['on_demand']
+  enum: ['onDemand']
 
 OnDemandTriggerInput:
   type: object

--- a/specs/ingestion/common/taskParameters.yml
+++ b/specs/ingestion/common/taskParameters.yml
@@ -55,4 +55,4 @@ triggerType:
     type: array
     items:
       $ref: './schemas/task.yml#/TriggerType'
-    example: on_demand,schedule
+    example: onDemand,schedule

--- a/templates/javascript/clients/client/api/guards.mustache
+++ b/templates/javascript/clients/client/api/guards.mustache
@@ -8,7 +8,7 @@
 export function isOnDemandTrigger(
   trigger: Trigger
 ): trigger is OnDemandTrigger {
-  return trigger.type === 'on_demand';
+  return trigger.type === 'onDemand';
 }
 
 /**


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

the `on_demand` property have been renamed to `onDemand`

## 🧪 Test

- 
