### PR TITLE
fix(scripts): release need verbose=false

### DIFF
--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -449,6 +449,7 @@ async function createReleasePR(): Promise<void> {
 
   await run(`git checkout -b ${headBranch}`);
 
+  setVerbose(true);
   console.log(`Pushing updated changes to: ${headBranch}`);
   const commitMessage = generationCommitText.commitPrepareReleaseMessage;
   await run('git add .');
@@ -492,6 +493,6 @@ async function createReleasePR(): Promise<void> {
 }
 
 if (require.main === module) {
-  setVerbose(true);
+  setVerbose(false);
   createReleasePR();
 }


### PR DESCRIPTION
## 🧭 What and Why

#1365 broke the release script because the output of `run` changes based on the verbose level, maybe it should and should always return the same thing (there is a newline at the end in verbose mode)
