### PR TITLE
chore: prepare release 2023-02-14

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [f7f0fbe8](https://github.com/algolia/api-clients-automation/commit/f7f0fbe8) feat(specs): make DELETE endpoints return a 200 OK ([#1314](https://github.com/algolia/api-clients-automation/pull/1314)) by [@Fluf22](https://github.com/Fluf22/)
+- [cb3001dd](https://github.com/algolia/api-clients-automation/commit/cb3001dd) fix(specs): remove segment version ([#1313](https://github.com/algolia/api-clients-automation/pull/1313)) by [@bengreenbank](https://github.com/bengreenbank/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [d3aead8a](https://github.com/algolia/api-clients-automation/commit/d3aead8a) refactor(specs): new predict segment condition syntax ([#1202](https://github.com/algolia/api-clients-automation/pull/1202)) by [@bengreenbank](https://github.com/bengreenbank/)
 - [bad11072](https://github.com/algolia/api-clients-automation/commit/bad11072) feat(specs): remove content attributes from models [PRED-982] ([#1226](https://github.com/algolia/api-clients-automation/pull/1226)) by [@bengreenbank](https://github.com/bengreenbank/)
 

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0-alpha.46](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.45...5.0.0-alpha.46)
+
+- [f7f0fbe8](https://github.com/algolia/api-clients-automation/commit/f7f0fbe8) feat(specs): make DELETE endpoints return a 200 OK ([#1314](https://github.com/algolia/api-clients-automation/pull/1314)) by [@Fluf22](https://github.com/Fluf22/)
+- [cb3001dd](https://github.com/algolia/api-clients-automation/commit/cb3001dd) fix(specs): remove segment version ([#1313](https://github.com/algolia/api-clients-automation/pull/1313)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [5.0.0-alpha.45](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.44...5.0.0-alpha.45)
 
 - [d3aead8a](https://github.com/algolia/api-clients-automation/commit/d3aead8a) refactor(specs): new predict segment condition syntax ([#1202](https://github.com/algolia/api-clients-automation/pull/1202)) by [@bengreenbank](https://github.com/bengreenbank/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.45",
+  "version": "5.0.0-alpha.46",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.45",
+  "version": "5.0.0-alpha.46",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.45"
+    "@algolia/client-common": "5.0.0-alpha.46"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.45",
+  "version": "5.0.0-alpha.46",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.45"
+    "@algolia/client-common": "5.0.0-alpha.46"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.45",
+  "version": "5.0.0-alpha.46",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.45"
+    "@algolia/client-common": "5.0.0-alpha.46"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-alpha.44](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.43...4.0.0-alpha.44)
+
+- [f7f0fbe8](https://github.com/algolia/api-clients-automation/commit/f7f0fbe8) feat(specs): make DELETE endpoints return a 200 OK ([#1314](https://github.com/algolia/api-clients-automation/pull/1314)) by [@Fluf22](https://github.com/Fluf22/)
+- [cb3001dd](https://github.com/algolia/api-clients-automation/commit/cb3001dd) fix(specs): remove segment version ([#1313](https://github.com/algolia/api-clients-automation/pull/1313)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [4.0.0-alpha.43](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.42...4.0.0-alpha.43)
 
 - [d3aead8a](https://github.com/algolia/api-clients-automation/commit/d3aead8a) refactor(specs): new predict segment condition syntax ([#1202](https://github.com/algolia/api-clients-automation/pull/1202)) by [@bengreenbank](https://github.com/bengreenbank/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.45",
+    "utilsPackageVersion": "5.0.0-alpha.46",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.43",
+    "packageVersion": "4.0.0-alpha.44",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.45"
+          "packageVersion": "5.0.0-alpha.46"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.45"
+          "packageVersion": "1.0.0-alpha.46"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.19"
+          "packageVersion": "1.0.0-alpha.20"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.45 -> **`prerelease` _(e.g. 5.0.0-alpha.46)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.43 -> **`prerelease` _(e.g. 4.0.0-alpha.44)_**

### Skipped Commits

_(None)_