### PR TITLE
fix(specs): remove unsupported delete option for task action type

### DIFF
--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -125,7 +125,7 @@ TaskSearch:
 ActionType:
   type: string
   description: The action to perform on the Algolia index.
-  enum: ['replace', 'save', 'delete']
+  enum: ['replace', 'save']
 
 TriggerInput:
   type: object


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-1218](https://algolia.atlassian.net/browse/DI-1218)

### Changes included:

Remove `delete` option in the task action type enum so it is also removed in the doc, as it's unsupported right now

[DI-1218]: https://algolia.atlassian.net/browse/DI-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ