### PR TITLE
chore: add release using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     # python is used by nvm to install some packages
     python3 \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Go

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docker:build": "./scripts/docker/build.sh",
     "docker:clean": "docker stop api-clients-automation; docker rm -f api-clients-automation; docker image rm -f api-clients-automation",
     "docker:mount": "./scripts/docker/mount.sh",
-    "docker:release": "docker exec -e GITHUB_TOKEN -it api-clients-automation bash -lc \"yarn release\"",
+    "docker:release": "docker exec -e GITHUB_TOKEN=$GITHUB_TOKEN -it api-clients-automation bash -lc \"yarn release\"",
     "docker:setup": "yarn docker:clean && yarn docker:build && yarn docker:mount",
     "fix:json": "eslint --ext=json . --fix",
     "github-actions:lint": "eslint --ext=yml .github/",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docker:build": "./scripts/docker/build.sh",
     "docker:clean": "docker stop api-clients-automation; docker rm -f api-clients-automation; docker image rm -f api-clients-automation",
     "docker:mount": "./scripts/docker/mount.sh",
+    "docker:release": "docker exec -e GITHUB_TOKEN -it api-clients-automation bash -lc \"yarn release\"",
     "docker:setup": "yarn docker:clean && yarn docker:build && yarn docker:mount",
     "fix:json": "eslint --ext=json . --fix",
     "github-actions:lint": "eslint --ext=yml .github/",

--- a/scripts/docker/mount.sh
+++ b/scripts/docker/mount.sh
@@ -2,4 +2,6 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)/../.."
 
-docker run -d -it --name api-clients-automation --mount type=bind,source=$ROOT/,target=/app api-clients-automation
+docker run -d -it --name api-clients-automation \
+-v ~/.ssh:/root/.ssh:ro \
+--mount type=bind,source=$ROOT/,target=/app api-clients-automation


### PR DESCRIPTION
## 🧭 What and Why

This PR aims to streamline the process of creating release PRs for Docker images. 
We can now use the `yarn docker:release` command to create a release PR.

🎟 JIRA Ticket: APIC-699

### Changes included:

- Added `docker:release` command in `package.json`.
- Modified `Dockerfile` to install `git` during the Docker image build process.

_`GITHUB_TOKEN` environment variable is required to run the release command._
