### PR TITLE
chore(scripts): remove double error log

### DIFF
--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -102,7 +102,8 @@ export async function run(
     if (errorMessage) {
       throw new Error(`[ERROR] ${errorMessage}`);
     } else {
-      throw err;
+      // it's already log thanks to the `all` option
+      throw new Error(`command failed: ${command}`);
     }
   }
 }


### PR DESCRIPTION
## 🧭 What and Why

When an error occurs in `execa` we printed the error twice, there is no need for that and we can print a better error instead.