### PR TITLE
chore(dart): update publish script

### DIFF
--- a/clients/algoliasearch-client-dart/.github/scripts/version.sh
+++ b/clients/algoliasearch-client-dart/.github/scripts/version.sh
@@ -23,7 +23,7 @@ for package_dir in "${!packages[@]}"; do
         echo "Creating new tag..."
         git tag "$tag_prefix-$new_version"
         git push origin "$tag_prefix-$new_version"
-        echo "$tag_prefix=true" >> "$GITHUB_ENV"
+        echo "$tag_prefix=true" >> "$GITHUB_OUTPUT"
     else
         echo "Version was not updated in $package_dir."
     fi


### PR DESCRIPTION
## 🧭 What and Why

Resolve an issue within Dart CI workflow where the publish script used `GITHUB_ENV`, where it should have utilized `GITHUB_OUTPUT` instead.

### Changes included:

Update the script to use `GITHUB_OUTPUT`.