### PR TITLE
chore: prepare release 2023-06-16

### DIFF
--- a/clients/algoliasearch-client-dart/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.1...0.3.2)
+
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
 ## [0.3.1](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.3.1)
 
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.17](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.16...4.0.0-alpha.17)
+
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
 ## [4.0.0-alpha.16](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.15...4.0.0-alpha.16)
 
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)
 
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.70](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.69...5.0.0-alpha.70)
+
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
 ## [5.0.0-alpha.69](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.68...5.0.0-alpha.69)
 
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.69",
+  "version": "5.0.0-alpha.70",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.69",
+  "version": "5.0.0-alpha.70",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.69"
+    "@algolia/client-common": "5.0.0-alpha.70"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.69",
+  "version": "5.0.0-alpha.70",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.69"
+    "@algolia/client-common": "5.0.0-alpha.70"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.69",
+  "version": "5.0.0-alpha.70",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.69"
+    "@algolia/client-common": "5.0.0-alpha.70"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
 
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)
 
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.68](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.67...4.0.0-alpha.68)
+
+- [308c7ccb](https://github.com/algolia/api-clients-automation/commit/308c7ccb) fix(specs): add blocking to reasonCode instead of outcome ([#1622](https://github.com/algolia/api-clients-automation/pull/1622)) by [@damcou](https://github.com/damcou/)
+
 ## [4.0.0-alpha.67](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.66...4.0.0-alpha.67)
 
 - [3cdb7495](https://github.com/algolia/api-clients-automation/commit/3cdb7495) fix(specs): add blocking run outcome ([#1619](https://github.com/algolia/api-clients-automation/pull/1619)) by [@damcou](https://github.com/damcou/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.69",
+    "utilsPackageVersion": "5.0.0-alpha.70",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.67",
+    "packageVersion": "4.0.0-alpha.68",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.16",
+    "packageVersion": "4.0.0-alpha.17",
     "modelFolder": "algolia/models",
     "apiFolder": "algolia/api",
     "customGenerator": "algolia-go",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.3.1",
+    "packageVersion": "0.3.2",
     "modelFolder": "lib/src",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,63 +6,63 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.69"
+          "packageVersion": "5.0.0-alpha.70"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.69"
+          "packageVersion": "1.0.0-alpha.70"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.43"
+          "packageVersion": "1.0.0-alpha.44"
         }
       },
       "java-search": {


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.69 -> **`prerelease` _(e.g. 5.0.0-alpha.70)_**
- java: 4.0.0-SNAPSHOT -> **`patch` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.67 -> **`prerelease` _(e.g. 4.0.0-alpha.68)_**
- go: 4.0.0-alpha.16 -> **`prerelease` _(e.g. 4.0.0-alpha.17)_**
- kotlin: 3.0.0-SNAPSHOT -> **`patch` _(e.g. 3.0.0-SNAPSHOT)_**
- dart: 0.3.1 -> **`patch` _(e.g. 0.3.2)_**

### Skipped Commits

_(None)_