### PR TITLE
chore: prepare release 2023-04-06

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-alpha.3](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.2...4.0.0-alpha.3)
+
+- [ca763fbb](https://github.com/algolia/api-clients-automation/commit/ca763fbb) feat(go): template improvements ([#1444](https://github.com/algolia/api-clients-automation/pull/1444)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+- [619e2ad7](https://github.com/algolia/api-clients-automation/commit/619e2ad7) feat(specs): add delimiter option for csv source ([#1445](https://github.com/algolia/api-clients-automation/pull/1445)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.1...4.0.0-alpha.2)
 
 - [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [619e2ad7](https://github.com/algolia/api-clients-automation/commit/619e2ad7) feat(specs): add delimiter option for csv source ([#1445](https://github.com/algolia/api-clients-automation/pull/1445)) by [@millotp](https://github.com/millotp/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)
 
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.56](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.55...5.0.0-alpha.56)
+
+- [619e2ad7](https://github.com/algolia/api-clients-automation/commit/619e2ad7) feat(specs): add delimiter option for csv source ([#1445](https://github.com/algolia/api-clients-automation/pull/1445)) by [@millotp](https://github.com/millotp/)
+
 ## [5.0.0-alpha.55](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.54...5.0.0-alpha.55)
 
 - [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.55",
+  "version": "5.0.0-alpha.56",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.55",
+  "version": "5.0.0-alpha.56",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.55"
+    "@algolia/client-common": "5.0.0-alpha.56"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.55",
+  "version": "5.0.0-alpha.56",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.55"
+    "@algolia/client-common": "5.0.0-alpha.56"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.55",
+  "version": "5.0.0-alpha.56",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.55"
+    "@algolia/client-common": "5.0.0-alpha.56"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.54](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.53...4.0.0-alpha.54)
+
+- [619e2ad7](https://github.com/algolia/api-clients-automation/commit/619e2ad7) feat(specs): add delimiter option for csv source ([#1445](https://github.com/algolia/api-clients-automation/pull/1445)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.53](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.52...4.0.0-alpha.53)
 
 - [33ec7bc7](https://github.com/algolia/api-clients-automation/commit/33ec7bc7) feat(specs): add `lastUpdatedAt` field to predict segments ([#1431](https://github.com/algolia/api-clients-automation/pull/1431)) by [@bengreenbank](https://github.com/bengreenbank/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.55",
+    "utilsPackageVersion": "5.0.0-alpha.56",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.53",
+    "packageVersion": "4.0.0-alpha.54",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.2",
+    "packageVersion": "4.0.0-alpha.3",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.55"
+          "packageVersion": "5.0.0-alpha.56"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.55"
+          "packageVersion": "1.0.0-alpha.56"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.29"
+          "packageVersion": "1.0.0-alpha.30"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.55 -> **`prerelease` _(e.g. 5.0.0-alpha.56)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.53 -> **`prerelease` _(e.g. 4.0.0-alpha.54)_**
- go: 4.0.0-alpha.2 -> **`prerelease` _(e.g. 4.0.0-alpha.3)_**

### Skipped Commits

_(None)_