### PR TITLE
fix(cts): predict tests values as double

### DIFF
--- a/tests/CTS/methods/requests/predict/createSegment.json
+++ b/tests/CTS/methods/requests/predict/createSegment.json
@@ -11,7 +11,7 @@
             "filters": [
               {
                 "operator": "GT",
-                "value": 200
+                "value": 200.0
               }
             ]
           }
@@ -31,7 +31,7 @@
               "filters": [
                 {
                   "operator": "GT",
-                  "value": 200
+                  "value": 200.0
                 }
               ]
             }
@@ -55,7 +55,7 @@
                 "value": "red",
                 "probability": {
                   "GTE": 0.5,
-                  "LTE": 1
+                  "LTE": 1.0
                 }
               }
             ]
@@ -79,7 +79,7 @@
                   "value": "red",
                   "probability": {
                     "GTE": 0.5,
-                    "LTE": 1
+                    "LTE": 1.0
                   }
                 }
               ]

--- a/tests/CTS/methods/requests/predict/updateSegment.json
+++ b/tests/CTS/methods/requests/predict/updateSegment.json
@@ -28,7 +28,7 @@
               "filters": [
                 {
                   "operator": "GT",
-                  "value": 200
+                  "value": 200.0
                 }
               ]
             }
@@ -48,7 +48,7 @@
               "filters": [
                 {
                   "operator": "GT",
-                  "value": 200
+                  "value": 200.0
                 }
               ]
             }
@@ -71,7 +71,7 @@
               "filters": [
                 {
                   "operator": "GT",
-                  "value": 200
+                  "value": 200.0
                 }
               ]
             }
@@ -92,7 +92,7 @@
               "filters": [
                 {
                   "operator": "GT",
-                  "value": 200
+                  "value": 200.0
                 }
               ]
             }
@@ -117,7 +117,7 @@
                   "value": "red",
                   "probability": {
                     "GTE": 0.5,
-                    "LTE": 1
+                    "LTE": 1.0
                   }
                 }
               ]
@@ -141,7 +141,7 @@
                   "value": "red",
                   "probability": {
                     "GTE": 0.5,
-                    "LTE": 1
+                    "LTE": 1.0
                   }
                 }
               ]


### PR DESCRIPTION
## 🧭 What and Why

A few values are expected to be floating numbers. 
CTS generator uses the numbers format to determine expected type (for typed clients).
