### PR TITLE
fix(specs): change github container registry name

### DIFF
--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -262,7 +262,7 @@ SourceDocker:
 
 DockerRegistry:
   type: string
-  enum: ['dockerhub', 'gcr']
+  enum: ['dockerhub', 'ghcr']
   description: The registry where the image is stored.
 
 DockerImageType:


### PR DESCRIPTION
## 🧭 What and Why

Fixes a tiny typo in the Github Container Repository.