### PR TITLE
fix(java): delete tag before release

### DIFF
--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-console */
-import { ensureGitHubToken, MAIN_BRANCH, run } from '../../common';
-import { configureGitHubAuthor } from '../../release/common';
+import {
+  configureGitHubAuthor,
+  ensureGitHubToken,
+  MAIN_BRANCH,
+  run,
+} from '../../common';
 import { getNbGitDiff } from '../utils';
 
 import text, { commitStartPrepareRelease } from './text';

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -151,7 +151,8 @@ async function spreadGeneration(): Promise<void> {
         `Processing release commit, creating new release tag ('${version}') for '${lang}' repository.`
       );
 
-      await run(`git tag -d ${version}`, { cwd: tempGitDir });
+      // we always want to delete the tag in case it exists
+      await run(`git tag -d ${version} || true`, { cwd: tempGitDir });
       await run(`git tag ${version} HEAD`, { cwd: tempGitDir });
       await run('git push --tags', { cwd: tempGitDir });
     }

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -9,15 +9,12 @@ import {
   toAbsolutePath,
   REPO_URL,
   ensureGitHubToken,
+  configureGitHubAuthor,
 } from '../../common';
 import { getLanguageFolder, getPackageVersionDefault } from '../../config';
-import {
-  cloneRepository,
-  configureGitHubAuthor,
-  RELEASED_TAG,
-} from '../../release/common';
+import { RELEASED_TAG } from '../../release/common';
 import type { Language } from '../../types';
-import { getNbGitDiff } from '../utils';
+import { cloneRepository, getNbGitDiff } from '../utils';
 
 import text, { commitStartRelease } from './text';
 
@@ -106,7 +103,7 @@ async function spreadGeneration(): Promise<void> {
     await run(`git push --delete origin ${RELEASED_TAG}`);
 
     console.log('Creating new `released` tag for latest commit');
-    await run('git tag released');
+    await run(`git tag ${RELEASED_TAG}`);
     await run('git push --tags');
   }
 
@@ -154,6 +151,7 @@ async function spreadGeneration(): Promise<void> {
         `Processing release commit, creating new release tag ('${version}') for '${lang}' repository.`
       );
 
+      await run(`git tag -d ${version}`, { cwd: tempGitDir });
       await run(`git tag ${version} HEAD`, { cwd: tempGitDir });
       await run('git push --tags', { cwd: tempGitDir });
     }

--- a/scripts/ci/utils.ts
+++ b/scripts/ci/utils.ts
@@ -1,4 +1,10 @@
+import fsp from 'fs/promises';
+import { resolve } from 'path';
+
 import { run } from '../common';
+import { getGitHubUrl } from '../config';
+import { getTargetBranch } from '../release/common';
+import type { Language } from '../types';
 
 /**
  * Returns the number of diff between a `branch` and its `HEAD` for the given `path`.
@@ -31,4 +37,27 @@ export async function getNbGitDiff({
     ).trim(),
     10
   );
+}
+
+export async function cloneRepository({
+  lang,
+  githubToken,
+  tempDir,
+}: {
+  lang: Language;
+  githubToken: string;
+  tempDir: string;
+}): Promise<{ tempGitDir: string }> {
+  const targetBranch = getTargetBranch(lang);
+
+  const gitHubUrl = getGitHubUrl(lang, { token: githubToken });
+  const tempGitDir = resolve(tempDir, lang);
+  await fsp.rm(tempGitDir, { force: true, recursive: true });
+  await run(
+    `git clone --depth 1 --branch ${targetBranch} ${gitHubUrl} ${tempGitDir}`
+  );
+
+  return {
+    tempGitDir,
+  };
 }

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -9,6 +9,7 @@ import { remove } from 'fs-extra';
 import openapiConfig from '../config/openapitools.json';
 import releaseConfig from '../config/release.config.json';
 
+import { getGitAuthor } from './release/common';
 import { createSpinner } from './spinners';
 import type {
   CheckForCache,
@@ -284,6 +285,13 @@ export function camelize(str: string, delimiter: string = '-'): string {
  */
 export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export async function configureGitHubAuthor(cwd?: string): Promise<void> {
+  const { name, email } = getGitAuthor();
+
+  await run(`git config user.name "${name}"`, { cwd });
+  await run(`git config user.email "${email}"`, { cwd });
 }
 
 let verbose = false;

--- a/scripts/release/common.ts
+++ b/scripts/release/common.ts
@@ -1,10 +1,6 @@
 import fsp from 'fs/promises';
-import path from 'path';
 
 import config from '../../config/release.config.json';
-import { run } from '../common';
-import { getGitHubUrl } from '../config';
-import type { Language } from '../types';
 
 export const RELEASED_TAG = config.releasedTag;
 export const TEAM_SLUG = config.teamSlug;
@@ -15,36 +11,6 @@ export function getTargetBranch(language: string): string {
 
 export function getGitAuthor(): { name: string; email: string } {
   return config.gitAuthor;
-}
-
-export async function configureGitHubAuthor(cwd?: string): Promise<void> {
-  const { name, email } = getGitAuthor();
-
-  await run(`git config user.name "${name}"`, { cwd });
-  await run(`git config user.email "${email}"`, { cwd });
-}
-
-export async function cloneRepository({
-  lang,
-  githubToken,
-  tempDir,
-}: {
-  lang: Language;
-  githubToken: string;
-  tempDir: string;
-}): Promise<{ tempGitDir: string }> {
-  const targetBranch = getTargetBranch(lang);
-
-  const gitHubUrl = getGitHubUrl(lang, { token: githubToken });
-  const tempGitDir = path.resolve(tempDir, lang);
-  await fsp.rm(tempGitDir, { force: true, recursive: true });
-  await run(
-    `git clone --depth 1 --branch ${targetBranch} ${gitHubUrl} ${tempGitDir}`
-  );
-
-  return {
-    tempGitDir,
-  };
 }
 
 /**

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -18,10 +18,11 @@ import {
   CI,
   gitBranchExists,
   setVerbose,
+  configureGitHubAuthor,
 } from '../common';
 import { getPackageVersionDefault } from '../config';
 
-import { configureGitHubAuthor, RELEASED_TAG } from './common';
+import { RELEASED_TAG } from './common';
 import TEXT from './text';
 import type {
   Versions,
@@ -458,6 +459,9 @@ async function createReleasePR(): Promise<void> {
   } else {
     await run(`CI=false git commit -m "${commitMessage}"`);
   }
+
+  // cleanup all the changes to the generated files (the ones not commited because of the pre-commit hook)
+  await run(`git checkout .`);
 
   await run(`git push origin ${headBranch}`);
   await run(`git checkout ${MAIN_BRANCH}`);


### PR DESCRIPTION
## 🧭 What and Why

Refacto some functions to put them in the right common file and avoid importing between folders.

Fix the java release by deleting the tag before the release
