### PR TITLE
docs(specs): Review OpenAPI Search API (advanced operations)

### DIFF
--- a/specs/search/paths/advanced/getLogs.yml
+++ b/specs/search/paths/advanced/getLogs.yml
@@ -2,25 +2,33 @@ get:
   tags:
     - Advanced
   operationId: getLogs
-  description: Return the latest log entries.
+  description: >
+    The request must be authenticated by an API key with the [`logs` ACL](https://www.algolia.com/doc/guides/security/api-keys/#access-control-list-acl).
+
+    Logs are held for the last seven days. There's also a logging limit of 1,000 API calls per server.
+
+    This request counts towards your [operations quota](https://support.algolia.com/hc/en-us/articles/4406981829777-How-does-Algolia-count-records-and-operations-) but doesn't appear in the logs itself.
+
+    > **Note**: To fetch the logs for a Distributed Search Network (DSN) cluster, target the [DSN's endpoint](https://www.algolia.com/doc/guides/scaling/distributed-search-network-dsn/#accessing-dsn-servers).
   summary: Return the latest log entries.
   parameters:
     - name: offset
       in: query
-      description: First entry to retrieve (zero-based). Log entries are sorted by decreasing date, therefore 0 designates the most recent log entry.
+      description: First log entry to retrieve. Sorted by decreasing date with 0 being the most recent.
       schema:
         type: integer
         default: 0
     - name: length
       in: query
-      description: Maximum number of entries to retrieve. The maximum allowed value is 1000.
+      description: Maximum number of entries to retrieve.
       schema:
         type: integer
         default: 10
         maximum: 1000
     - name: indexName
       in: query
-      description: Index for which log entries should be retrieved. When omitted, log entries are retrieved across all indices.
+      description: Index for which log entries should be retrieved. When omitted, log entries are retrieved for all indices.
+      example: 'products'
       schema:
         type: string
         nullable: true
@@ -49,49 +57,64 @@ get:
                   properties:
                     timestamp:
                       type: string
-                      description: Timestamp in ISO-8601 format.
+                      description: Timestamp in [ISO 8601](https://wikipedia.org/wiki/ISO_8601) format.
+                      example: '2023-03-08T12:34:56Z'
                     method:
                       type: string
                       description: HTTP method of the performed request.
+                      example: 'GET'
                     answer_code:
                       type: string
                       description: HTTP response code.
+                      example: '200'
                     query_body:
                       type: string
-                      description: Request body. Truncated after 1000 characters.
+                      description: Request body. Truncated after 1,000 characters.
+                      example: '\n{\n \"requests\": [\n  {\n   \"indexName\": \"best_buy\",\n   \"params\": \"query=&hitsPerPage=10&page=0&attributesToRetrieve=*&highlightPreTag=%3Cais-highlight-0000000000%3E&highlightPostTag=%3C%2Fais-highlight-0000000000%3E&getRankingInfo=1&facets=%5B%22brand%22%2C%22categories%22%2C%22free_shipping%22%2C%22type%22%5D&tagFilters=\"\n  }\n ]\n}\n'
                     answer:
                       type: string
-                      description: Answer body. Truncated after 1000 characters.
+                      description: Answer body. Truncated after 1,000 characters.
+                      example: >
+                        'n{\n \"results\": [\n  {\n   \"hits\": [\n    {\n     \"name\": \"Amazon - Fire TV Stick\",\n     \"description\": \"Amazon Fire TV Stick connects to your TV's HDMI port. Just grab and go to enjoy Netflix, Prime Instant Video, Hulu Plus, YouTube.com, music, and much more.\",\n     \"brand\": \"Amazon\",\n     \"categories\": [\n      \"TV & Home Theater\",\n      \"Streaming Media Players\"\n     ],\n     \"hierarchicalCategories\": {\n      \"lvl0\": \"TV & Home Theater\",\n      \"lvl1\": \"TV & Home Theater > Streaming Media Players\"\n     },\n     \"type\": \"Streaming media plyr\",\n     \"price\": 39.99,\n     \"price_range\": \"1 - 50\",\n     \"image\": \"https:\/\/cdn-demo.algolia.com\/bestbuy\/9999119_sb.jpg\",\n     \"url\": \"http:\/\/www.bestbuy.com\/site\/amazon-fire-tv-stick\/9999119.p?id=1219460752591&skuId=9999119&cmp=RMX&ky=1uWSHMdQqBeVJB9cXgEke60s5EjfS6M1W\",\n     \"free_shipping\": false,\n     \"popularity\": 9843,\n     \"rating\": 4,\n     \"objectID\": \"9999119\"\n'
                     url:
                       type: string
                       description: Request URL.
+                      example: '/1/indexes'
                     ip:
                       type: string
-                      description: IP of the client which performed the request.
+                      description: IP address of the client that performed the request.
+                      example: '127.0.0.1'
                     query_headers:
                       type: string
-                      description: Request Headers (API Key is obfuscated).
+                      description: Request headers (API key is obfuscated).
+                      example: 'User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8x zlib/1.2.5\nHost: localhost.algolia.com:8080\nAccept: */*\nContent-Type: application/json; charset=utf-8\nX-Algolia-API-Key: 20f***************************\nX-Algolia-Application-Id: MyApplicationID\n'
                     sha1:
                       type: string
                       description: SHA1 signature of the log entry.
+                      example: '26c53bd7e38ca71f4741b71994cd94a600b7ac68'
                     nb_api_calls:
                       type: string
                       description: Number of API calls.
+                      example: '1'
                     processing_time_ms:
                       type: string
-                      description: Processing time for the query. It doesn't include network time.
+                      description: Processing time for the query. Doesn't include network time.
+                      example: '2'
                     index:
                       type: string
                       description: Index targeted by the query.
+                      example: 'best_buy'
                     query_params:
                       type: string
                       description: Query parameters sent with the request.
+                      example: 'query=georgia&attributesToRetrieve=name,city,country'
                     query_nb_hits:
                       type: string
                       description: Number of hits returned for the query.
+                      example: '1'
                     inner_queries:
                       type: array
-                      description: Array of all performed queries for the given request.
+                      description: Performed queries for the given request.
                       items:
                         type: object
                         title: logQuery
@@ -99,12 +122,15 @@ get:
                           index_name:
                             type: string
                             description: Index targeted by the query.
+                            example: 'best_buy'
                           user_token:
                             type: string
                             description: User identifier.
+                            example: '93.189.166.128'
                           query_id:
                             type: string
-                            description: QueryID for the given query.
+                            description: Unique query identifier.
+                            example: '313453231'
                   required:
                     - timestamp
                     - method

--- a/specs/search/paths/advanced/getTask.yml
+++ b/specs/search/paths/advanced/getTask.yml
@@ -2,18 +2,18 @@ get:
   tags:
     - Indices
   operationId: getTask
-  description: Check the current status of a given task.
-  summary: Check the status of a task.
+  description: Some operations, such as copying an index, will respond with a `taskID` value. Use this value here to check the status of that task.
+  summary: Check a task's status.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - name: taskID
       in: path
-      description: Unique identifier of an task. Numeric value (up to 64bits).
+      description: Unique task identifier.
       required: true
       schema:
         type: integer
         format: int64
-        example: 13235
+        example: 1506303845001
   responses:
     '200':
       description: OK


### PR DESCRIPTION
## 🧭 What and Why

This is one of several PRs addressing the Search API.

This PR reviews just the advanced operations of the Search API.

### Questions and notes

#### getTask

`pendingTask` is returned in the response but isn’t in the OAS. The [docs](https://www.algolia.com/doc/rest-api/search/#interpreting-the-response) say “pendingTask is deprecated and shouldn’t be used.” Given that it _is_ returned, should it be added to the OAS along with a description saying something like  “`pendingTask` is a legacy value, no longer used by Algolia”?

🎟 JIRA Ticket: [DOC-1107](https://algolia.atlassian.net/browse/DOC-1107)

### Changes included:

Changes to summary, description and examples

## 🧪 Test


[DOC-1107]: https://algolia.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ