### PR TITLE
fix(specs): add processing run outcome

### DIFF
--- a/specs/ingestion/common/schemas/run.yml
+++ b/specs/ingestion/common/schemas/run.yml
@@ -77,7 +77,7 @@ RunStatus:
 
 RunOutcome:
   type: string
-  enum: ['success', 'failure']
+  enum: ['success', 'failure', 'processing']
 
 RunType:
   type: string
@@ -86,4 +86,5 @@ RunType:
 RunReasonCode:
   type: string
   description: 'An identifier that pairs with the outcome reason.'
-  enum: ['internal', 'critical', 'no_events', 'too_many_errors', 'ok', 'discarded']
+  enum:
+    ['internal', 'critical', 'no_events', 'too_many_errors', 'ok', 'discarded']


### PR DESCRIPTION
## 🧭 What and Why

Add the `processing` outcome to run, returned when the compute is already taking place by someone else, or a previous request.