### PR TITLE
chore: prepare release 2023-06-08

### DIFF
--- a/clients/algoliasearch-client-dart/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.0-alpha.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.1.0-alpha.2...0.1.0-alpha.3)
+
+- [f65d1b4b](https://github.com/algolia/api-clients-automation/commit/f65d1b4b) refactor(dart): remove dart search lite ([#1597](https://github.com/algolia/api-clients-automation/pull/1597)) by [@aallam](https://github.com/aallam/)
+- [e5c88b01](https://github.com/algolia/api-clients-automation/commit/e5c88b01) feat(dart): algoliasearch with lite and umbrella libs ([#1596](https://github.com/algolia/api-clients-automation/pull/1596)) by [@aallam](https://github.com/aallam/)
+
 ## [0.1.0-alpha.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.1.0-alpha.1...0.1.0-alpha.2)
 
 - [e1cb1c89](https://github.com/algolia/api-clients-automation/commit/e1cb1c89) fix(specs): add docker source input ([#1594](https://github.com/algolia/api-clients-automation/pull/1594)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.68](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.67...5.0.0-alpha.68)
+
+- [31f1050a](https://github.com/algolia/api-clients-automation/commit/31f1050a) fix(javascript): waitForApiKey helper ([#1598](https://github.com/algolia/api-clients-automation/pull/1598)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.67](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.66...5.0.0-alpha.67)
 
 - [e1cb1c89](https://github.com/algolia/api-clients-automation/commit/e1cb1c89) fix(specs): add docker source input ([#1594](https://github.com/algolia/api-clients-automation/pull/1594)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.67",
+  "version": "5.0.0-alpha.68",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.67",
+  "version": "5.0.0-alpha.68",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.67"
+    "@algolia/client-common": "5.0.0-alpha.68"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.67",
+  "version": "5.0.0-alpha.68",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.67"
+    "@algolia/client-common": "5.0.0-alpha.68"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.67",
+  "version": "5.0.0-alpha.68",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.67"
+    "@algolia/client-common": "5.0.0-alpha.68"
   },
   "devDependencies": {
     "@types/jest": "29.5.1",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.67",
+    "utilsPackageVersion": "5.0.0-alpha.68",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.1.0-alpha.2",
+    "packageVersion": "0.1.0-alpha.3",
     "modelFolder": "lib/src",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.67"
+          "packageVersion": "5.0.0-alpha.68"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.67"
+          "packageVersion": "1.0.0-alpha.68"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.41"
+          "packageVersion": "1.0.0-alpha.42"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.67 -> **`prerelease` _(e.g. 5.0.0-alpha.68)_**
- ~java: 4.0.0-SNAPSHOT (no commit)~
- ~php: 4.0.0-alpha.65 (no commit)~
- ~go: 4.0.0-alpha.14 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- dart: 0.1.0-alpha.2 -> **`prerelease` _(e.g. 0.1.0-alpha.3)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - revert: "fix(javascript): waitForApiKey helper (#1598)" (#1599)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  
</details>