### PR TITLE
docs(specs): Review OpenAPI Analytics (advanced)

### DIFF
--- a/specs/analytics/paths/status/getStatus.yml
+++ b/specs/analytics/paths/status/getStatus.yml
@@ -3,7 +3,10 @@ get:
     - advanced
   operationId: getStatus
   summary: Get Analytics API status.
-  description: Returns the latest update time of the analytics API for a given index. If the index has been recently created and/or no search has been performed yet the updated time will be null.
+  description: >
+    Returns the latest update time of the Analytics API for an index. If the index has been recently created or no search has been performed yet, `updatedAt` will be `null`.
+
+    > **Note**: The Analytics API is updated every 5&nbsp;minutes.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'
   responses:

--- a/specs/analytics/paths/status/getStatus.yml
+++ b/specs/analytics/paths/status/getStatus.yml
@@ -4,7 +4,7 @@ get:
   operationId: getStatus
   summary: Get Analytics API status.
   description: >
-    Returns the latest update time of the Analytics API for an index. If the index has been recently created or no search has been performed yet, `updatedAt` will be `null`.
+    Return the latest update time of the Analytics API for an index. If the index has been recently created or no search has been performed yet, `updatedAt` will be `null`.
 
     > **Note**: The Analytics API is updated every 5&nbsp;minutes.
   parameters:


### PR DESCRIPTION
This is one of several PRs addressing the Analytics API.

This PR reviews just the advanced operations of the Analytics API.

## 🧭 What and Why

### Questions and notes

Some seemingly contradictory statements here: 

- There’s a note that says “The Analytics API is updated every 5 minutes” Does that mean that the API data can be up to five minutes behind real-time? 
- The statement “Returns the latest update time of the Analytics API for an index.” seems to refer to that “When in the last five minutes has the Analytics API (data?) been updated?” Should it instead say something like “Returns the time of the most recent Analytics API call”?
- The statement “If the index has been recently created or no search has been performed yet, `updatedAt` will be `null`.” seems to imply that the Analytics API (data) will be updated even if no Analytics API call is made (just a search).


🎟 JIRA Ticket: [DOC-1112](https://algolia.atlassian.net/browse/DOC-1112)

### Changes included:

Update summary, description and examples

## 🧪 Test


[DOC-1112]: https://algolia.atlassian.net/browse/DOC-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ