### PR TITLE
fix(specs): add skipped runs

### DIFF
--- a/specs/ingestion/common/schemas/run.yml
+++ b/specs/ingestion/common/schemas/run.yml
@@ -71,7 +71,7 @@ Run:
 
 RunStatus:
   type: string
-  enum: ['created', 'started', 'idled', 'finished']
+  enum: ['created', 'started', 'idled', 'finished', 'skipped']
 
 RunOutcome:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

`skipped` run can be used to filter runs, and are returned by the API.
doc: The run have been skipped by the tasks-scheduler due to an already ongoing run for the given task.