### PR TITLE
docs(specs): Review OpenAPI Search API (API key operations)

### DIFF
--- a/specs/search/paths/keys/common/parameters.yml
+++ b/specs/search/paths/keys/common/parameters.yml
@@ -5,4 +5,4 @@ KeyString:
   schema:
     type: string
     example: myAPIKey
-  description: API key string.
+  description: API key.

--- a/specs/search/paths/keys/common/parameters.yml
+++ b/specs/search/paths/keys/common/parameters.yml
@@ -5,4 +5,4 @@ KeyString:
   schema:
     type: string
     example: myAPIKey
-  description: API Key string.
+  description: API key string.

--- a/specs/search/paths/keys/common/parameters.yml
+++ b/specs/search/paths/keys/common/parameters.yml
@@ -4,5 +4,5 @@ KeyString:
   required: true
   schema:
     type: string
-    example: myAPIKey
+    example: YourAPIKey
   description: API key.

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -13,7 +13,7 @@ apiKey:
         $ref: '#/acl'
     description:
       type: string
-      description: A description of an API key. This can be helpful for display in the Algolia dashboard.
+      description: Description of an API key for you and your team members.
       example: 'Browse-restricted key'
       default: ''
     indexes:

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -74,7 +74,7 @@ apiKey:
       description: >
         Validity duration of a key (in seconds).  The key will automatically be removed after this time has expired. The default value of 0 never expires.
 
-        Short-lived API keys are useful to grant temporary access to your data, for example, for demos. 
+        Short-lived API keys are useful to grant temporary access to your data. For example, in mobile apps, you can't [control when users update your app](https://www.algolia.com/doc/guides/security/security-best-practices/#use-secured-api-keys-in-mobile-apps). So instead of encoding keys into your app as you would for a web app, you should dynamically fetch them from your mobile app's backend.
       example: 86400
       default: 0
   required:

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -44,10 +44,6 @@ apiKey:
 
         Each time an API call is performed with this key, a check is performed. If there were more than the specified number of calls within the last hour, the API returns an error with the status code `429` (Too Many Requests).
 
-        **If [proxying the query through your servers](https://www.algolia.com/doc/api-client/getting-started/customize/javascript/?client=javascript#use-a-custom-host), use the admin API key and set:**
-          
-        - `X-Forwarded-For` HTTP header with the client IP
-        - `X-Forwarded-API-Key` with the rate-limited API key.
 
         > **Note**: Use this parameter to protect you from third-party attempts to retrieve your entire content by massively querying the index.
       default: 0

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -42,7 +42,7 @@ apiKey:
       description: >
         Maximum number of API calls per hour allowed from a given IP address or [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken/).
 
-        Each time an API call is performed with this key, a check is performed. If there were more than the specified number of calls within the last hour, the API returns a 429 (Too Many Requests) status code.
+        Each time an API call is performed with this key, a check is performed. If there were more than the specified number of calls within the last hour, the API returns an error with the status code `429` (Too Many Requests).
 
         **If [proxying the query through your servers](https://www.algolia.com/doc/api-client/getting-started/customize/javascript/?client=javascript#use-a-custom-host), use the admin API key and set:**
           

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -62,7 +62,7 @@ apiKey:
     referers:
       type: array
       description: >
-        Restrict this API key to specific [referrers](https://www.algolia.com/doc/guides/security/api-keys/in-depth/api-key-restrictions/#http-referrers). If empty or blank, defaults to all referrers.
+        Restrict this API key to specific [referrers](https://www.algolia.com/doc/guides/security/api-keys/in-depth/api-key-restrictions/#http-referrers). If empty, all referrers are allowed.
 
         For example:
 

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -33,7 +33,7 @@ apiKey:
     maxHitsPerQuery:
       type: integer
       description: >
-        Maximum number (positive integer) of hits this API key can retrieve in one query. If zero, no limit is enforced.
+        Maximum number of hits this API key can retrieve in one query. If zero, no limit is enforced.
 
         > **Note**: Use this parameter to protect you from third-party attempts to retrieve your entire content by massively querying the index.
       default: 0

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -19,7 +19,7 @@ apiKey:
     indexes:
       type: array
       description: >
-        Restrict this API key to a list of indices or index patterns. If the list is empty, all indices are allowed.
+        Restricts this API key to a list of indices or index patterns. If the list is empty, all indices are allowed.
 
         Specify either an exact index name or a pattern with a leading or trailing wildcard character (or both). For example:
 

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -26,7 +26,7 @@ apiKey:
         - `dev_*` matches all indices starting with "dev_"
         - `*_dev` matches all indices ending with "_dev"
         - `*_products_*` matches all indices containing "_products_".
-      example: ['dev_products','prod_products']
+      example: ['dev_*','prod_products']
       default: []
       items:
         type: string

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -1,52 +1,93 @@
 apiKey:
   type: object
-  description: Api Key object.
+  description: API key object.
   additionalProperties: false
   properties:
     acl:
       type: array
-      description: Set of permissions associated with the key.
+      description: >
+        [Permissions](https://www.algolia.com/doc/guides/security/api-keys/#access-control-list-acl) associated with the key.
+      example: ['search','addObject']
       default: []
       items:
         $ref: '#/acl'
     description:
       type: string
-      description: A comment used to identify a key more easily in the dashboard. It is not interpreted by the API.
+      description: A description of an API key. This can be helpful for display in the Algolia dashboard.
+      example: 'Browse-restricted key'
       default: ''
     indexes:
       type: array
-      description: Restrict this new API key to a list of indices or index patterns. If the list is empty, all indices are allowed.
+      description: >
+        Restrict this API key to a list of indices or index patterns. If the list is empty, all indices are allowed.
+
+        Specify either an exact index name or a pattern with a leading or trailing wildcard character (or both). For example:
+
+        - `dev_*` matches all indices starting with "dev_"
+        - `*_dev` matches all indices ending with "_dev"
+        - `*_products_*` matches all indices containing "_products_".
+      example: ['dev_products','prod_products']
       default: []
       items:
         type: string
     maxHitsPerQuery:
       type: integer
-      description: Maximum number of hits this API key can retrieve in one query. If zero, no limit is enforced.
+      description: >
+        Maximum number (positive integer) of hits this API key can retrieve in one query. If zero, no limit is enforced.
+
+        > **Note**: Use this parameter to protect you from third-party attempts to retrieve your entire content by massively querying the index.
       default: 0
     maxQueriesPerIPPerHour:
       type: integer
-      description: Maximum number of API calls per hour allowed from a given IP address or a user token.
+      description: >
+        Maximum number of API calls per hour allowed from a given IP address or [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken/).
+
+        Each time an API call is performed with this key, a check is performed. If there were more than the specified number of calls within the last hour, the API returns a 429 (Too Many Requests) status code.
+
+        **If [proxying the query through your servers](https://www.algolia.com/doc/api-client/getting-started/customize/javascript/?client=javascript#use-a-custom-host), use the admin API key and set:**
+          
+        - `X-Forwarded-For` HTTP header with the client IP
+        - `X-Forwarded-API-Key` with the rate-limited API key.
+
+        > **Note**: Use this parameter to protect you from third-party attempts to retrieve your entire content by massively querying the index.
       default: 0
     queryParameters:
       type: string
-      description: URL-encoded query string. Force some query parameters to be applied for each query made with this API key.
+      description: >
+        Force some [query parameters](https://www.algolia.com/doc/api-reference/api-parameters/) to be applied for each query made with this API key.
+        
+        It's a URL-encoded query string.
+      example: 'typoTolerance%3Dstrict%26ignorePlurals%3Dfalse%26filters%3Drights%3Apublic'
       default: ''
     referers:
       type: array
-      description: Restrict this new API key to specific referers. If empty or blank, defaults to all referers.
+      description: >
+        Restrict this API key to specific [referrers](https://www.algolia.com/doc/guides/security/api-keys/in-depth/api-key-restrictions/#http-referrers). If empty or blank, defaults to all referrers.
+
+        For example:
+
+        - `https://algolia.com/*` matches all referrers starting with "https://algolia.com/"
+        - `*.algolia.com` matches all referrers ending with ".algolia.com"
+        - `*algolia.com*` allows everything in the domain "algolia.com".
+      example: ['*algolia.com*']
       default: []
       items:
         type: string
     validity:
       type: integer
-      description: Validity limit for this key in seconds. The key will automatically be removed after this period of time.
+      description: >
+        Validity duration of a key (in seconds).  The key will automatically be removed after this time has expired. The default value of 0 never expires.
+
+        Short-lived API keys are useful to grant temporary access to your data, for example, for demos. 
+      example: 86400
       default: 0
   required:
     - acl
 
 keyString:
   type: string
-  description: The API key.
+  description: API key.
+  example: '13ad45b4d0a2f6ea65ecbddf6aa260f2'
 
 getApiKeyResponse:
   allOf:
@@ -79,20 +120,20 @@ addApiKeyResponse:
 
 acl:
   description: |
-    List of rights for the API key. The following rights can be used:
+    API key permissions:
 
-    addObject: allows to add/update an object in the index (copy/move index are also allowed with this right).
-    analytics: allows to retrieve the analytics through the Analytics API.
-    browse: allows to retrieve all index content via the browse API.
-    deleteIndex: allows to delete or clear index content.
-    deleteObject: allows to delete objects from the index.
-    editSettings: allows to change index settings.
-    listIndexes: allows to list all accessible indices.
-    logs: allows to get the logs.
-    recommendation: Allows usage of the Personalization dashboard and the Recommendation API.
-    search: allows to search the index.
-    seeUnretrievableAttributes: disable unretrievableAttributes feature for all operations returning records.
-    settings: allows to get index settings.
+    `addObject`: required to add or update records, copy or move an index.
+    `analytics`: required to access the Analytics API.
+    `browse`: required to view records
+    `deleteIndex`: required to delete indices.
+    `deleteObject`: required to delete records.
+    `editSettings`: required to change index settings.
+    `listIndexes`: required to list indices.
+    `logs`: required to access logs of search and indexing operations.
+    `recommendation`: required to access the Personalization and Recommend APIs.
+    `search`: required to search records
+    `seeUnretrievableAttributes`: required to retrieve [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/) for all operations that return records.
+    `settings`: required to examine index settings.
   type: string
   enum:
     - addObject

--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -32,7 +32,7 @@ put:
   operationId: updateApiKey
   summary: Update an API key.
   description: >
-    Replace every permission of an existing API key.
+    Replace the permissions of an existing API key.
 
     Any unspecified parameter resets that permission to its default value.
 

--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -4,7 +4,7 @@ get:
   operationId: getApiKey
   summary: Get API key permissions.
   description: >
-    Permissions and restrictions of a specific API key.
+    Get the permissions and restrictions of a specific API key.
 
     When authenticating with the admin API key, you can request information for any of your application's keys.
     When authenticating with other API keys, you can only retrieve information for that key.

--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -2,8 +2,12 @@ get:
   tags:
     - Api Keys
   operationId: getApiKey
-  summary: Get an API key.
-  description: Get the permissions of an API key.
+  summary: Get API key permissions.
+  description: >
+    Permissions and restrictions of a specific API key.
+
+    When authenticating with the admin API key, you can request information for any of your application's keys.
+    When authenticating with other API keys, you can only retrieve information for that key.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'
   responses:
@@ -27,7 +31,12 @@ put:
     - Api Keys
   operationId: updateApiKey
   summary: Update an API key.
-  description: Replace every permission of an existing API key.
+  description: >
+    Replace every permission of an existing API key.
+
+    Any unspecified parameter resets that permission to its default value.
+
+    The request must be authenticated with the admin API key.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'
   requestBody:
@@ -66,8 +75,11 @@ delete:
   tags:
     - Api Keys
   operationId: deleteApiKey
-  summary: Delete an API key.
-  description: Delete an existing API Key.
+  summary: Delete API key.
+  description: >
+    Delete an existing API key.
+
+    The request must be authenticated with the admin API key.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'
   responses:

--- a/specs/search/paths/keys/keys.yml
+++ b/specs/search/paths/keys/keys.yml
@@ -3,7 +3,7 @@ get:
     - Api Keys
   operationId: listApiKeys
   summary: List API keys.
-  description: API keys associated with the Algolia application, including their permissions and restrictions.
+  description: List all API keys associated with your Algolia application, including their permissions and restrictions.
   responses:
     '200':
       description: OK

--- a/specs/search/paths/keys/keys.yml
+++ b/specs/search/paths/keys/keys.yml
@@ -2,8 +2,8 @@ get:
   tags:
     - Api Keys
   operationId: listApiKeys
-  summary: List API Keys.
-  description: List API keys, along with their associated rights.
+  summary: List API keys.
+  description: API keys associated with the Algolia application, including their permissions and restrictions.
   responses:
     '200':
       description: OK
@@ -18,7 +18,7 @@ get:
             properties:
               keys:
                 type: array
-                description: List of api keys.
+                description: API keys.
                 items:
                   $ref: 'common/schemas.yml#/getApiKeyResponse'
     '400':
@@ -34,8 +34,13 @@ post:
   tags:
     - Api Keys
   operationId: addApiKey
-  summary: Create an API key.
-  description: Add a new API Key with specific permissions/restrictions.
+  summary: Add API key.
+  description: >
+    Add a new API key with specific permissions and restrictions.
+
+    The request must be authenticated with the admin API key.
+
+    The response returns an API key string.
   requestBody:
     required: true
     content:

--- a/specs/search/paths/keys/restoreApiKey.yml
+++ b/specs/search/paths/keys/restoreApiKey.yml
@@ -2,8 +2,11 @@ post:
   tags:
     - Api Keys
   operationId: restoreApiKey
-  summary: Restore an API key.
-  description: Restore a deleted API key, along with its associated rights.
+  summary: Restore API key.
+  description: >
+    Restore a deleted API key, along with its associated permissions.
+
+    The request must be authenticated with the admin API key.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'
   responses:


### PR DESCRIPTION
## 🧭 What and Why

This is one of several PRs addressing the Search API.

This PR reviews just the API key operations of the Search API.

### Questions and notes

On the [docs site,](https://www.algolia.com/doc/rest-api/search/#keys-endpoints) there are quite a few more operations that deal with index-specific API keys. These aren’t present in the Search API OAS. Should they be added to it?

🎟 JIRA Ticket: [DOC-1107](https://algolia.atlassian.net/browse/DOC-1107)

### Changes included:

Changes to summary, description and examples

## 🧪 Test

[DOC-1107]: https://algolia.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ