### PR TITLE
chore: prepare release 2023-03-02

### DIFF
--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [5a93964e](https://github.com/algolia/api-clients-automation/commit/5a93964e) fix(specs): add skipped runs ([#1359](https://github.com/algolia/api-clients-automation/pull/1359)) by [@millotp](https://github.com/millotp/)
+- [2a4fe7ea](https://github.com/algolia/api-clients-automation/commit/2a4fe7ea) feat(clients): upgrade to node 18 ([#1344](https://github.com/algolia/api-clients-automation/pull/1344)) by [@millotp](https://github.com/millotp/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [33700b8c](https://github.com/algolia/api-clients-automation/commit/33700b8c) feat(specs): add a reason string to the run object ([#1347](https://github.com/algolia/api-clients-automation/pull/1347)) by [@Fluf22](https://github.com/Fluf22/)
 - [d7b03aed](https://github.com/algolia/api-clients-automation/commit/d7b03aed) chore(java): add api compat check ([#1335](https://github.com/algolia/api-clients-automation/pull/1335)) by [@aallam](https://github.com/aallam/)
 

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0-alpha.51](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.50...5.0.0-alpha.51)
+
+- [5a93964e](https://github.com/algolia/api-clients-automation/commit/5a93964e) fix(specs): add skipped runs ([#1359](https://github.com/algolia/api-clients-automation/pull/1359)) by [@millotp](https://github.com/millotp/)
+- [2a4fe7ea](https://github.com/algolia/api-clients-automation/commit/2a4fe7ea) feat(clients): upgrade to node 18 ([#1344](https://github.com/algolia/api-clients-automation/pull/1344)) by [@millotp](https://github.com/millotp/)
+
 ## [5.0.0-alpha.50](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.49...5.0.0-alpha.50)
 
 - [33700b8c](https://github.com/algolia/api-clients-automation/commit/33700b8c) feat(specs): add a reason string to the run object ([#1347](https://github.com/algolia/api-clients-automation/pull/1347)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.50",
+  "version": "5.0.0-alpha.51",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.50",
+  "version": "5.0.0-alpha.51",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.50"
+    "@algolia/client-common": "5.0.0-alpha.51"
   },
   "devDependencies": {
     "@types/jest": "29.4.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.50",
+  "version": "5.0.0-alpha.51",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.50"
+    "@algolia/client-common": "5.0.0-alpha.51"
   },
   "devDependencies": {
     "@types/jest": "29.4.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.50",
+  "version": "5.0.0-alpha.51",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.50"
+    "@algolia/client-common": "5.0.0-alpha.51"
   },
   "devDependencies": {
     "@types/jest": "29.4.0",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-alpha.49](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.48...4.0.0-alpha.49)
+
+- [5a93964e](https://github.com/algolia/api-clients-automation/commit/5a93964e) fix(specs): add skipped runs ([#1359](https://github.com/algolia/api-clients-automation/pull/1359)) by [@millotp](https://github.com/millotp/)
+- [2a4fe7ea](https://github.com/algolia/api-clients-automation/commit/2a4fe7ea) feat(clients): upgrade to node 18 ([#1344](https://github.com/algolia/api-clients-automation/pull/1344)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.48](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.47...4.0.0-alpha.48)
 
 - [33700b8c](https://github.com/algolia/api-clients-automation/commit/33700b8c) feat(specs): add a reason string to the run object ([#1347](https://github.com/algolia/api-clients-automation/pull/1347)) by [@Fluf22](https://github.com/Fluf22/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.50",
+    "utilsPackageVersion": "5.0.0-alpha.51",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.48",
+    "packageVersion": "4.0.0-alpha.49",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.50"
+          "packageVersion": "5.0.0-alpha.51"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.50"
+          "packageVersion": "1.0.0-alpha.51"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.24"
+          "packageVersion": "1.0.0-alpha.25"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.50 -> **`prerelease` _(e.g. 5.0.0-alpha.51)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.48 -> **`prerelease` _(e.g. 4.0.0-alpha.49)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - fix(scripts): release need verbose=false (#1367)
- chore(scripts): remove double error log (#1366)
- chore(scripts): use spinnies for multi spinner (#1365)
- chore(deps): dependencies 2023-02-27 (#1358)
- chore(all): upgrade openapi-generator to v6.4.0 (#1360)
- chore(scripts): update gradle to v8 (#1346)
- chore(scripts): fix version for everything and use debian in docker (#1349)
</details>