### PR TITLE
chore(renovate): don't use includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -160,11 +160,9 @@
     "**/predict/**",
     "**/recommend/**",
     "clients/algoliasearch-client-php/composer.json",
-    "tests/output/**"
-  ],
-  "includePaths": [
-    "tests/output/javascript/.yarn/**",
-    "tests/output/kotlin/gradle/**"
+    "tests/output/dart/**",
+    "tests/output/java/**",
+    "tests/output/javascript/package.json"
   ],
   "prHourlyLimit": 20,
   "prConcurrentLimit": 50


### PR DESCRIPTION
## 🧭 What and Why

`ignorePaths` and `includePaths` don't work together, only `includePaths` was taken into account