### PR TITLE
fix(specs): add blocking to reasonCode instead of outcome

### DIFF
--- a/specs/ingestion/common/schemas/run.yml
+++ b/specs/ingestion/common/schemas/run.yml
@@ -77,7 +77,7 @@ RunStatus:
 
 RunOutcome:
   type: string
-  enum: ['success', 'failure', 'processing', 'blocking']
+  enum: ['success', 'failure', 'processing']
 
 RunType:
   type: string
@@ -87,4 +87,4 @@ RunReasonCode:
   type: string
   description: 'An identifier that pairs with the outcome reason.'
   enum:
-    ['internal', 'critical', 'no_events', 'too_many_errors', 'ok', 'discarded']
+    ['internal', 'critical', 'no_events', 'too_many_errors', 'ok', 'discarded', 'blocking']


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: DI-1351

### Changes included:

- blocking value should belong to possible `reasonCode` and not `RunOutcome`
