### PR TITLE
chore: prepare release 2023-05-09

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.0-alpha.8](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.7...4.0.0-alpha.8)
+
+- [57b59189](https://github.com/algolia/api-clients-automation/commit/57b59189) feat(go): release process for generated go client ([#1512](https://github.com/algolia/api-clients-automation/pull/1512)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+- [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
+- [4fb9def5](https://github.com/algolia/api-clients-automation/commit/4fb9def5) feat(go): CTS implementation for go client ([#1509](https://github.com/algolia/api-clients-automation/pull/1509)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+- [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
+- [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [4.0.0-alpha.7](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.6...4.0.0-alpha.7)
 
 - [3af3eb49](https://github.com/algolia/api-clients-automation/commit/3af3eb49) fix(specs): update required for kotlin tests to pass ([#1492](https://github.com/algolia/api-clients-automation/pull/1492)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
+- [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
+- [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [3af3eb49](https://github.com/algolia/api-clients-automation/commit/3af3eb49) fix(specs): update required for kotlin tests to pass ([#1492](https://github.com/algolia/api-clients-automation/pull/1492)) by [@aallam](https://github.com/aallam/)
 - [44962fa5](https://github.com/algolia/api-clients-automation/commit/44962fa5) feat(clients): add bigquery to sourceTypes enum ([#1490](https://github.com/algolia/api-clients-automation/pull/1490)) by [@damcou](https://github.com/damcou/)
 

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.0.0-alpha.61](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.60...5.0.0-alpha.61)
+
+- [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
+- [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
+- [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [5.0.0-alpha.60](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.59...5.0.0-alpha.60)
 
 - [3af3eb49](https://github.com/algolia/api-clients-automation/commit/3af3eb49) fix(specs): update required for kotlin tests to pass ([#1492](https://github.com/algolia/api-clients-automation/pull/1492)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.60",
+  "version": "5.0.0-alpha.61",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.60",
+  "version": "5.0.0-alpha.61",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.60"
+    "@algolia/client-common": "5.0.0-alpha.61"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.60",
+  "version": "5.0.0-alpha.61",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.60"
+    "@algolia/client-common": "5.0.0-alpha.61"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.60",
+  "version": "5.0.0-alpha.61",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.60"
+    "@algolia/client-common": "5.0.0-alpha.61"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
+- [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
+- [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
+- [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)
+

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.59](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.58...4.0.0-alpha.59)
+
+- [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
+- [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
+- [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [4.0.0-alpha.58](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.57...4.0.0-alpha.58)
 
 - [3af3eb49](https://github.com/algolia/api-clients-automation/commit/3af3eb49) fix(specs): update required for kotlin tests to pass ([#1492](https://github.com/algolia/api-clients-automation/pull/1492)) by [@aallam](https://github.com/aallam/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.60",
+    "utilsPackageVersion": "5.0.0-alpha.61",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.58",
+    "packageVersion": "4.0.0-alpha.59",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.7",
+    "packageVersion": "4.0.0-alpha.8",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.60"
+          "packageVersion": "5.0.0-alpha.61"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.60"
+          "packageVersion": "1.0.0-alpha.61"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.34"
+          "packageVersion": "1.0.0-alpha.35"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.60 -> **`prerelease` _(e.g. 5.0.0-alpha.61)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.58 -> **`prerelease` _(e.g. 4.0.0-alpha.59)_**
- go: 4.0.0-alpha.7 -> **`prerelease` _(e.g. 4.0.0-alpha.8)_**
- kotlin: 3.0.0-SNAPSHOT -> **`minor` _(e.g. 3.0.0-SNAPSHOT)_**

### Skipped Commits

_(None)_