### PR TITLE
chore(ci): fix melos post script compat

### DIFF
--- a/clients/algoliasearch-client-dart/melos.yaml
+++ b/clients/algoliasearch-client-dart/melos.yaml
@@ -42,8 +42,4 @@ scripts:
 command:
   version:
     hooks:
-      post: |
-        for dir in packages/*/ ; do \
-          version=$(grep "^version:" "${dir}pubspec.yaml" | sed 's/version: //') && \
-          sed -i '' -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart"; \
-        done
+      post: ./sync.sh

--- a/clients/algoliasearch-client-dart/sync.sh
+++ b/clients/algoliasearch-client-dart/sync.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-for dir in packages/*/ ; do \
-  dir=${dir%/} \
-  version=$(grep "^version:" "${dir}/pubspec.yaml" | sed 's/version: //') && \
-  awk -v ver="$version" '{gsub(/const packageVersion = .*;/, "const packageVersion = \047"ver"\047;"); print}' "${dir}/lib/src/version.dart" > temp && mv temp "${dir}/lib/src/version.dart"; \
+for dir in packages/*/ ; do
+  dir=${dir%/}
+  version=$(grep "^version:" "${dir}/pubspec.yaml" | sed 's/version: //') &&
+  if [[ "$(uname)" == "Darwin" ]]; then \
+    sed -i '' -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart";
+  else
+    sed -i -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart";
+  fi;
 done

--- a/clients/algoliasearch-client-dart/sync.sh
+++ b/clients/algoliasearch-client-dart/sync.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for dir in packages/*/ ; do \
+  dir=${dir%/} \
+  version=$(grep "^version:" "${dir}/pubspec.yaml" | sed 's/version: //') && \
+  awk -v ver="$version" '{gsub(/const packageVersion = .*;/, "const packageVersion = \047"ver"\047;"); print}' "${dir}/lib/src/version.dart" > temp && mv temp "${dir}/lib/src/version.dart"; \
+done

--- a/clients/algoliasearch-client-dart/sync.sh
+++ b/clients/algoliasearch-client-dart/sync.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed_arg=('-i' '' '-e')
+else
+  sed_arg=('-i' '-e')
+fi
+
 for dir in packages/*/ ; do
   dir=${dir%/}
-  version=$(grep "^version:" "${dir}/pubspec.yaml" | sed 's/version: //') &&
-  if [[ "$(uname)" == "Darwin" ]]; then \
-    sed -i '' -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart";
-  else
-    sed -i -e "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart";
-  fi;
+  version=$(grep "^version:" "${dir}/pubspec.yaml" | sed 's/version: //')
+  sed "${sed_arg[@]}" "s/^const packageVersion = .*;$/const packageVersion = '$version';/" "${dir}/lib/src/version.dart";
 done


### PR DESCRIPTION
## 🧭 What and Why

The command `sed` isn't behaving the same way in both macos and linux, causing the scripts to fail.

🎟 JIRA Ticket:

### Changes included:

Update the script to work for BSD/Linux platforms.