### PR TITLE
fix(specs): remove segment version

### DIFF
--- a/specs/predict/responses/Segment.yml
+++ b/specs/predict/responses/Segment.yml
@@ -65,15 +65,12 @@ createSegmentResponse:
 segment:
   type: object
   required:
-    - version
     - segmentID
     - name
     - conditions
     - segmentStatus
     - type
   properties:
-    version:
-      $ref: '#/segmentVersion'
     segmentID:
       $ref: '#/segmentID'
     name:
@@ -101,12 +98,6 @@ segmentType:
   enum:
     - computed
     - custom
-
-segmentVersion:
-  type: number
-  format: float
-  description: The segment syntax version.
-  example: 1.1
 
 segmentID:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

The Predict API doesn't support a segment version yet. This will be added in a later iteration.

🎟 JIRA Ticket: n/a

### Changes included:

- Remove `version` from `Segment` response.

## 🧪 Test

n/a
