### PR TITLE
chore(ci): fix melos version post scripts

### DIFF
--- a/clients/algoliasearch-client-dart/melos.yaml
+++ b/clients/algoliasearch-client-dart/melos.yaml
@@ -43,8 +43,7 @@ command:
   version:
     hooks:
       post: |
-        cd packages && \
-        for dir in */ ; do \
-          version=$(grep "^version:" "$dir/pubspec.yaml" | sed 's/version: //') && \
-          sed -i '' "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "$dir/lib/src/version.dart"; \
+        for dir in packages/*/ ; do \
+          version=$(grep "^version:" "${dir}pubspec.yaml" | sed 's/version: //') && \
+          sed -i '' -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart"; \
         done

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -219,12 +219,12 @@ export async function updateAPIVersions(
 export async function updateDartPackages(): Promise<void> {
   const cwd = getLanguageFolder('dart');
 
-  console.log("Generate dart packages versions and changelogs")
+  // Generate dart packages versions and changelogs
   await run(
     `(cd ${cwd} && melos version --no-git-tag-version --published --yes)`
   );
 
-  console.log("Update packages configs based on generated versions")
+  // Update packages configs based on generated versions
   for (const gen of Object.values(GENERATORS)) {
     if (gen.language === 'dart') {
       const { additionalProperties } = gen;

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -219,15 +219,18 @@ export async function updateAPIVersions(
 export async function updateDartPackages(): Promise<void> {
   const cwd = getLanguageFolder('dart');
 
-  // Generate packages versions and changelogs.
+  console.log("Generate dart packages versions and changelogs")
   await run(
     `(cd ${cwd} && melos version --no-git-tag-version --published --yes)`
   );
 
+  console.log("Update packages configs based on generated versions")
   for (const gen of Object.values(GENERATORS)) {
     if (gen.language === 'dart') {
       const { additionalProperties } = gen;
-      const newVersion = await getPubspecVersion(`${gen.output}/pubspec.yaml`);
+      const newVersion = await getPubspecVersion(
+        `../${gen.output}/pubspec.yaml`
+      );
       if (!newVersion) {
         throw new Error(`Failed to bump '${gen.packageName}'.`);
       }


### PR DESCRIPTION
## 🧭 What and Why

The scripts is not able to update static version and config file after an update.

### Changes included:

- Update melos post script
- Update config file version script
