### PR TITLE
feat(specs): add predict segment size to responses [PRED-1277]

### DIFF
--- a/specs/predict/responses/Segment.yml
+++ b/specs/predict/responses/Segment.yml
@@ -7,6 +7,8 @@ updateSegmentResponse:
   properties:
     segmentID:
       $ref: '#/segmentID'
+    size:
+      $ref: '#/segmentSize'
     updatedAt:
       $ref: '#/updatedAt'
 
@@ -59,6 +61,8 @@ createSegmentResponse:
   properties:
     segmentID:
       $ref: '#/segmentID'
+    size:
+      $ref: '#/segmentSize'
     updatedAt:
       $ref: '#/updatedAt'
 


### PR DESCRIPTION
## 🧭 What and Why

Follow up to https://github.com/algolia/api-clients-automation/pull/1434

🎟 JIRA Ticket: [PRED-1277](https://algolia.atlassian.net/browse/PRED-1277)

### Changes included:

This adds the segment's `size` to the create and update responses.

## 🧪 Test

n/a


[PRED-1277]: https://algolia.atlassian.net/browse/PRED-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ