### PR TITLE
docs(specs): Review OpenAPI Search API (multicluster operations)

### DIFF
--- a/specs/search/paths/multiclusters/batchAssignUserIds.yml
+++ b/specs/search/paths/multiclusters/batchAssignUserIds.yml
@@ -4,7 +4,7 @@ post:
   operationId: batchAssignUserIds
   summary: Batch assign userIDs.
   description: >
-    Assign multiple userIDs to a cluster.
+    Assign multiple user IDs to a cluster.
 
     **You can't _move_ users with this operation.**.
   parameters:

--- a/specs/search/paths/multiclusters/batchAssignUserIds.yml
+++ b/specs/search/paths/multiclusters/batchAssignUserIds.yml
@@ -6,9 +6,7 @@ post:
   description: >
     Assign multiple userIDs to a cluster.
 
-    Upon success, the response is 200 OK.
-
-    A successful response indicates that the operation has been taken into account, and the userIDs are directly usable.
+    **You can't _move_ users with this operation.**.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInHeader'
   requestBody:
@@ -25,7 +23,8 @@ post:
               $ref: '../../common/schemas/Cluster.yml#/clusterName'
             users:
               type: array
-              description: userIDs to assign. Note you cannot move users with this method.
+              description: userIDs to assign.
+              example: ['einstein','bohr','feynman']
               items:
                 type: string
           required:

--- a/specs/search/paths/multiclusters/batchAssignUserIds.yml
+++ b/specs/search/paths/multiclusters/batchAssignUserIds.yml
@@ -23,7 +23,7 @@ post:
               $ref: '../../common/schemas/Cluster.yml#/clusterName'
             users:
               type: array
-              description: userIDs to assign.
+              description: User IDs to assign.
               example: ['einstein','bohr','feynman']
               items:
                 type: string

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -4,11 +4,9 @@ get:
   operationId: getTopUserIds
   summary: Get top userID.
   description: >
-    Get the top 10 userIDs with the highest number of records per cluster.
+    Get the top 10 userIDs (users with the highest number of records per cluster).
 
-    The data returned will usually be a few seconds behind real time, because userID usage may take up to a few seconds to propagate to the different clusters.
-
-    Upon success, the response is 200 OK and contains the following array of userIDs and clusters.
+    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
   responses:
     '200':
       description: OK
@@ -17,11 +15,11 @@ get:
           schema:
             title: getTopUserIdsResponse
             type: object
-            description: Array of userIDs and clusters.
+            description: UserIDs and clusters.
             properties:
               topUsers:
                 type: array
-                description: Mapping of cluster names to top users.
+                description: Mapping of cluster names to top users (users with the highest number of records per cluster).
                 items:
                   type: object
                   additionalProperties:

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopUserIds
   summary: Get top userID.
   description: >
-    Get the top 10 userIDs (users with the highest number of records per cluster).
+    Get the IDs of the 10 users with the highest number of records per cluster.
 
     Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
   responses:

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -6,7 +6,8 @@ get:
   description: >
     Get the IDs of the 10 users with the highest number of records per cluster.
 
-    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
+    Since it can take up to a few seconds to get the data from the different clusters,
+    the response isn't real-time.
   responses:
     '200':
       description: OK

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -20,7 +20,7 @@ get:
             properties:
               topUsers:
                 type: array
-                description: Mapping of cluster names to top users (users with the highest number of records per cluster).
+                description: Key-value pairs with cluster names as keys and lists of users with the highest number of records per cluster as values.
                 items:
                   type: object
                   additionalProperties:

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -16,7 +16,7 @@ get:
           schema:
             title: getTopUserIdsResponse
             type: object
-            description: UserIDs and clusters.
+            description: User IDs and clusters.
             properties:
               topUsers:
                 type: array

--- a/specs/search/paths/multiclusters/hasPendingMappings.yml
+++ b/specs/search/paths/multiclusters/hasPendingMappings.yml
@@ -22,7 +22,7 @@ get:
             additionalProperties: false
             properties:
               pending:
-                description: If `true`, there are clusters undergoing migration, creation, or deletion.
+                description: Indicates whether there are clusters undergoing migration, creation, or deletion.
                 type: boolean
               clusters:
                 description: >

--- a/specs/search/paths/multiclusters/hasPendingMappings.yml
+++ b/specs/search/paths/multiclusters/hasPendingMappings.yml
@@ -8,7 +8,7 @@ get:
   parameters:
     - in: query
       name: getClusters
-      description: If `true`, include the cluster's pending mapping state with the response.
+      description: Indicates whether to include the cluster's pending mapping state in the response.
       schema:
         type: boolean
   responses:

--- a/specs/search/paths/multiclusters/hasPendingMappings.yml
+++ b/specs/search/paths/multiclusters/hasPendingMappings.yml
@@ -2,19 +2,13 @@ get:
   tags:
     - Clusters
   operationId: hasPendingMappings
-  summary: Get migration status.
+  summary: Get migration and user mapping status.
   description: >
-    Get the status of your clusters' migrations or user creations.
-
-    Creating a large batch of users or migrating your multi-cluster may take quite some time. This method lets you retrieve the status of the migration, so you can know when it's done.
-
-    Upon success, the response is 200 OK.
-
-    A successful response indicates that the operation has been taken into account, and the userIDs are directly usable.
+    To determine when the time-consuming process of creating a large batch of users or migrating users from one cluster to another is complete, this operation retrieves the status of the process.
   parameters:
     - in: query
       name: getClusters
-      description: If the clusters pending mapping state should be on the response.
+      description: If `true`, include the cluster's pending mapping state with the response.
       schema:
         type: boolean
   responses:
@@ -28,10 +22,11 @@ get:
             additionalProperties: false
             properties:
               pending:
-                description: If there is any clusters with pending mapping state.
+                description: If `true`, there are clusters undergoing migration, creation, or deletion.
                 type: boolean
               clusters:
-                description: Describe cluster pending (migrating, creating, deleting) mapping state.
+                description: >
+                  Cluster pending mapping state: migrating, creating, deleting.
                 type: object
                 additionalProperties:
                   type: array

--- a/specs/search/paths/multiclusters/listClusters.yml
+++ b/specs/search/paths/multiclusters/listClusters.yml
@@ -3,10 +3,7 @@ get:
     - Clusters
   operationId: listClusters
   summary: List clusters.
-  description: >
-    List the clusters available in a multi-clusters setup for a single appID.
-
-    Upon success, the response is 200 OK and contains the following clusters.
+  description: List the available clusters in a multi-cluster setup.
   responses:
     '200':
       description: OK
@@ -15,11 +12,11 @@ get:
           schema:
             title: listClustersResponse
             type: object
-            description: Array of clusters.
+            description: Clusters.
             properties:
               topUsers:
                 type: array
-                description: Mapping of cluster names to top users.
+                description: Mapping of cluster names to top users (users with the highest number of records per cluster).
                 items:
                   $ref: '../../common/schemas/Cluster.yml#/clusterName'
             required:

--- a/specs/search/paths/multiclusters/listClusters.yml
+++ b/specs/search/paths/multiclusters/listClusters.yml
@@ -16,7 +16,7 @@ get:
             properties:
               topUsers:
                 type: array
-                description: Mapping of cluster names to top users (users with the highest number of records per cluster).
+                description: Key-value pairs with cluster names as keys and lists of users with the highest number of records per cluster as values.
                 items:
                   $ref: '../../common/schemas/Cluster.yml#/clusterName'
             required:

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -4,15 +4,11 @@ post:
   operationId: searchUserIds
   x-use-read-transporter: true
   x-cacheable: true
-  summary: Search userID.
+  summary: Search for a userID.
   description: >
-    Search for userIDs.
-
-    The data returned will usually be a few seconds behind real time, because userID usage may take up to a few seconds propagate to the different clusters.
-
-    To keep updates moving quickly, the index of userIDs isn't built synchronously with the mapping. Instead, the index is built once every 12h, at the same time as the update of userID usage. For example, when you perform a modification like adding or moving a userID, the search will report an outdated value until the next rebuild of the mapping, which takes place every 12h.
-
-    Upon success, the response is 200 OK and contains the following userIDs data.
+    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
+    
+    To ensure rapid updates, the userIDs index isn't built at the same time as the mapping. Instead, it's built every 12 hours, at the same time as the update of user ID usage. For example, if you add or move a user ID, the search will show an old value until the next time the mapping is rebuilt (every 12 hours). 
   requestBody:
     required: true
     content:
@@ -25,7 +21,7 @@ post:
           properties:
             query:
               type: string
-              description: Query to search. The search is a prefix search with typoTolerance. Use empty query to retrieve all users.
+              description: Query to search. The search is a prefix search with [typo tolerance](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/typo-tolerance/) enabled. An empty query will retrieve all users.
             clusterName:
               $ref: '../../common/schemas/Cluster.yml#/clusterName'
             page:
@@ -46,7 +42,7 @@ post:
             properties:
               hits:
                 type: array
-                description: List of user object matching the query.
+                description: User objects that match the query.
                 items:
                   title: userHit
                   type: object

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -4,7 +4,7 @@ post:
   operationId: searchUserIds
   x-use-read-transporter: true
   x-cacheable: true
-  summary: Search for a userID.
+  summary: Search for a user ID.
   description: >
     Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
     

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -9,7 +9,7 @@ post:
     Since it can take up to a few seconds to get the data from the different clusters,
     the response isn't real-time.
     
-    To ensure rapid updates, the userIDs index isn't built at the same time as the mapping. Instead, it's built every 12 hours, at the same time as the update of user ID usage. For example, if you add or move a user ID, the search will show an old value until the next time the mapping is rebuilt (every 12 hours). 
+    To ensure rapid updates, the user IDs index isn't built at the same time as the mapping. Instead, it's built every 12 hours, at the same time as the update of user ID usage. For example, if you add or move a user ID, the search will show an old value until the next time the mapping is rebuilt (every 12 hours). 
   requestBody:
     required: true
     content:

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -6,7 +6,8 @@ post:
   x-cacheable: true
   summary: Search for a user ID.
   description: >
-    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
+    Since it can take up to a few seconds to get the data from the different clusters,
+    the response isn't real-time.
     
     To ensure rapid updates, the userIDs index isn't built at the same time as the mapping. Instead, it's built every 12 hours, at the same time as the update of user ID usage. For example, if you add or move a user ID, the search will show an old value until the next time the mapping is rebuilt (every 12 hours). 
   requestBody:

--- a/specs/search/paths/multiclusters/userId.yml
+++ b/specs/search/paths/multiclusters/userId.yml
@@ -6,7 +6,8 @@ get:
   description: >
     Returns the userID data stored in the mapping.
 
-    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
+    Since it can take up to a few seconds to get the data from the different clusters,
+    the response isn't real-time.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInPath'
   responses:

--- a/specs/search/paths/multiclusters/userId.yml
+++ b/specs/search/paths/multiclusters/userId.yml
@@ -6,9 +6,7 @@ get:
   description: >
     Returns the userID data stored in the mapping.
 
-    The data returned will usually be a few seconds behind real time, because userID usage may take up to a few seconds to propagate to the different clusters.
-
-    Upon success, the response is 200 OK and contains the following userID data.
+    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInPath'
   responses:
@@ -32,10 +30,7 @@ delete:
     - Clusters
   operationId: removeUserId
   summary: Remove userID.
-  description: >
-    Remove a userID and its associated data from the multi-clusters.
-
-    Upon success, the response is 200 OK and a task is created to remove the userID data and mapping.
+  description: Remove a userID and its associated data from the multi-clusters.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInPath'
   responses:

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -43,7 +43,8 @@ get:
   description: >
     List the userIDs assigned to a multi-cluster application.
 
-    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
+    Since it can take up to a few seconds to get the data from the different clusters,
+    the response isn't real-time.
   parameters:
     - $ref: '../../../common/parameters.yml#/Page'
     - $ref: '../../../common/parameters.yml#/HitsPerPage'

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -60,7 +60,7 @@ get:
             properties:
               userIDs:
                 type: array
-                description: UserIDs.
+                description: User IDs.
                 items:
                   $ref: '../../common/schemas/UserId.yml#/userId'
             required:

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -4,7 +4,7 @@ post:
   operationId: assignUserId
   summary: Assign or move a userID.
   description: >
-    Assign or move a userID to a cluster.
+    Assign or move a user ID to a cluster.
 
     The time it takes to move a user is proportional to the amount of data linked to the user ID.
   parameters:

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -56,7 +56,7 @@ get:
           schema:
             title: listUserIdsResponse
             type: object
-            description: UserID data.
+            description: User ID data.
             properties:
               userIDs:
                 type: array

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - Clusters
   operationId: assignUserId
-  summary: Assign or move a userID.
+  summary: Assign or move a user ID.
   description: >
     Assign or move a user ID to a cluster.
 

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -6,7 +6,7 @@ post:
   description: >
     Assign or move a userID to a cluster.
 
-    The time it takes to move a user is proportional to the amount of data linked to the userID.
+    The time it takes to move a user is proportional to the amount of data linked to the user ID.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInHeader'
   requestBody:

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -2,15 +2,11 @@ post:
   tags:
     - Clusters
   operationId: assignUserId
-  summary: Assign or Move userID.
+  summary: Assign or move a userID.
   description: >
-    Assign or Move a userID to a cluster.
+    Assign or move a userID to a cluster.
 
-    The time it takes to migrate (move) a user is proportional to the amount of data linked to the userID.
-
-    Upon success, the response is 200 OK.
-
-    A successful response indicates that the operation has been taken into account, and the userID is directly usable.
+    The time it takes to move a user is proportional to the amount of data linked to the userID.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInHeader'
   requestBody:
@@ -45,11 +41,9 @@ get:
   operationId: listUserIds
   summary: List userIDs.
   description: >
-    List the userIDs assigned to a multi-clusters appID.
+    List the userIDs assigned to a multi-cluster application.
 
-    The data returned will usually be a few seconds behind real time, because userID usage may take up to a few seconds to propagate to the different clusters.
-
-    Upon success, the response is 200 OK and contains the following userIDs data.
+    Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.
   parameters:
     - $ref: '../../../common/parameters.yml#/Page'
     - $ref: '../../../common/parameters.yml#/HitsPerPage'
@@ -61,11 +55,11 @@ get:
           schema:
             title: listUserIdsResponse
             type: object
-            description: UserIDs data.
+            description: UserID data.
             properties:
               userIDs:
                 type: array
-                description: List of userIDs.
+                description: UserIDs.
                 items:
                   $ref: '../../common/schemas/UserId.yml#/userId'
             required:


### PR DESCRIPTION
## 🧭 What and Why

This is one of several PRs addressing the Search API.

This PR reviews just the cluster operations of the Search API.

### Questions and notes

Given that [MCM is no longer offered](https://www.algolia.com/doc/guides/scaling/managing-multiple-clusters-mcm/#managing-multiple-clusters), check the new note in spec.yml. Is this ok?

#### listUserIds

[Docs site](https://www.algolia.com/doc/rest-api/search/#list-userids) intimates a hitsPerPage default of 1,000. However, the OAS states a default of 100. Which is correct?

#### searchUserIds

The two statements seem self-contradictory:

1. To ensure rapid updates, the userIDs index isn't built at the same time as the mapping. Instead, it's built every 12 hours, at the same time as the update of user ID usage. For example, if you add or move a user ID, the search will show an old value until the next time the mapping is rebuilt (every 12 hours).
1. Since userID usage can take up to a few seconds to propagate to the different clusters, the response data isn't quite real-time.

The first statement seems to say that user ID usage can be up to 12 hours out of date. The second statement seems to say that it’s up to a few seconds out of date.

It’s not clear how either of these statements relate to the operation? Does it mean “If you’ve added or updated a userID in the last half day (or few seconds), you may not be able to find it”? And the workaround is to wait a few seconds (or half a day) after adding or updating a user ID before searching for it?

🎟 JIRA Ticket: [DOC-1107](https://algolia.atlassian.net/browse/DOC-1107)

### Changes included:

Changes to summary, description and examples

## 🧪 Test

[DOC-1107]: https://algolia.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ