### PR TITLE
fix(scripts): unused imports in go tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,6 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Go
-COPY --from=go-builder /usr/local/go/ /usr/local/go/
-ENV PATH /usr/local/go/bin:$PATH
-
-
 # Javascript (node)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
 RUN nvm install ${NODE_VERSION}
@@ -48,6 +43,10 @@ RUN sdk install java ${JAVA_VERSION}-zulu
 
 # Java formatter
 ADD https://github.com/google/google-java-format/releases/download/v1.17.0/google-java-format-1.17.0-all-deps.jar /tmp/java-formatter.jar
+
+# Go
+COPY --from=go-builder /usr/local/go/ /usr/local/go/
+RUN echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile && source ~/.profile
 
 # Dart
 COPY --from=dart-builder /usr/lib/dart/ /usr/lib/dart/

--- a/scripts/formatter.ts
+++ b/scripts/formatter.ts
@@ -1,4 +1,4 @@
-import { DOCKER, run, runComposerUpdate } from './common';
+import { run, runComposerUpdate } from './common';
 import { createSpinner } from './spinners';
 
 export async function formatter(
@@ -27,9 +27,6 @@ export async function formatter(
       break;
     case 'go':
       cmd = `cd ${folder} && go fmt ./...`;
-      if (DOCKER) {
-        cmd = `cd ${folder} && /usr/local/go/bin/go fmt ./...`;
-      }
       break;
     case 'kotlin':
       cmd = `${folder}/gradlew -p ${folder} spotlessApply`;

--- a/templates/go/tests/requests/requests.mustache
+++ b/templates/go/tests/requests/requests.mustache
@@ -21,6 +21,9 @@ func create{{#lambda.titlecase}}{{clientPrefix}}{{/lambda.titlecase}}Client() (*
   }
   client := {{clientPrefix}}.NewClientWithConfig(cfg)
 
+  // so that the linter doesn't complain
+  _ = jsonassert.New(nil)
+
   return client, echo
 }
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

unused imports aren't removed, and as the linter is not fully setup yet, let's quickly unlock pending PRs (https://github.com/algolia/api-clients-automation/pull/1683) . I've created https://algolia.atlassian.net/browse/DI-1417 for next sprint

Also fix the PATH so that it uses the same command everywhere, useful when using sh directly