### PR TITLE
docs(specs): Review OpenAPI Search API (index operations)

### DIFF
--- a/specs/search/paths/manage_indices/listIndices.yml
+++ b/specs/search/paths/manage_indices/listIndices.yml
@@ -2,10 +2,11 @@ get:
   tags:
     - Indices
   operationId: listIndices
-  summary: List existing indexes.
-  description: List existing indexes from an application.
+  summary: List indices.
+  description: List indices in an Algolia application.
   parameters:
     - $ref: '../../../common/parameters.yml#/Page'
+    - $ref: '../../../common/parameters.yml#/HitsPerPage'
   responses:
     '200':
       description: OK

--- a/specs/search/paths/manage_indices/operationIndex.yml
+++ b/specs/search/paths/manage_indices/operationIndex.yml
@@ -2,8 +2,18 @@ post:
   tags:
     - Indices
   operationId: operationIndex
-  summary: Copy/move index.
-  description: Performs a copy or a move operation on a index.
+  summary: Copy, move, or rename an index.
+  description: |-
+    This `operation`, _copy_ or _move_, will copy or move a source index's (`IndexName`) records, settings, synonyms, and rules to a `destination` index.
+    If the destination index exists, it will be replaced, except for index-specific API keys and analytics data.
+    If the destination index doesn't exist, it will be created.
+
+    The choice between moving or copying an index depends on your needs. Choose:
+
+    - **Move** to rename an index.
+    - **Copy** to create a new index with the same records and configuration as an existing one.
+
+    > **Note**: When considering copying or moving, be aware of the [rate limitations](https://www.algolia.com/doc/guides/scaling/algolia-service-limits/#application-record-and-index-limits) on these processes and the [impact on your analytics data](https://www.algolia.com/doc/guides/sending-and-managing-data/manage-indices-and-apps/manage-indices/concepts/indices-analytics/).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   requestBody:
@@ -23,7 +33,12 @@ post:
               type: array
               items:
                 $ref: '../../common/enums.yml#/scopeType'
-              description: Scope of the data to copy. When absent, a full copy is performed. When present, only the selected scopes are copied.
+              description: |-
+                **This only applies to the _copy_ operation.**
+                
+                If you omit `scope`, the copy command copies all records, settings, synonyms, and rules.
+                
+                If you specify `scope`, only the specified scopes are copied.
           required:
             - operation
             - destination

--- a/specs/search/paths/settings/settings.yml
+++ b/specs/search/paths/settings/settings.yml
@@ -2,8 +2,8 @@ get:
   tags:
     - Indices
   operationId: getSettings
-  description: Retrieve settings of an index.
-  summary: Retrieve settings of an index.
+  description: Return an object containing an index's [configuration settings](https://www.algolia.com/doc/api-reference/settings-api-parameters/).
+  summary: Get index settings.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   responses:
@@ -26,8 +26,8 @@ put:
   tags:
     - Indices
   operationId: setSettings
-  description: Update settings of an index. Only specified settings are overridden; unspecified settings are left unchanged. Specifying null for a setting resets it to its default value.
-  summary: Update settings of an index.
+  description: Update the specified [index settings](https://www.algolia.com/doc/api-reference/settings-api-parameters/). Specifying null for a setting resets it to its default value.
+  summary: Update index settings.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'

--- a/tests/CTS/methods/requests/search/listIndices.json
+++ b/tests/CTS/methods/requests/search/listIndices.json
@@ -10,13 +10,15 @@
   {
     "testName": "listIndices with parameters",
     "parameters": {
-      "page": 8
+      "page": 8,
+      "hitsPerPage": 3
     },
     "request": {
       "path": "/1/indexes",
       "method": "GET",
       "queryParameters": {
-        "page": "8"
+        "page": "8",
+        "hitsPerPage": "3"
       }
     }
   }


### PR DESCRIPTION
## 🧭 What and Why

This is one of several PRs addressing the Search API.

This PR reviews just the index operations of the Search API.

### Questions and notes

#### operationIndex

- Original content says “ You can't move a source index that has replicas.” but that appears not to be true. I can carry out a move operation on an index with replicas. It won’t rename the original but, instead, creates an empty index with the destination name. Should this be stated?

#### listIndices

- The `page` parameter requires a  `hitsPerPage` parameter to make any sense/return sensible results. This was missing in the original OAS, I’ve added it but is the default of 100 correct?

#### getSettings

- In the response, `allowCompressionOfIntegerArray` notes say “If `true`, the engine applies a better compression ratio. This is recommended for arrays containing non-negative integers. When enabled, the compressed arrays may be reordered.”

  What’s the user benefit in compressing arrays? Is there any performance impact?

  In the final sentence does this mean that the engine might reorder the array? Could this pose issues?

- In the response, what's the difference between `facetOrdering` and `facets`?

🎟 JIRA Ticket: [DOC-1107](https://algolia.atlassian.net/browse/DOC-1107)

### Changes included:

Changes to summary, description and examples

## 🧪 Test

[DOC-1107]: https://algolia.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ