### PR TITLE
feat(specs): update affinity value type to accomodate booleans and numbers

### DIFF
--- a/specs/predict/responses/UserProfile.yml
+++ b/specs/predict/responses/UserProfile.yml
@@ -144,5 +144,6 @@ predictionsAffinitiesSuccess:
 predictionAffinityValue:
   oneOf:
     - type: string
-    - type: integer
+    - type: number
+      format: double
     - type: boolean

--- a/specs/predict/responses/UserProfile.yml
+++ b/specs/predict/responses/UserProfile.yml
@@ -125,7 +125,7 @@ predictionsAffinitiesSuccess:
           name:
             type: string
           value:
-            type: string
+            $ref: '#/predictionAffinityValue'
           probability:
             type: number
             format: double
@@ -140,3 +140,9 @@ predictionsAffinitiesSuccess:
   required:
     - value
     - lastUpdatedAt
+
+predictionAffinityValue:
+  oneOf:
+    - type: string
+    - type: integer
+    - type: boolean


### PR DESCRIPTION
## 🧭 What and Why
Introducing support for numbers and booleans in the value property of the `Affinity` type

From
```js
{
    name:string,
    value:string,
    probability:number
}
```
to
```js
{
    name:string,
    value:string | number | boolean,
    probability:number
}
```

### Changes included:
- Add `PredictionAffinityValue` type