### PR TITLE
chore: prepare release 2023-04-18

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0-alpha.5](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.4...4.0.0-alpha.5)
+
+- [9a65a533](https://github.com/algolia/api-clients-automation/commit/9a65a533) feat(specs): add `size` to predict segment response ([#1434](https://github.com/algolia/api-clients-automation/pull/1434)) by [@bengreenbank](https://github.com/bengreenbank/)
+- [0ed9eb22](https://github.com/algolia/api-clients-automation/commit/0ed9eb22) fix(specs): add `input` in GET tasks ([#1472](https://github.com/algolia/api-clients-automation/pull/1472)) by [@shortcuts](https://github.com/shortcuts/)
+- [692aa2d8](https://github.com/algolia/api-clients-automation/commit/692aa2d8) fix(specs): add transform event type ([#1470](https://github.com/algolia/api-clients-automation/pull/1470)) by [@millotp](https://github.com/millotp/)
+- [69aac53d](https://github.com/algolia/api-clients-automation/commit/69aac53d) fix(specs): task trigger guard import order ([#1459](https://github.com/algolia/api-clients-automation/pull/1459)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [4.0.0-alpha.4](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.3...4.0.0-alpha.4)
 
 - [a0d96721](https://github.com/algolia/api-clients-automation/commit/a0d96721) fix(specs): task trigger guard import ([#1458](https://github.com/algolia/api-clients-automation/pull/1458)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [9a65a533](https://github.com/algolia/api-clients-automation/commit/9a65a533) feat(specs): add `size` to predict segment response ([#1434](https://github.com/algolia/api-clients-automation/pull/1434)) by [@bengreenbank](https://github.com/bengreenbank/)
+- [0ed9eb22](https://github.com/algolia/api-clients-automation/commit/0ed9eb22) fix(specs): add `input` in GET tasks ([#1472](https://github.com/algolia/api-clients-automation/pull/1472)) by [@shortcuts](https://github.com/shortcuts/)
+- [692aa2d8](https://github.com/algolia/api-clients-automation/commit/692aa2d8) fix(specs): add transform event type ([#1470](https://github.com/algolia/api-clients-automation/pull/1470)) by [@millotp](https://github.com/millotp/)
+- [69aac53d](https://github.com/algolia/api-clients-automation/commit/69aac53d) fix(specs): task trigger guard import order ([#1459](https://github.com/algolia/api-clients-automation/pull/1459)) by [@Fluf22](https://github.com/Fluf22/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [a0d96721](https://github.com/algolia/api-clients-automation/commit/a0d96721) fix(specs): task trigger guard import ([#1458](https://github.com/algolia/api-clients-automation/pull/1458)) by [@Fluf22](https://github.com/Fluf22/)
 - [d3f107d4](https://github.com/algolia/api-clients-automation/commit/d3f107d4) fix(specs): task trigger guard update ([#1457](https://github.com/algolia/api-clients-automation/pull/1457)) by [@Fluf22](https://github.com/Fluf22/)
 

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.0.0-alpha.58](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.57...5.0.0-alpha.58)
+
+- [9a65a533](https://github.com/algolia/api-clients-automation/commit/9a65a533) feat(specs): add `size` to predict segment response ([#1434](https://github.com/algolia/api-clients-automation/pull/1434)) by [@bengreenbank](https://github.com/bengreenbank/)
+- [0ed9eb22](https://github.com/algolia/api-clients-automation/commit/0ed9eb22) fix(specs): add `input` in GET tasks ([#1472](https://github.com/algolia/api-clients-automation/pull/1472)) by [@shortcuts](https://github.com/shortcuts/)
+- [692aa2d8](https://github.com/algolia/api-clients-automation/commit/692aa2d8) fix(specs): add transform event type ([#1470](https://github.com/algolia/api-clients-automation/pull/1470)) by [@millotp](https://github.com/millotp/)
+- [69aac53d](https://github.com/algolia/api-clients-automation/commit/69aac53d) fix(specs): task trigger guard import order ([#1459](https://github.com/algolia/api-clients-automation/pull/1459)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [5.0.0-alpha.57](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.56...5.0.0-alpha.57)
 
 - [a0d96721](https://github.com/algolia/api-clients-automation/commit/a0d96721) fix(specs): task trigger guard import ([#1458](https://github.com/algolia/api-clients-automation/pull/1458)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.57",
+  "version": "5.0.0-alpha.58",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.57",
+  "version": "5.0.0-alpha.58",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.57"
+    "@algolia/client-common": "5.0.0-alpha.58"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.57",
+  "version": "5.0.0-alpha.58",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.57"
+    "@algolia/client-common": "5.0.0-alpha.58"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.57",
+  "version": "5.0.0-alpha.58",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.57"
+    "@algolia/client-common": "5.0.0-alpha.58"
   },
   "devDependencies": {
     "@types/jest": "29.5.0",

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0-alpha.56](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.55...4.0.0-alpha.56)
+
+- [9a65a533](https://github.com/algolia/api-clients-automation/commit/9a65a533) feat(specs): add `size` to predict segment response ([#1434](https://github.com/algolia/api-clients-automation/pull/1434)) by [@bengreenbank](https://github.com/bengreenbank/)
+- [0ed9eb22](https://github.com/algolia/api-clients-automation/commit/0ed9eb22) fix(specs): add `input` in GET tasks ([#1472](https://github.com/algolia/api-clients-automation/pull/1472)) by [@shortcuts](https://github.com/shortcuts/)
+- [692aa2d8](https://github.com/algolia/api-clients-automation/commit/692aa2d8) fix(specs): add transform event type ([#1470](https://github.com/algolia/api-clients-automation/pull/1470)) by [@millotp](https://github.com/millotp/)
+- [69aac53d](https://github.com/algolia/api-clients-automation/commit/69aac53d) fix(specs): task trigger guard import order ([#1459](https://github.com/algolia/api-clients-automation/pull/1459)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [4.0.0-alpha.55](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.54...4.0.0-alpha.55)
 
 - [a0d96721](https://github.com/algolia/api-clients-automation/commit/a0d96721) fix(specs): task trigger guard import ([#1458](https://github.com/algolia/api-clients-automation/pull/1458)) by [@Fluf22](https://github.com/Fluf22/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.57",
+    "utilsPackageVersion": "5.0.0-alpha.58",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.55",
+    "packageVersion": "4.0.0-alpha.56",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.4",
+    "packageVersion": "4.0.0-alpha.5",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.57"
+          "packageVersion": "5.0.0-alpha.58"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.57"
+          "packageVersion": "1.0.0-alpha.58"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.31"
+          "packageVersion": "1.0.0-alpha.32"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.57 -> **`prerelease` _(e.g. 5.0.0-alpha.58)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.55 -> **`prerelease` _(e.g. 4.0.0-alpha.56)_**
- go: 4.0.0-alpha.4 -> **`prerelease` _(e.g. 4.0.0-alpha.5)_**

### Skipped Commits

_(None)_