### PR TITLE
chore: prepare release 2023-04-03

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [4.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.1...4.0.0-alpha.2)
+
+- [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)
+- [3e12a19f](https://github.com/algolia/api-clients-automation/commit/3e12a19f) feat(go): initial setup for go client ([#1423](https://github.com/algolia/api-clients-automation/pull/1423)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [c49b6e6d](https://github.com/algolia/api-clients-automation/commit/c49b6e6d) fix(specs): add customRequest to ingestion and small fix ([#1418](https://github.com/algolia/api-clients-automation/pull/1418)) by [@millotp](https://github.com/millotp/)
 - [524347e3](https://github.com/algolia/api-clients-automation/commit/524347e3) fix(specs): update BigCommerce source payload ([#1416](https://github.com/algolia/api-clients-automation/pull/1416)) by [@shortcuts](https://github.com/shortcuts/)
 

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.55](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.54...5.0.0-alpha.55)
+
+- [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [5.0.0-alpha.54](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.53...5.0.0-alpha.54)
 
 - [c49b6e6d](https://github.com/algolia/api-clients-automation/commit/c49b6e6d) fix(specs): add customRequest to ingestion and small fix ([#1418](https://github.com/algolia/api-clients-automation/pull/1418)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.54",
+  "version": "5.0.0-alpha.55",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.54",
+  "version": "5.0.0-alpha.55",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.54"
+    "@algolia/client-common": "5.0.0-alpha.55"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.54",
+  "version": "5.0.0-alpha.55",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.54"
+    "@algolia/client-common": "5.0.0-alpha.55"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.54",
+  "version": "5.0.0-alpha.55",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.54"
+    "@algolia/client-common": "5.0.0-alpha.55"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.53](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.52...4.0.0-alpha.53)
+
+- [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)
+
 ## [4.0.0-alpha.52](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.51...4.0.0-alpha.52)
 
 - [c49b6e6d](https://github.com/algolia/api-clients-automation/commit/c49b6e6d) fix(specs): add customRequest to ingestion and small fix ([#1418](https://github.com/algolia/api-clients-automation/pull/1418)) by [@millotp](https://github.com/millotp/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.54",
+    "utilsPackageVersion": "5.0.0-alpha.55",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.52",
+    "packageVersion": "4.0.0-alpha.53",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.1",
+    "packageVersion": "4.0.0-alpha.2",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.54"
+          "packageVersion": "5.0.0-alpha.55"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.54"
+          "packageVersion": "1.0.0-alpha.55"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.28"
+          "packageVersion": "1.0.0-alpha.29"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.54 -> **`prerelease` _(e.g. 5.0.0-alpha.55)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.52 -> **`prerelease` _(e.g. 4.0.0-alpha.53)_**
- go: 4.0.0-alpha.1 -> **`prerelease` _(e.g. 4.0.0-alpha.2)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2023-04-03 (#1435)
- chore(deps): dependencies 2023-03-27 (#1422)
</details>