### PR TITLE
fix(dart): `collection` version to `1.17.1`

### DIFF
--- a/templates/dart/pubspec.mustache
+++ b/templates/dart/pubspec.mustache
@@ -1,12 +1,12 @@
-name: {{pubName}}
-version: {{pubVersion}}
-description: {{pubDescription}}
-homepage: {{pubHomepage}}
+name: {{{pubName}}}
+version: {{{pubVersion}}}
+description: {{{pubDescription}}}
+homepage: {{{pubHomepage}}}
 {{#pubRepository}}
-repository: {{.}}
+repository: {{{.}}}
 {{/pubRepository}}
 {{#pubPublishTo}}
-publish_to: {{.}}
+publish_to: {{{.}}}
 {{/pubPublishTo}}
 topics:
   - search
@@ -19,11 +19,11 @@ dependencies:
   # Pinning versions until the API stabilizes.
   algolia_client_core: 0.1.1+1
   {{#isAlgoliasearchClient}}
-  algolia_client_search: {{searchVersion}}
-  algolia_client_insights: {{insightsVersion}}
+  algolia_client_search: {{{searchVersion}}}
+  algolia_client_insights: {{{insightsVersion}}}
   {{/isAlgoliasearchClient}}
   json_annotation: ^4.8.1
-  collection: ^1.17.2
+  collection: ^1.17.1
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
## 🧭 Overview

This PR addresses the dependency issue with the latest version of Flutter, which relies on `collection` version `1.17.1`. Using a higher version prevents users from utilizing the library.

## 📝 Changes

The following modifications have been made:

- The `collection` dependency version has been reduced to `1.17.1` to align with the latest Flutter version.
- Resolved an issue with `pubspec.yaml` generation which involved improper string escaping.