### PR TITLE
chore(scripts): catch up on deprecated github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,9 +6,6 @@ inputs:
   type:
     description: Type of setup, `minimal` will only setup the JavaScript monorepo, `matrix` will set the run variables.
     required: false
-  workflow_name:
-    description: Name of the workflow that is executing this action.
-    required: false
   language:
     description: the language for which to install deps
     required: false
@@ -24,7 +21,7 @@ runs:
     # Java for code generation
     - name: Install Java
       if: inputs.type != 'minimal'
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: 11.0.4
@@ -41,7 +38,7 @@ runs:
 
     # JavaScript for monorepo and tooling
     - name: Install Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc
         cache: yarn
@@ -49,7 +46,7 @@ runs:
     - name: Get yarn cache directory path
       shell: bash
       id: yarn-cache-dir
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore Yarn
       uses: actions/cache@v3
@@ -73,7 +70,7 @@ runs:
       if: ${{ inputs.language == 'javascript' }}
       shell: bash
       id: yarn-cache-dir-client
-      run: echo "::set-output name=dir::$(cd clients/algoliasearch-client-javascript && yarn config get cacheFolder)"
+      run: echo "dir=$(cd clients/algoliasearch-client-javascript && yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
     - name: Restore Yarn js-client
       if: ${{ inputs.language == 'javascript' }}
@@ -134,7 +131,7 @@ runs:
       run: |
         if ${{ steps.gen-matrix.outputs.RUN_GEN_JAVASCRIPT || steps.diff.outputs.JAVASCRIPT_UTILS_CHANGED > 0 }}; then
           echo "Running JavaScript utils: true"
-          echo "::set-output name=RUN_JS_UTILS::true"
+          echo "RUN_JS_UTILS=true" >> $GITHUB_OUTPUT
         fi
 
 outputs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.RUN_SCRIPTS == 'true' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 10
     needs: setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache bundled specs
         id: cache
@@ -136,7 +136,7 @@ jobs:
           - requester-node-http
           - requester-fetch
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache '${{ matrix.client }}' client folder
         id: cache
@@ -184,7 +184,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.GEN_MATRIX) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache clients folder
         id: cache
@@ -247,7 +247,7 @@ jobs:
         if: ${{ matrix.client.language == 'javascript' }}
         shell: bash
         id: yarn-cache-dir-tests
-        run: echo "::set-output name=dir::$(cd ${{ matrix.client.testsRootFolder }} && yarn config get cacheFolder)"
+        run: echo "dir=$(cd ${{ matrix.client.testsRootFolder }} && yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - name: Restore Yarn js tests
         if: ${{ matrix.client.language == 'javascript' }}
@@ -288,7 +288,7 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     if: (github.event.action == 'opened' || github.event.action == 'synchronize') && github.event.number
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     if: github.event.action == 'closed'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,6 +14,6 @@ jobs:
           fetch-depth: 0
 
       - name: Pull Request title rules
-        uses: deepakputhraya/action-pr-title@v1.0.2
+        uses: Slashgear/action-check-pr-title@v4.3.0
         with:
           regex: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|javascript|php|java|cts|specs|scripts|ci|templates|deps)\)): .+'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Pull Request title rules
         uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regex: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|javascript|php|java|cts|specs|scripts|ci|templates|deps)\)): .+'
+          regexp: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|javascript|php|java|cts|specs|scripts|ci|templates|deps)\)): .+'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Scheduled Release
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: main

--- a/clients/algoliasearch-client-java-2/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-java-2/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_PRIVATE_KEY_ID }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 11.0.4
@@ -36,7 +36,7 @@ jobs:
         id: snapshot
         run: |
           if [[ $(cat ./gradle.properties | grep 'VERSION_NAME=.*-SNAPSHOT') ]]; then
-            echo "::set-output name=IS_SNAPSHOT::true"
+            echo "IS_SNAPSHOT=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Release Artifacts

--- a/clients/algoliasearch-client-javascript/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-javascript/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-20.04
     if: "startsWith(github.event.head_commit.message, 'chore: release')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
           cache: yarn

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -17,7 +17,7 @@ import type {
   SpecMatrix,
   ToRunMatrix,
 } from './types';
-import { computeCacheKey, isBaseChanged } from './utils';
+import { computeCacheKey, isBaseChanged, setOutput } from './utils';
 
 // This empty matrix is required by the CI, otherwise it throws
 const EMPTY_MATRIX = { client: ['no-run'] };
@@ -150,16 +150,15 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
       testsToDelete,
       testsToStore,
     });
-    console.log(`::set-output name=RUN_GEN_${language.toUpperCase()}::true`);
+    console.log(`name=RUN_GEN_${language.toUpperCase()}::true`);
   }
 
   const shouldRun = clientMatrix.client.length > 0;
 
-  console.log(`::set-output name=RUN_GEN::${shouldRun}`);
-  console.log(
-    `::set-output name=GEN_MATRIX::${JSON.stringify(
-      shouldRun ? clientMatrix : EMPTY_MATRIX
-    )}`
+  await setOutput('RUN_GEN', shouldRun);
+  await setOutput(
+    'GEN_MATRIX',
+    JSON.stringify(shouldRun ? clientMatrix : EMPTY_MATRIX)
   );
 }
 
@@ -187,7 +186,7 @@ async function getSpecMatrix(): Promise<void> {
     ]),
   };
 
-  console.log(`::set-output name=MATRIX::${JSON.stringify(ciMatrix)}`);
+  await setOutput('MATRIX', JSON.stringify(ciMatrix));
 }
 
 /**

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console,no-case-declarations */
+import * as core from '@actions/core';
+
 import { CLIENTS, createClientName, GENERATORS, LANGUAGES } from '../../common';
 import {
   getClientsConfigField,
@@ -17,7 +19,7 @@ import type {
   SpecMatrix,
   ToRunMatrix,
 } from './types';
-import { computeCacheKey, isBaseChanged, setOutput } from './utils';
+import { computeCacheKey, isBaseChanged } from './utils';
 
 // This empty matrix is required by the CI, otherwise it throws
 const EMPTY_MATRIX = { client: ['no-run'] };
@@ -155,8 +157,8 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
 
   const shouldRun = clientMatrix.client.length > 0;
 
-  await setOutput('RUN_GEN', shouldRun);
-  await setOutput(
+  core.setOutput('RUN_GEN', shouldRun);
+  core.setOutput(
     'GEN_MATRIX',
     JSON.stringify(shouldRun ? clientMatrix : EMPTY_MATRIX)
   );
@@ -186,7 +188,7 @@ async function getSpecMatrix(): Promise<void> {
     ]),
   };
 
-  await setOutput('MATRIX', JSON.stringify(ciMatrix));
+  core.setOutput('MATRIX', JSON.stringify(ciMatrix));
 }
 
 /**

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console,no-case-declarations */
+/* eslint-disable no-case-declarations */
 import * as core from '@actions/core';
 
 import { CLIENTS, createClientName, GENERATORS, LANGUAGES } from '../../common';
@@ -152,7 +152,7 @@ async function getClientMatrix(baseBranch: string): Promise<void> {
       testsToDelete,
       testsToStore,
     });
-    console.log(`name=RUN_GEN_${language.toUpperCase()}::true`);
+    core.setOutput(`RUN_GEN_${language.toUpperCase()}`, true);
   }
 
   const shouldRun = clientMatrix.client.length > 0;

--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -2,7 +2,7 @@
 import { CLIENTS_JS_UTILS } from '../../common';
 import { getLanguageFolder } from '../../config';
 
-import { isBaseChanged } from './utils';
+import { isBaseChanged, setOutput } from './utils';
 
 const JS_CLIENT_FOLDER = getLanguageFolder('javascript');
 const JAVA_CLIENT_FOLDER = getLanguageFolder('java');
@@ -81,7 +81,7 @@ async function setRunVariables({
 }): Promise<void> {
   console.log(`Checking diff between ${originBranch} and HEAD`);
 
-  console.log(`::set-output name=ORIGIN_BRANCH::${originBranch}`);
+  await setOutput('ORIGIN_BRANCH', originBranch);
 
   await isBaseChanged(originBranch, DEPENDENCIES, true);
 }

--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -1,8 +1,10 @@
 /* eslint-disable no-console */
+import * as core from '@actions/core';
+
 import { CLIENTS_JS_UTILS } from '../../common';
 import { getLanguageFolder } from '../../config';
 
-import { isBaseChanged, setOutput } from './utils';
+import { isBaseChanged } from './utils';
 
 const JS_CLIENT_FOLDER = getLanguageFolder('javascript');
 const JAVA_CLIENT_FOLDER = getLanguageFolder('java');
@@ -81,7 +83,7 @@ async function setRunVariables({
 }): Promise<void> {
   console.log(`Checking diff between ${originBranch} and HEAD`);
 
-  await setOutput('ORIGIN_BRANCH', originBranch);
+  core.setOutput('ORIGIN_BRANCH', originBranch);
 
   await isBaseChanged(originBranch, DEPENDENCIES, true);
 }

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-console */
 import crypto from 'crypto';
+import fsp from 'fs/promises';
+import { EOL } from 'os';
 
 import { hashElement } from 'folder-hash';
 
 import { toAbsolutePath } from '../../common';
 import { getNbGitDiff } from '../utils';
-
 /**
  * This cache key holds the hash of the common dependencies of all the clients.
  */
@@ -63,12 +64,12 @@ export async function computeCacheKey(
 /**
  * Determines if changes have been found in the `dependencies`, compared to the `baseBranch`.
  *
- * If `setOutput` is true, it will set log the variable values for the CI.
+ * If `output` is true, it will set log the variable values for the CI.
  */
 export async function isBaseChanged(
   baseBranch: string,
   dependencies: Record<string, string[]>,
-  setOutput?: boolean
+  output?: boolean
 ): Promise<boolean> {
   for (const [key, path] of Object.entries(dependencies)) {
     const diff = await getNbGitDiff({
@@ -76,13 +77,18 @@ export async function isBaseChanged(
       path: path.join(' '),
     });
 
-    if (setOutput) {
+    if (output) {
       console.log(`Found ${diff} changes for '${key}'`);
-      console.log(`::set-output name=${key}::${diff}`);
+      await setOutput(key, diff);
     } else if (diff > 0) {
       return true;
     }
   }
 
   return false;
+}
+
+export async function setOutput(key: string, value: any): Promise<void> {
+  const output = process.env.GITHUB_OUTPUT!;
+  await fsp.writeFile(output, `${key}=${value}${EOL}`);
 }

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-console */
 import crypto from 'crypto';
-import fsp from 'fs/promises';
-import { EOL } from 'os';
 
+import * as core from '@actions/core';
 import { hashElement } from 'folder-hash';
 
 import { toAbsolutePath } from '../../common';
@@ -79,16 +78,11 @@ export async function isBaseChanged(
 
     if (output) {
       console.log(`Found ${diff} changes for '${key}'`);
-      await setOutput(key, diff);
+      core.setOutput(key, diff);
     } else if (diff > 0) {
       return true;
     }
   }
 
   return false;
-}
-
-export async function setOutput(key: string, value: any): Promise<void> {
-  const output = process.env.GITHUB_OUTPUT!;
-  await fsp.writeFile(output, `${key}=${value}${EOL}`);
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,6 +13,7 @@
     "upsertGenerationComment": "ts-node ci/codegen/upsertGenerationComment.ts"
   },
   "devDependencies": {
+    "@actions/core": "1.10.0",
     "@octokit/rest": "19.0.7",
     "@types/folder-hash": "4.0.2",
     "@types/inquirer": "8.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,25 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@actions/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@actions/core@npm:1.10.0"
+  dependencies:
+    "@actions/http-client": ^2.0.1
+    uuid: ^8.3.2
+  checksum: 0a75621e007ab20d887434cdd165f0b9036f14c22252a2faed33543d8b9d04ec95d823e69ca636a25245574e4585d73e1e9e47a845339553c664f9f2c9614669
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@actions/http-client@npm:2.0.1"
+  dependencies:
+    tunnel: ^0.0.6
+  checksum: 799ec3df91e28a9da91ce6592e94f8b8923ccf6cc21a2f72c7429be5af5273f1625335411adc2a1bb222d56c852d5767214dfa6fa32a6da7e81dba8290e08f17
+  languageName: node
+  linkType: hard
+
 "@algolia/api-client-automation@workspace:.":
   version: 0.0.0-use.local
   resolution: "@algolia/api-client-automation@workspace:."
@@ -7943,6 +7962,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "scripts@workspace:scripts"
   dependencies:
+    "@actions/core": 1.10.0
     "@octokit/rest": 19.0.7
     "@types/folder-hash": 4.0.2
     "@types/inquirer": 8.2.6
@@ -8686,6 +8706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tunnel@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -8837,7 +8864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:8.3.2":
+"uuid@npm:8.3.2, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-923](https://algolia.atlassian.net/browse/DI-923)

We have a lot of deprecation warning, for node 12 and for the `set-output` thing, but it's not supported in js so we have to do a [workaround](https://github.com/actions/toolkit/issues/1218#issuecomment-1288890856) until this is fixed.


[DI-923]: https://algolia.atlassian.net/browse/DI-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ