### PR TITLE
docs(specs): Review OpenAPI Search API (synonym operations)

### DIFF
--- a/specs/search/paths/synonyms/clearAllSynonyms.yml
+++ b/specs/search/paths/synonyms/clearAllSynonyms.yml
@@ -2,8 +2,8 @@ post:
   tags:
     - Synonyms
   operationId: clearAllSynonyms
-  summary: Clear all synonyms.
-  description: Remove all synonyms from an index.
+  summary: Delete all synonyms.
+  description: Delete all synonyms in the index.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'

--- a/specs/search/paths/synonyms/common/parameters.yml
+++ b/specs/search/paths/synonyms/common/parameters.yml
@@ -3,12 +3,12 @@ ReplaceExistingSynonyms:
   name: replaceExistingSynonyms
   schema:
     type: boolean
-  description: Replace all synonyms of the index with the ones sent with this request.
+  description: If `true`, delete all synonyms in the index and then add the ones sent with this request.
 
 Query:
   in: query
   name: query
-  description: Search for specific synonyms matching this string.
+  description: Search for synonyms that match this string.
   schema:
     type: string
     default: ''
@@ -16,16 +16,26 @@ Query:
 Type:
   in: query
   name: type
-  description: Only search for specific types of synonyms.
+  description: Search for specific [types of synonyms](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/#the-different-types-of-synonyms).
   schema:
     $ref: '#/SynonymType'
 
 SynonymType:
   type: string
-  description: Type of the synonym object.
+  description: Synonym type.
+  example: onewaysynonym
   enum:
     - synonym
     - onewaysynonym
     - altcorrection1
     - altcorrection2
     - placeholder
+
+ObjectID:
+  name: objectID
+  in: path
+  description: Unique identifier of a synonym object.
+  required: true
+  schema:
+    type: string
+    example: 'synonymID'

--- a/specs/search/paths/synonyms/common/parameters.yml
+++ b/specs/search/paths/synonyms/common/parameters.yml
@@ -3,7 +3,7 @@ ReplaceExistingSynonyms:
   name: replaceExistingSynonyms
   schema:
     type: boolean
-  description: If `true`, delete all synonyms in the index and then add the ones sent with this request.
+  description: Indicates whether to replace all synonyms in the index with the ones sent with this request.
 
 Query:
   in: query

--- a/specs/search/paths/synonyms/common/schemas.yml
+++ b/specs/search/paths/synonyms/common/schemas.yml
@@ -1,6 +1,6 @@
 synonymHits:
   type: array
-  description: Array of synonym objects.
+  description: Synonym objects.
   items:
     $ref: '#/synonymHit'
 
@@ -11,7 +11,8 @@ synonymHit:
   properties:
     objectID:
       type: string
-      description: Unique identifier of the synonym object to be created or updated.
+      description: Unique identifier of a synonym object.
+      example: 'synonymID'
     type:
       $ref: './parameters.yml#/SynonymType'
 
@@ -19,26 +20,33 @@ synonymHit:
       type: array
       items:
         type: string
-      description: Words or phrases to be considered equivalent.
+      description: Words or phrases considered equivalent.
+      example: ['vehicle','auto']
     input:
       type: string
-      description: Word or phrase to appear in query strings (for onewaysynonym).
+      description: Word or phrase to appear in query strings (for [`onewaysynonym`s](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/in-depth/one-way-synonyms/)).
+      example: 'car'
     word:
       type: string
-      description: Word or phrase to appear in query strings (for altcorrection1 and altcorrection2).
+      description: Word or phrase to appear in query strings (for [`altcorrection1` and `altcorrection2`](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/in-depth/synonyms-alternative-corrections/)).
+      example: 'car'
     corrections:
       type: array
       items:
         type: string
       description: Words to be matched in records.
+      example: ['vehicle','auto']
     placeholder:
       type: string
-      description: Token to be put inside records.
+      description: >
+        [Placeholder token](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/in-depth/synonyms-placeholders/) to be put inside records.
+      example: '<Street>'
     replacements:
       type: array
       items:
         type: string
-      description: List of query words that will match the token.
+      description: Query words that will match the [placeholder token](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/in-depth/synonyms-placeholders/).
+      example: ['street','st']
   required:
     - objectID
     - type

--- a/specs/search/paths/synonyms/saveSynonyms.yml
+++ b/specs/search/paths/synonyms/saveSynonyms.yml
@@ -3,7 +3,7 @@ post:
     - Synonyms
   operationId: saveSynonyms
   summary: Save a batch of synonyms.
-  description: Create/update multiple synonym objects at once, potentially replacing the entire list of synonyms if replaceExistingSynonyms is true.
+  description: Create or update multiple synonyms.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'

--- a/specs/search/paths/synonyms/searchSynonyms.yml
+++ b/specs/search/paths/synonyms/searchSynonyms.yml
@@ -4,8 +4,8 @@ post:
   operationId: searchSynonyms
   x-use-read-transporter: true
   x-cacheable: true
-  summary: List synonyms.
-  description: List all the synonyms matching various criteria.
+  summary: Search for synonyms.
+  description: Search for synonyms in your index. You can control and filter the search with parameters. To get all synonyms, send an empty request body.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: './common/parameters.yml#/Type'

--- a/specs/search/paths/synonyms/searchSynonyms.yml
+++ b/specs/search/paths/synonyms/searchSynonyms.yml
@@ -4,15 +4,15 @@ post:
   operationId: searchSynonyms
   x-use-read-transporter: true
   x-cacheable: true
-  summary: Search synonyms.
-  description: Search or browse all synonyms, optionally filtering them by type.
+  summary: List synonyms.
+  description: List all the synonyms matching various criteria.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: './common/parameters.yml#/Type'
     - $ref: '../../../common/parameters.yml#/PageDefault0'
     - $ref: '../../../common/parameters.yml#/HitsPerPage'
   requestBody:
-    description: The body of the the `searchSynonyms` method.
+    description: Body of the `searchSynonyms` operation.
     content:
       application/json:
         schema:

--- a/specs/search/paths/synonyms/synonym.yml
+++ b/specs/search/paths/synonyms/synonym.yml
@@ -2,11 +2,11 @@ get:
   tags:
     - Synonyms
   operationId: getSynonym
-  summary: Get synonym.
-  description: Fetch a synonym object identified by its objectID.
+  summary: Get a synonym object.
+  description: To list synonym objectIDs for an index, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: '../../../common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectID'
   responses:
     '200':
       description: OK
@@ -27,11 +27,18 @@ put:
   tags:
     - Synonyms
   operationId: saveSynonym
-  summary: Save synonym.
-  description: Create a new synonym object or update the existing synonym object with the given object ID.
+  summary: Save a synonym.
+  description: >
+    Add a [synonym](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/adding-synonyms/#the-different-types-of-synonyms) to an index or replace it.
+
+    If the synonym `objectID` doesn't exist, Algolia adds a new one.
+    
+    If you use an existing synonym `objectID`, the existing synonym is replaced with the new one.
+    
+    To add multiple synonyms in a single API request, use the [`batch` operation](#tag/Synonyms/operation/saveSynonyms).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: '../../../common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectID'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'
   requestBody:
     required: true
@@ -72,11 +79,11 @@ delete:
   tags:
     - Synonyms
   operationId: deleteSynonym
-  summary: Delete synonym.
-  description: Delete a single synonyms set, identified by the given objectID.
+  summary: Delete a synonym.
+  description: To list synonym objectIDs for an index, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: '../../../common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectID'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'
   responses:
     '200':

--- a/specs/search/paths/synonyms/synonym.yml
+++ b/specs/search/paths/synonyms/synonym.yml
@@ -3,7 +3,7 @@ get:
     - Synonyms
   operationId: getSynonym
   summary: Get a synonym object.
-  description: To list synonym objectIDs for an index, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
+  description: Get a syonym by its `objectID`. To find the object IDs for your synonyms, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: 'common/parameters.yml#/ObjectID'
@@ -80,7 +80,7 @@ delete:
     - Synonyms
   operationId: deleteSynonym
   summary: Delete a synonym.
-  description: To list synonym objectIDs for an index, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
+  description: Delete a synonym by its `objectID`. To find the object IDs of your synonyms, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: 'common/parameters.yml#/ObjectID'


### PR DESCRIPTION
## 🧭 What and Why

This is one of several PRs addressing the Search API.

This PR reviews just the synonym operations of the Search API.

### Questions and notes

#### saveSynonyms

You can add synonym objectIDs in the path parameter and the body parameter. It appears that the objectID in the body parameter takes precedence. Is that always the case?

🎟 JIRA Ticket: [DOC-1107](https://algolia.atlassian.net/browse/DOC-1107)

### Changes included:

Changes to summary, description and examples

## 🧪 Test


[DOC-1107]: https://algolia.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ