### PR TITLE
fix(dart): update `dio` exceptions handling 

### DIFF
--- a/clients/algoliasearch-client-dart/melos.yaml
+++ b/clients/algoliasearch-client-dart/melos.yaml
@@ -12,7 +12,7 @@ scripts:
     description: Build all generated files.
 
   analyze:
-    exec: dart analyze .
+    exec: dart analyze --fatal-infos
     description: Run static analysis checks in all packages
 
   format:
@@ -24,16 +24,24 @@ scripts:
     description: Find and fix static analysis issues in all packages
 
   lint:
-    run: melos fix && melos format
+    run: melos fix && melos format && melos analyze
     description: fix and format all packages
+
+  test:
+    exec: dart test
+    description: Run `dart test` in all packages
 
   get:
     exec: dart pub get
     description: Run `dart pub get` in all packages
 
-  test:
-    exec: dart test
-    description: Run `dart test` in all packages
+  update:
+    exec: dart pub update
+    description: Run `dart pub update` in all packages
+
+  upgrade:
+    exec: dart pub update
+    description: Run `dart pub update` in all packages
 
   clear:
     exec: rm -rf .dart_tool

--- a/clients/algoliasearch-client-dart/melos.yaml
+++ b/clients/algoliasearch-client-dart/melos.yaml
@@ -40,8 +40,8 @@ scripts:
     description: Run `dart pub update` in all packages
 
   upgrade:
-    exec: dart pub update
-    description: Run `dart pub update` in all packages
+    exec: dart pub upgrade
+    description: Run `dart pub upgrade` in all packages
 
   clear:
     exec: rm -rf .dart_tool

--- a/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
+++ b/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
@@ -53,21 +53,21 @@ class DioRequester implements Requester {
   Future<HttpResponse> perform(HttpRequest request) async {
     try {
       return await execute(request);
-    } on DioError catch (e) {
+    } on DioException catch (e) {
       switch (e.type) {
-        case DioErrorType.connectionTimeout:
-        case DioErrorType.sendTimeout:
-        case DioErrorType.receiveTimeout:
+        case DioExceptionType.connectionTimeout:
+        case DioExceptionType.sendTimeout:
+        case DioExceptionType.receiveTimeout:
           throw AlgoliaTimeoutException(e);
-        case DioErrorType.badResponse:
+        case DioExceptionType.badResponse:
           throw AlgoliaApiException(
             e.response?.statusCode ?? 0,
             e.error ?? e.response,
           );
-        case DioErrorType.badCertificate:
-        case DioErrorType.cancel:
-        case DioErrorType.connectionError:
-        case DioErrorType.unknown:
+        case DioExceptionType.badCertificate:
+        case DioExceptionType.cancel:
+        case DioExceptionType.connectionError:
+        case DioExceptionType.unknown:
           throw AlgoliaIOException(e);
       }
     }

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  dio: ^5.0.0
+  dio: ^5.2.1
 
 dev_dependencies:
   lints: ^2.1.1


### PR DESCRIPTION
## 🧭 What and Why

Starting from version `5.2.0`, the HTTP client Dio has started throwing errors in `dart analyze` due to a migration from `DioError` to `DioException`. Any errors thrown during `dart analyze` will cause the release process to fail.

### Changes included:

- The error handling logic has been updated to use `DioException`.
- The dio version has been updated.
- The Melos scripts have been updated to run `dart analyze` and will now fail if any errors are found.
