### PR TITLE
fix(specs): add input to authentication list

### DIFF
--- a/specs/ingestion/common/schemas/authentication.yml
+++ b/specs/ingestion/common/schemas/authentication.yml
@@ -11,6 +11,8 @@ Authentication:
       $ref: './common.yml#/name'
     platform:
       $ref: '#/Platform'
+    input:
+      $ref: '#/AuthInput'
     createdAt:
       $ref: './common.yml#/createdAt'
     updatedAt:
@@ -21,19 +23,6 @@ Authentication:
     - name
     - input
     - createdAt
-
-AuthenticationWithInput:
-  allOf:
-    - $ref: '#/Authentication'
-    - type: object
-      title: authenticationInput
-      description: The authentication input property stores the (encrypted) credentials.
-      additionalProperties: false
-      properties:
-        input:
-          $ref: '#/AuthInput'
-      required:
-        - input
 
 AuthenticationCreate:
   type: object

--- a/specs/ingestion/paths/authentications/authenticationID.yml
+++ b/specs/ingestion/paths/authentications/authenticationID.yml
@@ -12,7 +12,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: '../../common/schemas/authentication.yml#/AuthenticationWithInput'
+            $ref: '../../common/schemas/authentication.yml#/Authentication'
     '400':
       $ref: '../../../common/responses/BadRequest.yml'
 


### PR DESCRIPTION
## 🧭 What and Why

The list authentications endpoint now return `input` too (although obfuscated)