### PR TITLE
fix(cts): allow different ordering of `oneOf` schema

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
@@ -558,7 +558,9 @@ public class ParametersWithDataType {
             }
           }
         }
-        if (commonCount > maxCount) {
+        // >= is as wrong as >, but it allows different ordering of oneOf matching (e.g.
+        // `pushEvents.json` test file)
+        if (commonCount >= maxCount) {
           maxCount = commonCount;
           bestOneOf = oneOf;
         }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1379

### Changes included:

This PR makes the CTS code generation work for complex oneOf schemas like in https://github.com/algolia/api-clients-automation/pull/1647.

Today we only guess the matching oneOf by counting the number of matching elements, which is correct but enforce a specific order. The proposed solution is not more correct, but a bit looser as it doesn't enforce the element to be first in the oneOf matching list.

## 🧪 Test

This PR shouldn't impact the current CTS generation.
