### PR TITLE
feat(go): parameter arguments for request creation improved with all …

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -97,6 +97,7 @@ public class TestsRequest extends TestsGenerator {
           test.put("request", req.request);
           test.put("hasParameters", req.parameters.size() != 0);
           test.put("extras", req.extras);
+          test.put("hasOperationParams", ope.hasParams);
 
           if (req.requestOptions != null) {
             test.put("hasRequestOptions", true);

--- a/playground/go/analytics.go
+++ b/playground/go/analytics.go
@@ -11,7 +11,7 @@ func testAnalytics(appID, apiKey string) int {
 	analyticsClient := analytics.NewClient(appID, apiKey, analytics.US)
 
 	getTopFilterForAttributeResponse, err := analyticsClient.GetTopFilterForAttribute(
-		analyticsClient.NewApiGetTopFilterForAttributeRequest("myAttribute1,myAttribute2").WithIndex(indexName),
+		analyticsClient.NewApiGetTopFilterForAttributeRequest("myAttribute1,myAttribute2", indexName),
 	)
 	if err != nil {
 		fmt.Printf("request error with GetTopFilterForAttribute: %v\n", err)

--- a/playground/go/ingestion.go
+++ b/playground/go/ingestion.go
@@ -2,12 +2,33 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/algolia/algoliasearch-client-go/v4/algolia/ingestion"
 )
 
 func testIngestion(appID, apiKey string) int {
 	ingestionClient := ingestion.NewClient(appID, apiKey, ingestion.US)
+
+	// another example to generate payload for a request.
+	createAuthenticationResponse, err := ingestionClient.CreateAuthentication(ingestionClient.NewApiCreateAuthenticationRequest(
+		&ingestion.AuthenticationCreate{
+			Type: ingestion.AUTHENTICATIONTYPE_BASIC,
+			Name: fmt.Sprintf("my-authentication-%d", time.Now().Unix()),
+			Input: ingestion.AuthInput{
+				AuthBasic: &ingestion.AuthBasic{
+					Username: "username",
+					Password: "password",
+				},
+			},
+		}))
+
+	if err != nil {
+		fmt.Printf("request error with CreateAuthentication: %v\n", err)
+		return 1
+	}
+
+	printResponse(createAuthenticationResponse)
 
 	listAuthenticationsResponse, err := ingestionClient.GetAuthentications(
 		ingestionClient.NewApiGetAuthenticationsRequest().WithItemsPerPage(2),

--- a/playground/go/insights.go
+++ b/playground/go/insights.go
@@ -18,7 +18,7 @@ func testInsights(appID, apiKey string) int {
 			insights.WithInsightEventQueryID("myQueryID")),
 	})
 	pushEventsResponse, err := insightsClient.PushEvents(
-		insightsClient.NewApiPushEventsRequest().WithInsightEvents(events),
+		insightsClient.NewApiPushEventsRequest(events),
 	)
 	if err != nil {
 		fmt.Printf("request error with PushEvents: %v\n", err)

--- a/playground/go/predict.go
+++ b/playground/go/predict.go
@@ -14,7 +14,7 @@ func testPredict(appID, apiKey string) int {
 		predict.WithAllParamsTypesToRetrieve(predict.AllowedTypesToRetrieveEnumValues),
 	))
 	userProfile, err := predictClient.FetchUserProfile(
-		predictClient.NewApiFetchUserProfileRequest("userId").WithParams(&params),
+		predictClient.NewApiFetchUserProfileRequest("userId", &params),
 	)
 	if err != nil {
 		fmt.Printf("request error with FetchUserProfile: %v\n", err)

--- a/playground/go/query-suggestions.go
+++ b/playground/go/query-suggestions.go
@@ -9,9 +9,8 @@ import (
 func testQuerySuggestions(appID, apiKey string) int {
 	suggestionsClient := suggestions.NewClient(appID, apiKey, suggestions.US)
 
-	querySuggestionsIndex, err := suggestionsClient.GetAllConfigs(
-		suggestionsClient.NewApiGetAllConfigsRequest(),
-	)
+	// if there is no params for the requests, we don't need to give empty request instance such as `suggestionsClient.NewApiGetAllConfigsRequest()`.
+	querySuggestionsIndex, err := suggestionsClient.GetAllConfigs()
 	if err != nil {
 		fmt.Printf("request error with GetAllConfigs: %v\n", err)
 		return 1

--- a/playground/go/recommend.go
+++ b/playground/go/recommend.go
@@ -15,7 +15,7 @@ func testRecommend(appID, apiKey string) int {
 		})
 	*/
 	// alternative way to create the payloads, a similar approach can be used with any of the other clients
-	params := recommend.GetRecommendationsParams{
+	params := &recommend.GetRecommendationsParams{
 		Requests: []recommend.RecommendationsRequest{
 			{
 				RecommendationRequest: &recommend.RecommendationRequest{
@@ -29,7 +29,7 @@ func testRecommend(appID, apiKey string) int {
 	}
 
 	searchResponse, err := recommendClient.GetRecommendations(
-		recommendClient.NewApiGetRecommendationsRequest().WithGetRecommendationsParams(&params),
+		recommendClient.NewApiGetRecommendationsRequest(params),
 	)
 	if err != nil {
 		fmt.Printf("request error with SearchSingleIndex: %v\n", err)

--- a/templates/go/api.mustache
+++ b/templates/go/api.mustache
@@ -37,8 +37,6 @@ func HeaderParamOption(name string, val any) Option {
 }
 
 {{#operation}}
-
-  // hasParams: {{#hasParams}}true{{/hasParams}}{{^hasParams}}false{{/hasParams}}
   {{#hasParams}}
   type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request struct {
 {{#allParams}}

--- a/templates/go/api.mustache
+++ b/templates/go/api.mustache
@@ -38,6 +38,8 @@ func HeaderParamOption(name string, val any) Option {
 
 {{#operation}}
 
+  // hasParams: {{#hasParams}}true{{/hasParams}}{{^hasParams}}false{{/hasParams}}
+  {{#hasParams}}
   type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request struct {
 {{#allParams}}
 	{{paramName}} {{^isPathParam}}{{^isFreeFormObject}}{{^isArray}}{{^isPrimitiveType}}*{{/isPrimitiveType}}{{/isArray}}{{/isFreeFormObject}}{{/isPathParam}}{{{dataType}}}
@@ -51,7 +53,7 @@ func (r *{{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/
 		return err
 	}
   {{#allParams}}
-	if v, ok := req["{{#isQueryParam}}{{baseName}}{{/isQueryParam}}{{^isQueryParam}}{{paramName}}{{/isQueryParam}}"]; ok { //{{paramName}}
+	if v, ok := req["{{#isQueryParam}}{{baseName}}{{/isQueryParam}}{{^isQueryParam}}{{paramName}}{{/isQueryParam}}"]; ok {
 		err = json.Unmarshal(v, &r.{{paramName}})
 		if err != nil {
       err = json.Unmarshal(b, &r.{{paramName}})
@@ -71,7 +73,7 @@ func (r *{{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/
 }
 
 {{#allParams}}
-{{^isPathParam}}
+{{^required}}
 {{#description}}
 // {{.}}
 {{/description}}
@@ -83,26 +85,26 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/s
 	return r
 }
 
-{{/isPathParam}}
+{{/required}}
 {{/allParams}}
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
 //@return {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request
-func (c *APIClient) NewApi{{{nickname}}}Request({{#pathParams}} {{paramName}} {{{dataType}}} {{^-last}},{{/-last}}{{/pathParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request {
+func (c *APIClient) NewApi{{{nickname}}}Request({{#requiredParams}} {{paramName}} {{^isPathParam}}{{^isFreeFormObject}}{{^isArray}}{{^isPrimitiveType}}*{{/isPrimitiveType}}{{/isArray}}{{/isFreeFormObject}}{{/isPathParam}}{{{dataType}}} {{^-last}},{{/-last}}{{/requiredParams}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request {
 	return {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request{
-		{{#pathParams}}
+		{{#requiredParams}}
 		{{paramName}}: {{paramName}},
-		{{/pathParams}}
+		{{/requiredParams}}
 	}
 }
-
+{{/hasParams}}
 // {{nickname}} wraps {{nickname}}WithContext using context.Background.
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (c *APIClient) {{nickname}}(r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request, opts ...Option) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}error) {
-  return c.{{nickname}}WithContext(context.Background(), r, opts...)
+func (c *APIClient) {{nickname}}({{#hasParams}}r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request,{{/hasParams}} opts ...Option) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}error) {
+  return c.{{nickname}}WithContext(context.Background(), {{#hasParams}}r,{{/hasParams}} opts...)
 }
 
 // {{{description}}}{{#returnType}}
@@ -110,7 +112,7 @@ func (c *APIClient) {{nickname}}(r {{#structPrefix}}{{&classname}}{{/structPrefi
 {{#isDeprecated}}
 // Deprecated
 {{/isDeprecated}}
-func (c *APIClient) {{nickname}}WithContext(ctx context.Context, r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request, opts ...Option) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}error) {
+func (c *APIClient) {{nickname}}WithContext(ctx context.Context, {{#hasParams}}r {{#structPrefix}}{{&classname}}{{/structPrefix}}{{^structPrefix}}Api{{/structPrefix}}{{operationId}}Request,{{/hasParams}} opts ...Option) ({{#returnType}}{{^isArray}}{{^returnTypeIsPrimitive}}*{{/returnTypeIsPrimitive}}{{/isArray}}{{{.}}}, {{/returnType}}error) {
 	var (
     postBody     any
 		{{#returnType}}

--- a/templates/go/tests/requests/requests.mustache
+++ b/templates/go/tests/requests/requests.mustache
@@ -36,9 +36,11 @@ func Test{{#lambda.titlecase}}{{clientPrefix}}{{/lambda.titlecase}}_{{#lambda.ti
     name: "{{{testName}}}",
     testFunc: func(t *testing.T) { {{#extras}}{{#skipForGo}}
       t.Skip("skipping test for go client"){{/skipForGo}}{{/extras}}
+      {{#hasOperationParams}}
       parametersStr := `{{{parameters}}}`
       req := {{clientPrefix}}.Api{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}Request{}
       require.NoError(t, json.Unmarshal([]byte(parametersStr), &req))
+      {{/hasOperationParams}}
       {{#hasRequestOptions}}
         var opts []{{clientPrefix}}.Option
         {{#requestOptions.queryParameters}}
@@ -56,7 +58,7 @@ func Test{{#lambda.titlecase}}{{clientPrefix}}{{/lambda.titlecase}}_{{#lambda.ti
         }
         {{/requestOptions.headers}}
       {{/hasRequestOptions}}
-      _, err := client.{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}(req{{#hasRequestOptions}}, opts...{{/hasRequestOptions}})
+      _, err := client.{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}({{#hasOperationParams}}req{{/hasOperationParams}}{{#hasRequestOptions}}{{#hasOperationParams}},{{/hasOperationParams}} opts...{{/hasRequestOptions}})
       require.NoError(t, err)
 
       expectedPath, err := url.QueryUnescape("{{{request.path}}}")


### PR DESCRIPTION
…required params

## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-676

When creating a request instance to pass we are expecting only path params and some required params was needed set with ".With{{Param}}()" syntax.  

### Changes included:

- Instead of just path parameters we are expecting all required params when instantiating.
- For some rare requests, there is no param at all. It is handled to not expect an empty request instance.
- Playground examples are updated with the new generation. 

## 🧪 Test

CI should pass and playground examples can be tried without an issue. 
