### PR TITLE
chore: prepare release 2023-05-16

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.9](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.8...4.0.0-alpha.9)
+
+- [49b4c00c](https://github.com/algolia/api-clients-automation/commit/49b4c00c) feat(specs): add property to BigQuery source input ([#1547](https://github.com/algolia/api-clients-automation/pull/1547)) by [@Fluf22](https://github.com/Fluf22/)
+- [fe7057d1](https://github.com/algolia/api-clients-automation/commit/fe7057d1) feat(go): parameter arguments for request creation improved with all … ([#1535](https://github.com/algolia/api-clients-automation/pull/1535)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+- [d2ad9cb9](https://github.com/algolia/api-clients-automation/commit/d2ad9cb9) feat(go): Add context support to all requests ([#1527](https://github.com/algolia/api-clients-automation/pull/1527)) by [@mehmetaligok](https://github.com/mehmetaligok/)
+
 ## [4.0.0-alpha.8](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.7...4.0.0-alpha.8)
 
 - [57b59189](https://github.com/algolia/api-clients-automation/commit/57b59189) feat(go): release process for generated go client ([#1512](https://github.com/algolia/api-clients-automation/pull/1512)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [49b4c00c](https://github.com/algolia/api-clients-automation/commit/49b4c00c) feat(specs): add property to BigQuery source input ([#1547](https://github.com/algolia/api-clients-automation/pull/1547)) by [@Fluf22](https://github.com/Fluf22/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
 - [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
 - [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.62](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.61...5.0.0-alpha.62)
+
+- [49b4c00c](https://github.com/algolia/api-clients-automation/commit/49b4c00c) feat(specs): add property to BigQuery source input ([#1547](https://github.com/algolia/api-clients-automation/pull/1547)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [5.0.0-alpha.61](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.60...5.0.0-alpha.61)
 
 - [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.61",
+  "version": "5.0.0-alpha.62",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.61",
+  "version": "5.0.0-alpha.62",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.61"
+    "@algolia/client-common": "5.0.0-alpha.62"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.61",
+  "version": "5.0.0-alpha.62",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.61"
+    "@algolia/client-common": "5.0.0-alpha.62"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.61",
+  "version": "5.0.0-alpha.62",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.61"
+    "@algolia/client-common": "5.0.0-alpha.62"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
 
+- [49b4c00c](https://github.com/algolia/api-clients-automation/commit/49b4c00c) feat(specs): add property to BigQuery source input ([#1547](https://github.com/algolia/api-clients-automation/pull/1547)) by [@Fluf22](https://github.com/Fluf22/)
+
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
 - [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)
 - [558b8fbb](https://github.com/algolia/api-clients-automation/commit/558b8fbb) feat(clients): add Kotlin API client ([#1400](https://github.com/algolia/api-clients-automation/pull/1400)) by [@aallam](https://github.com/aallam/)
 - [102f3d4d](https://github.com/algolia/api-clients-automation/commit/102f3d4d) fix(specs): remove unsupported delete option for task action type ([#1511](https://github.com/algolia/api-clients-automation/pull/1511)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.60](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.59...4.0.0-alpha.60)
+
+- [49b4c00c](https://github.com/algolia/api-clients-automation/commit/49b4c00c) feat(specs): add property to BigQuery source input ([#1547](https://github.com/algolia/api-clients-automation/pull/1547)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [4.0.0-alpha.59](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.58...4.0.0-alpha.59)
 
 - [7c9cfb9b](https://github.com/algolia/api-clients-automation/commit/7c9cfb9b) feat(specs): add reason code to run outcome ([#1531](https://github.com/algolia/api-clients-automation/pull/1531)) by [@Fluf22](https://github.com/Fluf22/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.61",
+    "utilsPackageVersion": "5.0.0-alpha.62",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.59",
+    "packageVersion": "4.0.0-alpha.60",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.8",
+    "packageVersion": "4.0.0-alpha.9",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.61"
+          "packageVersion": "5.0.0-alpha.62"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.61"
+          "packageVersion": "1.0.0-alpha.62"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.35"
+          "packageVersion": "1.0.0-alpha.36"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.61 -> **`prerelease` _(e.g. 5.0.0-alpha.62)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.59 -> **`prerelease` _(e.g. 4.0.0-alpha.60)_**
- go: 4.0.0-alpha.8 -> **`prerelease` _(e.g. 4.0.0-alpha.9)_**
- kotlin: 3.0.0-SNAPSHOT -> **`minor` _(e.g. 3.0.0-SNAPSHOT)_**

### Skipped Commits

_(None)_