### PR TITLE
fix(scripts): released tag needs to be deleted

### DIFF
--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -83,6 +83,7 @@ async function spreadGeneration(): Promise<void> {
     await run(
       `git fetch origin refs/tags/${RELEASED_TAG}:refs/tags/${RELEASED_TAG}`
     );
+    await run(`git tag -d ${RELEASED_TAG}`);
     await run(`git push --delete origin ${RELEASED_TAG}`);
 
     console.log('Creating new `released` tag for latest commit');


### PR DESCRIPTION
## 🧭 What and Why

`released` tag needs to be deleted both locally and on origin apparently.
