### PR TITLE
fix(specs): update Predict Segment operators to textual format

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
@@ -125,23 +125,6 @@ public class AlgoliaJavaGenerator extends JavaClientCodegen {
       return super.toEnumVarName(value, datatype);
     }
 
-    // predict has some enums that are operators, we internally convert them to prevent wrong
-    // assumptions from the generator/templates.
-    switch (value) {
-      case "<":
-        return "LT";
-      case ">":
-        return "GT";
-      case "=":
-        return "EQ";
-      case "<=":
-        return "LTE";
-      case ">=":
-        return "GTE";
-      case "!=":
-        return "NEQ";
-    }
-
     if (!value.matches("[A-Z0-9_]+")) {
       // convert camelCase77String to CAMEL_CASE_77_STRING
       return value.replaceAll("-", "_").replaceAll("(.+?)([A-Z]|[0-9])", "$1_$2").toUpperCase(Locale.ROOT);

--- a/specs/predict/responses/Segment.yml
+++ b/specs/predict/responses/Segment.yml
@@ -305,22 +305,22 @@ segmentPropertyFilterValue:
 segmentFilterOperatorBoolean:
   description: The operator used on the boolean filter value.
   type: string
-  default: =
+  default: 'EQ'
   enum:
-    - =
-    - '!='
+    - 'EQ'
+    - 'NEQ'
 
 segmentFilterOperatorNumerical:
   description: The operator used on the numerical filter value.
   type: string
-  default: =
+  default: 'EQ'
   enum:
-    - =
-    - '!='
-    - '>'
-    - '>='
-    - <
-    - <=
+    - 'EQ'
+    - 'NEQ'
+    - 'GT'
+    - 'GTE'
+    - 'LT'
+    - 'LTE'
 
 segmentFilterProbability:
   description: Probability of the filter.
@@ -328,11 +328,11 @@ segmentFilterProbability:
   minProperties: 1
   maxProperties: 2
   properties:
-    lt:
+    LT:
       type: number
-    lte:
+    LTE:
       type: number
-    gt:
+    GT:
       type: number
-    gte:
+    GTE:
       type: number

--- a/tests/CTS/methods/requests/predict/createSegment.json
+++ b/tests/CTS/methods/requests/predict/createSegment.json
@@ -53,7 +53,10 @@
               {
                 "operator": "EQ",
                 "value": "red",
-                "probability": { "GTE": 0.5, "LTE": 1 }
+                "probability": {
+                  "GTE": 0.5,
+                  "LTE": 1
+                }
               }
             ]
           }
@@ -74,7 +77,10 @@
                 {
                   "operator": "EQ",
                   "value": "red",
-                  "probability": { "GTE": 0.5, "LTE": 1 }
+                  "probability": {
+                    "GTE": 0.5,
+                    "LTE": 1
+                  }
                 }
               ]
             }

--- a/tests/CTS/methods/requests/predict/createSegment.json
+++ b/tests/CTS/methods/requests/predict/createSegment.json
@@ -10,7 +10,7 @@
             "name": "predictions.order_value",
             "filters": [
               {
-                "operator": ">",
+                "operator": "GT",
                 "value": 200
               }
             ]
@@ -30,8 +30,51 @@
               "name": "predictions.order_value",
               "filters": [
                 {
-                  "operator": ">",
+                  "operator": "GT",
                   "value": 200
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "testName": "create segment with filter probability",
+    "parameters": {
+      "name": "segment1",
+      "conditions": {
+        "operator": "AND",
+        "operands": [
+          {
+            "name": "predictions.affinities.color",
+            "filters": [
+              {
+                "operator": "EQ",
+                "value": "red",
+                "probability": { "GTE": 0.5, "LTE": 1 }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "request": {
+      "path": "/1/segments",
+      "method": "POST",
+      "body": {
+        "name": "segment1",
+        "conditions": {
+          "operator": "AND",
+          "operands": [
+            {
+              "name": "predictions.affinities.color",
+              "filters": [
+                {
+                  "operator": "EQ",
+                  "value": "red",
+                  "probability": { "GTE": 0.5, "LTE": 1 }
                 }
               ]
             }

--- a/tests/CTS/methods/requests/predict/updateSegment.json
+++ b/tests/CTS/methods/requests/predict/updateSegment.json
@@ -115,7 +115,10 @@
                 {
                   "operator": "EQ",
                   "value": "red",
-                  "probability": { "GTE": 0.5, "LTE": 1 }
+                  "probability": {
+                    "GTE": 0.5,
+                    "LTE": 1
+                  }
                 }
               ]
             }
@@ -136,7 +139,10 @@
                 {
                   "operator": "EQ",
                   "value": "red",
-                  "probability": { "GTE": 0.5, "LTE": 1 }
+                  "probability": {
+                    "GTE": 0.5,
+                    "LTE": 1
+                  }
                 }
               ]
             }

--- a/tests/CTS/methods/requests/predict/updateSegment.json
+++ b/tests/CTS/methods/requests/predict/updateSegment.json
@@ -27,7 +27,7 @@
               "name": "predictions.order_value",
               "filters": [
                 {
-                  "operator": ">",
+                  "operator": "GT",
                   "value": 200
                 }
               ]
@@ -47,7 +47,7 @@
               "name": "predictions.order_value",
               "filters": [
                 {
-                  "operator": ">",
+                  "operator": "GT",
                   "value": 200
                 }
               ]
@@ -70,7 +70,7 @@
               "name": "predictions.order_value",
               "filters": [
                 {
-                  "operator": ">",
+                  "operator": "GT",
                   "value": 200
                 }
               ]
@@ -91,8 +91,52 @@
               "name": "predictions.order_value",
               "filters": [
                 {
-                  "operator": ">",
+                  "operator": "GT",
                   "value": 200
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "testName": "updateSegment with filter probability",
+    "parameters": {
+      "segmentID": "segment1",
+      "updateSegmentParams": {
+        "conditions": {
+          "operator": "AND",
+          "operands": [
+            {
+              "name": "predictions.affinities.color",
+              "filters": [
+                {
+                  "operator": "EQ",
+                  "value": "red",
+                  "probability": { "GTE": 0.5, "LTE": 1 }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "request": {
+      "path": "/1/segments/segment1",
+      "method": "POST",
+      "body": {
+        "conditions": {
+          "operator": "AND",
+          "operands": [
+            {
+              "name": "predictions.affinities.color",
+              "filters": [
+                {
+                  "operator": "EQ",
+                  "value": "red",
+                  "probability": { "GTE": 0.5, "LTE": 1 }
                 }
               ]
             }


### PR DESCRIPTION
## 🧭 What and Why

Since the API client generator tool doesn't support `>` symbol as keys, we decided to use the `GT` syntax both in the API client and in the Predict REST API.

This PR updates symbol operators like `"="` to textual operators like `"EQ"`.

### Changes included:

- Updated the probability filters to use textual operators like `"EQ"`
- Updated all operators to uppercase
- Remove operator converter introduced in [`e1c61be` (#1202)](https://github.com/algolia/api-clients-automation/pull/1202/commits/e1c61bea44a33ed1c5f54ba444682300cac56345)

## 🧪 Test

- Added test with filter probability

### Related

- https://github.com/algolia/predict-api/pull/67