### PR TITLE
chore(all): upgrade openapi-generator to v6.4.0

### DIFF
--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -1,6 +1,6 @@
 {
   "generator-cli": {
-    "version": "6.0.1",
+    "version": "6.4.0",
     "generators": {
       "javascript-algoliasearch": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",

--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.openapitools:openapi-generator:6.0.1'
+    compileOnly 'org.openapitools:openapi-generator:6.4.0'
     compileOnly 'org.yaml:snakeyaml:1.32'
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "website:build-specs": "BUNDLE_WITH_DOC=true DOCKER=true yarn cli build specs all -s"
   },
   "devDependencies": {
-    "@openapitools/openapi-generator-cli": "2.5.1",
+    "@openapitools/openapi-generator-cli": "2.5.2",
     "@prettier/plugin-php": "0.19.3",
     "@redocly/openapi-cli": "1.0.0-beta.95",
     "@typescript-eslint/eslint-plugin": "5.53.0",

--- a/scripts/cts/generate.ts
+++ b/scripts/cts/generate.ts
@@ -1,4 +1,5 @@
-import { buildCustomGenerators, run, toAbsolutePath } from '../common';
+import { buildSpecs } from '../buildSpecs';
+import { buildCustomGenerators, CI, run, toAbsolutePath } from '../common';
 import { getTestOutputFolder } from '../config';
 import { formatter } from '../formatter';
 import { createSpinner } from '../oraLog';
@@ -22,8 +23,13 @@ export async function ctsGenerateMany(
   generators: Generator[],
   verbose: boolean
 ): Promise<void> {
-  await buildCustomGenerators(verbose);
+  if (!CI) {
+    const clients = [...new Set(generators.map((gen) => gen.client))];
+    await buildSpecs(clients, 'yml', verbose, true);
+  }
+
   await generateOpenapitools(generators);
+  await buildCustomGenerators(verbose);
 
   for (const gen of generators) {
     if (!getTestOutputFolder(gen.language)) {

--- a/templates/java/pojo.mustache
+++ b/templates/java/pojo.mustache
@@ -55,7 +55,7 @@ public {{classname}} setAdditionalProperty(String name, Object value) {
   public {{classname}} add{{nameInCamelCase}}({{#vendorExtensions.x-has-child-generic}}{{{complexType}}}<T>{{/vendorExtensions.x-has-child-generic}}{{^vendorExtensions.x-has-child-generic}}{{#items}}{{> generic_type}}{{/items}}{{/vendorExtensions.x-has-child-generic}} {{name}}Item) {
     {{^required}}
     if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}};
+      this.{{name}} = new ArrayList<>();
     }
     {{/required}}
     this.{{name}}.add({{name}}Item);
@@ -66,7 +66,7 @@ public {{classname}} setAdditionalProperty(String name, Object value) {
   public {{classname}} put{{nameInCamelCase}}(String key, {{#items}}{{> generic_type}}{{/items}} {{name}}Item) {
     {{^required}}
     if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}};
+      this.{{name}} = new HashMap<>();
     }
     {{/required}}
     this.{{name}}.put(key, {{name}}Item);

--- a/templates/javascript/clients/model.mustache
+++ b/templates/javascript/clients/model.mustache
@@ -4,6 +4,9 @@
 {{#tsImports}}
 import { {{classname}} } from '{{filename}}';
 {{/tsImports}}
+{{#interfaces.size}}{{#composedSchemas.allOf}}
+import type { {{{dataType}}} } from './{{#lambda.camelcase}}{{{dataType}}}{{/lambda.camelcase}}';
+{{/composedSchemas.allOf}}{{/interfaces.size}}
 
 {{! We handle types that depend on other interfaces }}
 {{#interfaces.size}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,7 +28,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/api-client-automation@workspace:."
   dependencies:
-    "@openapitools/openapi-generator-cli": 2.5.1
+    "@openapitools/openapi-generator-cli": 2.5.2
     "@prettier/plugin-php": 0.19.3
     "@redocly/openapi-cli": 1.0.0-beta.95
     "@typescript-eslint/eslint-plugin": 5.53.0
@@ -1309,9 +1309,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openapitools/openapi-generator-cli@npm:2.5.1":
-  version: 2.5.1
-  resolution: "@openapitools/openapi-generator-cli@npm:2.5.1"
+"@openapitools/openapi-generator-cli@npm:2.5.2":
+  version: 2.5.2
+  resolution: "@openapitools/openapi-generator-cli@npm:2.5.2"
   dependencies:
     "@nestjs/common": 8.4.4
     "@nestjs/core": 8.4.4
@@ -1330,7 +1330,7 @@ __metadata:
     tslib: 2.0.3
   bin:
     openapi-generator-cli: main.js
-  checksum: 9d5df24f950d2e1a4ae5a34deb0c2a4744ec58747b93a2a05e5230b25a21817b9acbc770e0513fcaa74901c64648477e5401ae440345ae285748c57879305897
+  checksum: 77a77be03877311b55c8a749646cebd6a1e330eb5c2edf64695b20ae575c3cd8c6c316d2099866f7a9ed9fe545847472f4ec44aab133d76b707c085e77b70605
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-904](https://algolia.atlassian.net/browse/DI-904)

Upgrade to the latest version, it was a lot less difficult than last time, I guess some bugs got fixed along the way.
It changes some weird things on the generated clients, but all the tests are okay, maybe it was because of inlining ?

### Changes included:

- Build specs locally before generating CTS, the same as for generate clients.

[DI-904]: https://algolia.atlassian.net/browse/DI-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ