### PR TITLE
fix(javascript): remove `mode` from Fetch requester

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
@@ -39,7 +39,6 @@ export function createFetchRequester({
       fetchRes = await fetch(request.url, {
         method: request.method,
         body: request.data || null,
-        mode: 'cors',
         redirect: 'manual',
         signal,
         ...requesterOptions,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1210

### Changes included:

Motivations can be found in https://github.com/algolia/algoliasearch-client-javascript/pull/1452

TLDR: We can remove this parameter from the defaulted values, as it's not compatible with Cloudflare workers. If the user wants to specify it, they can by providing request options.
