### PR TITLE
chore: make Java breaking changes non blocking

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -239,7 +239,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'java' }}
         run: |
           cd ${{ matrix.client.path }}
-          ./gradlew :api:japicmp
+          ./gradlew :api:japicmp || exit 0
 
           FILE=${{ matrix.client.path }}/api/build/reports/japi.txt
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -237,7 +237,15 @@ jobs:
 
       - name: Run Java 'algoliasearch' public API validation
         if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'java' }}
-        run: cd ${{ matrix.client.path }} && ./gradlew :api:japicmp
+        run: |
+          cd ${{ matrix.client.path }}
+          ./gradlew :api:japicmp
+
+          FILE=${{ matrix.client.path }}/api/build/reports/japi.txt
+
+          if [[ -f "$FILE" ]]; then
+            cat $FILE
+          fi
 
       - name: Remove previous CTS output
         run: rm -rf ${{ matrix.client.testsToDelete }} || true


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

It's not possible to easily debug issues like https://github.com/algolia/api-clients-automation/pull/1474 as the artifact is not generated when the CI fails, and therefore the file not accessible. This PR changes the CI check to be non blocking but to print the file if it exists
