### PR TITLE
refactor(dart): pin algolia packages versions

### DIFF
--- a/templates/dart/pubspec.mustache
+++ b/templates/dart/pubspec.mustache
@@ -16,13 +16,14 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  algolia_client_core: ^0.1.1
+  # Pinning versions until the API stabilizes.
+  algolia_client_core: 0.1.1+1
+  {{#isAlgoliasearchClient}}
+  algolia_client_search: {{searchVersion}}
+  algolia_client_insights: {{insightsVersion}}
+  {{/isAlgoliasearchClient}}
   json_annotation: ^4.8.1
   collection: ^1.17.2
-  {{#isAlgoliasearchClient}}
-  algolia_client_search: ^{{searchVersion}}
-  algolia_client_insights: ^{{insightsVersion}}
-  {{/isAlgoliasearchClient}}
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
## 🧭 What and Why

This PR pins the versions of the Algolia packages in the `pubspec.yaml` to ensure compatibility and stability as we await API stabilization. This proactive measure minimizes the risk of unexpected behavior or issues stemming from uncontrolled version updates. 

### Changes included:

Pinned versions of Algolia packages. On version update, `melos version` will automatically adjust these pinned versions.