### PR TITLE
docs: add `manage dictionary entries` guide

### DIFF
--- a/website/docs/clients/guides/manage-dictionary-entries.mdx
+++ b/website/docs/clients/guides/manage-dictionary-entries.mdx
@@ -1,0 +1,168 @@
+---
+title: Manage dictionary entries
+---
+
+import { TabsLanguage } from '../../../src/components/TabsLanguage';
+import TabItem from '@theme/TabItem';
+
+The REST API offers a single endpoint to manage your dictorionary, this guide will demonstrate how to manage entries based on your needs.
+
+## Append new entries to your dictionary
+
+<TabsLanguage>
+<TabItem value="javascript">
+
+```js
+await client.batchDictionaryEntries({
+      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      batchDictionaryEntriesParams: {
+        clearExistingDictionaryEntries: false, // here we want to append data, so we don't clear existing entries
+        requests: [
+          {
+            action: 'addEntry',
+            body: {
+              objectID: '1',
+              language: 'en',
+              word: 'fancy',
+              words: ['believe', 'algolia'],
+              decomposition: ['trust', 'algolia'],
+              state: 'enabled',
+            },
+          },
+        ],
+      },
+    })
+```
+
+</TabItem>
+<TabItem value="php">
+
+```php
+// TODO
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// TODO
+```
+
+</TabItem>
+</TabsLanguage>
+
+## Replace dictionary entries
+
+<TabsLanguage>
+<TabItem value="javascript">
+
+```js
+await client.batchDictionaryEntries({
+      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      batchDictionaryEntriesParams: {
+        clearExistingDictionaryEntries: true, // Since we replace, we will create a new dictionary from those entries
+        requests: [
+          {
+            action: 'addEntry',
+            body: {
+              objectID: '1',
+              language: 'en',
+              word: 'fancy',
+              words: ['believe', 'algolia'],
+              decomposition: ['trust', 'algolia'],
+              state: 'enabled',
+            },
+          },
+        ],
+      },
+    })
+```
+
+</TabItem>
+<TabItem value="php">
+
+```php
+// TODO
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// TODO
+```
+
+</TabItem>
+</TabsLanguage>
+
+## Clear dictionary
+
+<TabsLanguage>
+<TabItem value="javascript">
+
+```js
+await client.batchDictionaryEntries({
+      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      batchDictionaryEntriesParams: {
+        clearExistingDictionaryEntries: true, // We clear everything that exists in the dictionary
+        requests: [], // We don't push any new entries to it
+      },
+    })
+```
+
+</TabItem>
+<TabItem value="php">
+
+```php
+// TODO
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// TODO
+```
+
+</TabItem>
+</TabsLanguage>
+
+## Delete entries in the dictionary
+
+<TabsLanguage>
+<TabItem value="javascript">
+
+```js
+await client.batchDictionaryEntries({
+      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      batchDictionaryEntriesParams: {
+        clearExistingDictionaryEntries: true, // We clear everything that exists in the dictionary
+        requests: [
+          {
+            action: 'deleteEntry', // `deleteEntry` will remove any entries in the dictionary that have the same `objectID` as the `body.objectID` field.
+            body: {
+              objectID: '1',
+            },
+          },
+        ],
+      },
+    })
+```
+
+</TabItem>
+<TabItem value="php">
+
+```php
+// TODO
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+// TODO
+```
+
+</TabItem>
+</TabsLanguage>
+

--- a/website/docs/clients/guides/manage-dictionary-entries.mdx
+++ b/website/docs/clients/guides/manage-dictionary-entries.mdx
@@ -5,16 +5,20 @@ title: Manage dictionary entries
 import { TabsLanguage } from '../../../src/components/TabsLanguage';
 import TabItem from '@theme/TabItem';
 
-The REST API offers a single endpoint to manage your dictorionary, this guide will demonstrate how to manage entries based on your needs.
+The REST API offers a single endpoint to manage your dictorionary. In this guide, we will demonstrate how to manage entries for different scenarios.
+
+A `dictionaryName` can be either `stopword`, `plural` or `compound`.
 
 ## Append new entries to your dictionary
+
+> Useful when you have new data to add to a dictionary and don't want to impact existing entries.
 
 <TabsLanguage>
 <TabItem value="javascript">
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: false, // here we want to append data, so we don't clear existing entries
         requests: [
@@ -53,12 +57,14 @@ await client.batchDictionaryEntries({
 
 ## Replace dictionary entries
 
+> Useful when you want to clear every entries of a dictionary and add new ones at the same time.
+
 <TabsLanguage>
 <TabItem value="javascript">
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: true, // Since we replace, we will create a new dictionary from those entries
         requests: [
@@ -97,14 +103,16 @@ await client.batchDictionaryEntries({
 
 ## Clear dictionary
 
+> Deletes everything that exists in a dictionary.
+
 <TabsLanguage>
 <TabItem value="javascript">
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
       batchDictionaryEntriesParams: {
-        clearExistingDictionaryEntries: true, // We clear everything that exists in the dictionary
+        clearExistingDictionaryEntries: true,
         requests: [], // We don't push any new entries to it
       },
     })
@@ -129,14 +137,16 @@ await client.batchDictionaryEntries({
 
 ## Delete entries in the dictionary
 
+> Useful when deleting one or many entries from a dictionary.
+
 <TabsLanguage>
 <TabItem value="javascript">
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME',
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
       batchDictionaryEntriesParams: {
-        clearExistingDictionaryEntries: true, // We clear everything that exists in the dictionary
+        clearExistingDictionaryEntries: false, // we don't want to impact other entries.
         requests: [
           {
             action: 'deleteEntry', // `deleteEntry` will remove any entries in the dictionary that have the same `objectID` as the `body.objectID` field.

--- a/website/docs/clients/guides/manage-dictionary-entries.mdx
+++ b/website/docs/clients/guides/manage-dictionary-entries.mdx
@@ -5,9 +5,9 @@ title: Manage dictionary entries
 import { TabsLanguage } from '../../../src/components/TabsLanguage';
 import TabItem from '@theme/TabItem';
 
-The REST API offers a single endpoint to manage your dictorionary. In this guide, we will demonstrate how to manage entries for different scenarios.
+The REST API offers [a single endpoint to manage your dictorionary](https://api-clients-automation.netlify.app/specs/search#tag/Dictionaries/operation/batchDictionaryEntries). In this guide, we will demonstrate how to manage entries for different scenarios.
 
-A `dictionaryName` can be either `stopword`, `plural` or `compound`.
+A `dictionaryName` can be either `stopwords`, `plurals` or `compounds`.
 
 ## Append new entries to your dictionary
 
@@ -18,7 +18,7 @@ A `dictionaryName` can be either `stopword`, `plural` or `compound`.
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopwords`, `plurals` or `compounds`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: false, // here we want to append data, so we don't clear existing entries
         requests: [
@@ -64,7 +64,7 @@ await client.batchDictionaryEntries({
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopwords`, `plurals` or `compounds`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: true, // Since we replace, we will create a new dictionary from those entries
         requests: [
@@ -110,7 +110,7 @@ await client.batchDictionaryEntries({
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopwords`, `plurals` or `compounds`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: true,
         requests: [], // We don't push any new entries to it
@@ -144,7 +144,7 @@ await client.batchDictionaryEntries({
 
 ```js
 await client.batchDictionaryEntries({
-      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopword`, `plural` or `compound`.
+      dictionaryName: 'YOUR_DICTIONARY_NAME', // one of `stopwords`, `plurals` or `compounds`.
       batchDictionaryEntriesParams: {
         clearExistingDictionaryEntries: false, // we don't want to impact other entries.
         requests: [

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -82,6 +82,7 @@ const sidebars = {
         'clients/guides/wait-for-api-key-to-be-valid',
         'clients/guides/copy-or-move-index',
         'clients/guides/copy-index-to-another-application',
+        'clients/guides/manage-dictionary-entries',
       ],
     },
   ],


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/APIC-516

### Changes included:

This PR adds a small guide that indices to the user how to manage dictionary entries.

See [netlify preview](https://deploy-preview-1663--api-clients-automation.netlify.app/docs/clients/guides/manage-dictionary-entries/)