### PR TITLE
chore: loose cache key computing by including CTS

### DIFF
--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -11,7 +11,7 @@ const JAVA_CLIENT_FOLDER = getLanguageFolder('java');
 const PHP_CLIENT_FOLDER = getLanguageFolder('php');
 const GO_CLIENT_FOLDER = getLanguageFolder('go');
 
-// Files that are common to every clients
+// Files that are common to every clients, this is used to determine if we should generate the matrix for this job.
 const CLIENTS_COMMON_FILES = [
   'config/openapitools.json',
   'config/clients.config.json',
@@ -63,18 +63,21 @@ export const DEPENDENCIES = {
   JAVA_CLIENT_CHANGED: [
     ...CLIENTS_COMMON_FILES,
     JAVA_CLIENT_FOLDER,
+    'config/.java-version',
     'templates/java',
     'generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java',
   ],
   PHP_CLIENT_CHANGED: [
     ...CLIENTS_COMMON_FILES,
     PHP_CLIENT_FOLDER,
+    'config/.php-version',
     'templates/php',
     'generators/src/main/java/com/algolia/codegen/AlgoliaPhpGenerator.java',
   ],
   GO_CLIENT_CHANDED: [
     ...CLIENTS_COMMON_FILES,
     GO_CLIENT_FOLDER,
+    'config/.go-version',
     'templates/go',
     'generators/src/main/java/com/algolia/codegen/AlgoliaGoGenerator.java',
   ],

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -18,18 +18,30 @@ const commonCacheKey = (async function (): Promise<string> {
   const scriptsHash = await hashElement(toAbsolutePath('scripts'), {
     encoding: 'hex',
     folders: { exclude: ['docker', '__tests__'] },
+    files: { include: ['**'] },
   });
   const configHash = await hashElement(toAbsolutePath('.'), {
     encoding: 'hex',
     folders: { include: ['config'] },
-    files: { include: ['openapitools.json', 'clients.config.json'] },
+    files: {
+      include: [
+        'openapitools.json',
+        'clients.config.json',
+        'base.tsconfig.json',
+      ],
+    },
+  });
+  const ctsHash = await hashElement(toAbsolutePath('tests'), {
+    encoding: 'hex',
+    folders: { include: ['CTS'] },
+    files: { include: ['**'] },
   });
   const depsHash = await hashElement(toAbsolutePath('.'), {
     encoding: 'hex',
     files: { include: ['yarn.lock'] },
   });
 
-  return `${ghHash.hash}-${scriptsHash.hash}-${configHash.hash}-${depsHash}`;
+  return `${ghHash.hash}-${scriptsHash.hash}-${configHash.hash}-${depsHash.hash}-${ctsHash.hash}`;
 })();
 
 /**


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

The cache key computing was pretty strict since we were developping a lot on this repository, not that it's a bit stalled we can loose it so that we don't end-up with false computed cache and unwanted behaviors