### PR TITLE
docs(java): add migration guides code snippets

### DIFF
--- a/website/docs/clients/guides/delete-objects.mdx
+++ b/website/docs/clients/guides/delete-objects.mdx
@@ -41,9 +41,18 @@ php
 </TabItem>
 <TabItem value="java">
 
-java
-
-// TODO
+```java
+List<String> objectIDs = Arrays.asList("1", "2", "3", "4", "5");
+BatchWriteParams batchWriteParams = new BatchWriteParams();
+for (String objectID : objectIDs) {
+    batchWriteParams.addRequests(
+            new BatchRequest()
+                    .setAction(Action.DELETE)
+                    .setBody(Collections.singletonMap("objectID", objectID))
+    );
+}
+client.batch(indexName, batchWriteParams);
+```
 
 </TabItem>
 </TabsLanguage>

--- a/website/docs/clients/guides/manage-dictionary-entries.mdx
+++ b/website/docs/clients/guides/manage-dictionary-entries.mdx
@@ -49,7 +49,23 @@ await client.batchDictionaryEntries({
 <TabItem value="java">
 
 ```java
-// TODO
+client.batchDictionaryEntriesAsync(
+        DictionaryType.fromValue("YOUR_DICTIONARY_NAME"),
+        new BatchDictionaryEntriesParams()
+                .setClearExistingDictionaryEntries(false)
+                .setRequests(Arrays.asList(
+                        new BatchDictionaryEntriesRequest()
+                                .setAction(DictionaryAction.ADD_ENTRY)
+                                .setBody(new DictionaryEntry()
+                                        .setObjectID("1")
+                                        .setLanguage("en")
+                                        .setWord("fancy")
+                                        .setWords(Arrays.asList("believe", "algolia"))
+                                        .setDecomposition(Arrays.asList("trust", "algolia"))
+                                        .setState(DictionaryEntryState.ENABLED)
+                                )
+                ))
+);
 ```
 
 </TabItem>
@@ -95,7 +111,23 @@ await client.batchDictionaryEntries({
 <TabItem value="java">
 
 ```java
-// TODO
+client.batchDictionaryEntriesAsync(
+        DictionaryType.fromValue("YOUR_DICTIONARY_NAME"), // DictionaryType.PLURALS, DictionaryType.STOPWORDS or DictionaryType.COMPOUNDS
+        new BatchDictionaryEntriesParams()
+                .setClearExistingDictionaryEntries(true) // Since we replace, we will create a new dictionary from those entries
+                .setRequests(Arrays.asList(
+                        new BatchDictionaryEntriesRequest()
+                                .setAction(DictionaryAction.ADD_ENTRY)
+                                .setBody(new DictionaryEntry()
+                                        .setObjectID("1")
+                                        .setLanguage("en")
+                                        .setWord("fancy")
+                                        .setWords(Arrays.asList("believe", "algolia"))
+                                        .setDecomposition(Arrays.asList("trust", "algolia"))
+                                        .setState(DictionaryEntryState.ENABLED)
+                                )
+                ))
+);
 ```
 
 </TabItem>
@@ -170,7 +202,16 @@ await client.batchDictionaryEntries({
 <TabItem value="java">
 
 ```java
-// TODO
+client.batchDictionaryEntriesAsync(
+        DictionaryType.fromValue("YOUR_DICTIONARY_NAME"), // DictionaryType.PLURALS, DictionaryType.STOPWORDS or DictionaryType.COMPOUNDS
+        new BatchDictionaryEntriesParams()
+                .setClearExistingDictionaryEntries(false) // we don't want to impact other entries.
+                .setRequests(Arrays.asList(
+                        new BatchDictionaryEntriesRequest()
+                                .setAction(DictionaryAction.DELETE_ENTRY)
+                                .setBody(new DictionaryEntry().setObjectID("1")))
+                )
+);
 ```
 
 </TabItem>

--- a/website/docs/clients/guides/replace-all-rules-synonyms.mdx
+++ b/website/docs/clients/guides/replace-all-rules-synonyms.mdx
@@ -32,9 +32,14 @@ php
 </TabItem>
 <TabItem value="java">
 
-java
-
-// TODO
+```java
+client.saveRulesAsync(
+  indexName, 
+  rules, 
+  false, // forwardToReplicas (defaults to false)
+  true // clearExistingRules
+);
+```
 
 </TabItem>
 </TabsLanguage>
@@ -67,9 +72,14 @@ php
 </TabItem>
 <TabItem value="java">
 
-java
-
-// TODO
+```java
+client.saveSynonymsAsync(
+  indexName, 
+  synonymHits, 
+  false, // forwardToReplicas (defaults to false)
+  true // replaceExistingSynonyms
+);
+```
 
 </TabItem>
 </TabsLanguage>


### PR DESCRIPTION
## 🧭 What and Why

The migration guides are currently missing Java code snippets.

🎟 JIRA Ticket: APIC-685

### Changes included:

Added Java snippets to:
- [x] Delete objects guide
- [x] Manage dictionaries entries
- [x] Replace all rules/synonyms