### PR TITLE
docs: add migration guide for copyRules/settings/synonyms

### DIFF
--- a/website/docs/clients/guides/copy-or-move-index-rules-settings-synonyms.mdx
+++ b/website/docs/clients/guides/copy-or-move-index-rules-settings-synonyms.mdx
@@ -1,5 +1,5 @@
 ---
-title: Copy or move an index
+title: Copy or move an index, rules, settings or synonyms
 ---
 
 :::caution

--- a/website/docs/clients/migration-guides/index.mdx
+++ b/website/docs/clients/migration-guides/index.mdx
@@ -247,7 +247,9 @@ client.waitForTask("<YOUR_INDEX_NAME>", response.getTaskID());
 
 The `operationIndex` allows you to either `copy` or `move` a `source` index to a `destination` index **within the same Algolia application**.
 
-You can also decide what `scope` of the `source` index should be copied, [read more in our dedicated guide](/docs/clients/guides/copy-or-move-index).
+You can also decide what `scope` of the `source` index should be copied, [read more in our dedicated guide](/docs/clients/guides/copy-or-move-index-rules-settings-synonyms).
+
+This method can be used as a replacement for the `copyRules`, `copySynonyms`, and `copySettings` method when using the associated `scope`.
 
 </td><td width="600px">
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -80,7 +80,7 @@ const sidebars = {
         'clients/guides/customized-client-usage',
         'clients/guides/wait-for-a-task-to-finish',
         'clients/guides/wait-for-api-key-to-be-valid',
-        'clients/guides/copy-or-move-index',
+        'clients/guides/copy-or-move-index-rules-settings-synonyms',
         'clients/guides/copy-index-to-another-application',
         'clients/guides/manage-dictionary-entries',
         'clients/guides/delete-objects',


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [APIC-517](https://algolia.atlassian.net/browse/APIC-517)

The existing snippets are generic enough for this guide, just updated the title and added the old function name to make it easier to find.

[APIC-517]: https://algolia.atlassian.net/browse/APIC-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ