### PR TITLE
feat(go): add more playground examples

### DIFF
--- a/playground/go/analytics.go
+++ b/playground/go/analytics.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/analytics"
+)
+
+func testAnalytics(appID, apiKey string) int {
+	indexName := getEnvWithDefault("ANALYTICS_INDEX", "test_index")
+	analyticsClient := analytics.NewClient(appID, apiKey, analytics.US)
+
+	getTopFilterForAttributeResponse, err := analyticsClient.GetTopFilterForAttribute(
+		analyticsClient.NewApiGetTopFilterForAttributeRequest("myAttribute1,myAttribute2").WithIndex(indexName),
+	)
+	if err != nil {
+		fmt.Printf("request error with GetTopFilterForAttribute: %v\n", err)
+		return 1
+	}
+
+	printResponse(getTopFilterForAttributeResponse)
+
+	return 0
+}

--- a/playground/go/ingestion.go
+++ b/playground/go/ingestion.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/ingestion"
+)
+
+func testIngestion(appID, apiKey string) int {
+	ingestionClient := ingestion.NewClient(appID, apiKey, ingestion.US)
+
+	listAuthenticationsResponse, err := ingestionClient.GetAuthentications(
+		ingestionClient.NewApiGetAuthenticationsRequest().WithItemsPerPage(2),
+	)
+	if err != nil {
+		fmt.Printf("request error with GetAuthentications: %v\n", err)
+		return 1
+	}
+
+	printResponse(listAuthenticationsResponse)
+
+	return 0
+}

--- a/playground/go/insights.go
+++ b/playground/go/insights.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/insights"
+)
+
+func testInsights(appID, apiKey string) int {
+	insightsClient := insights.NewClient(appID, apiKey, insights.US)
+
+	events := insights.NewInsightEvents([]insights.InsightEvent{
+		*insights.NewInsightEvent("click",
+			"myEvent",
+			"test_index",
+			"myToken",
+			insights.WithInsightEventPositions([]int32{1, 2, 3}),
+			insights.WithInsightEventQueryID("myQueryID")),
+	})
+	pushEventsResponse, err := insightsClient.PushEvents(
+		insightsClient.NewApiPushEventsRequest().WithInsightEvents(*events),
+	)
+	if err != nil {
+		fmt.Printf("request error with PushEvents: %v\n", err)
+		return 1
+	}
+
+	printResponse(pushEventsResponse)
+
+	return 0
+}

--- a/playground/go/main.go
+++ b/playground/go/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
-
-	"github.com/algolia/algoliasearch-client-go/v4/algolia/ingestion"
-	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
 )
 
 func main() {
@@ -16,23 +14,40 @@ func main() {
 	appID := os.Getenv("ALGOLIA_APPLICATION_ID")
 	apiKey := os.Getenv("ALGOLIA_ADMIN_KEY")
 
+	var client string
+	var returnCode int
+
+	flag.StringVar(&client, "client", "", "client name")
+	flag.Parse()
+
+	if client == "" {
+		fmt.Println("Please specify a client name")
+		os.Exit(1)
+	}
+
 	//debug.Enable()
 
-	// ingestion
-	ingestionClient := ingestion.NewClient(appID, apiKey, ingestion.US)
+	switch client {
+	case "ingestion":
+		returnCode = testIngestion(appID, apiKey)
+	case "search":
+		returnCode = testSearch(appID, apiKey)
+	case "analytics":
+		returnCode = testAnalytics(appID, apiKey)
+	case "insights":
+		returnCode = testInsights(appID, apiKey)
+	case "personalization":
+		returnCode = testPersonalization(appID, apiKey)
+	case "predict":
+		returnCode = testPredict(appID, apiKey)
+	case "query-suggestions":
+		returnCode = testQuerySuggestions(appID, apiKey)
+	case "recommend":
+		returnCode = testRecommend(appID, apiKey)
+	default:
+		fmt.Println("Please specify a valid client name")
+		os.Exit(1)
+	}
 
-	auths, err := ingestionClient.GetAuthentications(
-		ingestionClient.NewApiGetAuthenticationsRequest().WithItemsPerPage(2),
-		ingestion.QueryParamOption("myQueryParam1", "myQueryParamValue1"),
-		ingestion.HeaderParamOption("myHeaderParam1", "myHeaderParamValue2"),
-	)
-	fmt.Println(auths, err)
-
-	// search
-	indexName := "test_index"
-	searchClient := search.NewClient(appID, apiKey)
-
-	searchParams := search.SearchParamsStringAsSearchParams(search.NewSearchParamsString(search.WithSearchParamsStringParams("query=jeans&hitsPerPage=2")))
-	searchRes, err := searchClient.SearchSingleIndex(searchClient.NewApiSearchSingleIndexRequest(indexName).WithSearchParams(searchParams))
-	fmt.Println(searchRes, err)
+	os.Exit(returnCode)
 }

--- a/playground/go/personalization.go
+++ b/playground/go/personalization.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/personalization"
+)
+
+func testPersonalization(appID, apiKey string) int {
+	personalizationClient := personalization.NewClient(appID, apiKey, personalization.US)
+
+	deleteUserProfileResponse, err := personalizationClient.DeleteUserProfile(
+		personalizationClient.NewApiDeleteUserProfileRequest("userToken"),
+	)
+	if err != nil {
+		fmt.Printf("request error with DeleteUserProfile: %v\n", err)
+		return 1
+	}
+
+	printResponse(deleteUserProfileResponse)
+
+	return 0
+}

--- a/playground/go/predict.go
+++ b/playground/go/predict.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/predict"
+)
+
+func testPredict(appID, apiKey string) int {
+	predictClient := predict.NewClient(appID, apiKey, predict.US)
+
+	params := predict.AllParamsAsParams(predict.NewAllParams(
+		predict.WithAllParamsModelsToRetrieve(predict.AllowedModelsToRetrieveEnumValues),
+		predict.WithAllParamsTypesToRetrieve(predict.AllowedTypesToRetrieveEnumValues),
+	))
+	userProfile, err := predictClient.FetchUserProfile(
+		predictClient.NewApiFetchUserProfileRequest("userId").WithParams(params),
+	)
+	if err != nil {
+		fmt.Printf("request error with FetchUserProfile: %v\n", err)
+		return 1
+	}
+
+	printResponse(userProfile)
+
+	return 0
+}

--- a/playground/go/query-suggestions.go
+++ b/playground/go/query-suggestions.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/query-suggestions"
+)
+
+func testQuerySuggestions(appID, apiKey string) int {
+	suggestionsClient := suggestions.NewClient(appID, apiKey, suggestions.US)
+
+	querySuggestionsIndex, err := suggestionsClient.GetAllConfigs(
+		suggestionsClient.NewApiGetAllConfigsRequest(),
+	)
+	if err != nil {
+		fmt.Printf("request error with GetAllConfigs: %v\n", err)
+		return 1
+	}
+
+	printResponse(querySuggestionsIndex)
+
+	return 0
+}

--- a/playground/go/recommend.go
+++ b/playground/go/recommend.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/recommend"
+)
+
+func testRecommend(appID, apiKey string) int {
+	recommendClient := recommend.NewClient(appID, apiKey)
+
+	/*
+		recommend.NewGetRecommendationsParams([]recommend.RecommendationsRequest{
+			recommend.RecommendationRequestAsRecommendationsRequest(recommend.NewRecommendationRequest(recommend.RECOMMENDATIONMODELS_BOUGHT_TOGETHER, "test_query", "test_index", 0)),
+		})
+	*/
+	// alternative way to create the payloads, a similar approach can be used with any of the other clients
+	params := recommend.GetRecommendationsParams{
+		Requests: []recommend.RecommendationsRequest{
+			{
+				RecommendationRequest: &recommend.RecommendationRequest{
+					Model:     recommend.RECOMMENDATIONMODELS_BOUGHT_TOGETHER,
+					ObjectID:  "test_query",
+					IndexName: "test_index",
+					Threshold: 0,
+				},
+			},
+		},
+	}
+
+	searchResponse, err := recommendClient.GetRecommendations(
+		recommendClient.NewApiGetRecommendationsRequest().WithGetRecommendationsParams(params),
+	)
+	if err != nil {
+		fmt.Printf("request error with SearchSingleIndex: %v\n", err)
+		return 1
+	}
+
+	printResponse(searchResponse)
+
+	return 0
+}

--- a/playground/go/search.go
+++ b/playground/go/search.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/search"
+)
+
+func testSearch(appID, apiKey string) int {
+	indexName := getEnvWithDefault("SEARCH_INDEX", "test_index")
+	searchClient := search.NewClient(appID, apiKey)
+
+	searchParams := search.SearchParamsStringAsSearchParams(search.NewSearchParamsString(search.WithSearchParamsStringParams("query=jeans&hitsPerPage=2")))
+	searchResponse, err := searchClient.SearchSingleIndex(searchClient.NewApiSearchSingleIndexRequest(indexName).WithSearchParams(searchParams))
+	if err != nil {
+		fmt.Printf("request error with SearchSingleIndex: %v\n", err)
+		return 1
+	}
+
+	printResponse(searchResponse)
+
+	return 0
+}

--- a/playground/go/util.go
+++ b/playground/go/util.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func printResponse(res any) {
+	bJson, _ := json.Marshal(res)
+
+	fmt.Printf("response json:   %s\n", string(bJson))
+	fmt.Printf("response string: %s\n", res)
+}
+
+func getEnvWithDefault(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok && value != "" {
+		return value
+	}
+	return fallback
+}

--- a/scripts/playground.ts
+++ b/scripts/playground.ts
@@ -30,7 +30,12 @@ export async function playground({
       );
       break;
     case 'go':
-      await run(`cd playground/go && /usr/local/go/bin/go run main.go`);
+      // eslint-disable-next-line no-console
+      console.log(
+        await run(
+          `cd playground/go && /usr/local/go/bin/go run . --client ${client}`
+        )
+      );
       break;
     default:
   }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-664

More structured playground examples were added for the go client to give more examples to test.

### Changes included:

- Playground examples added for generated go packages. 

## 🧪 Test

can be tested with `yarn docker playground go {client}`
