### PR TITLE
chore: openapi metadata files

### DIFF
--- a/clients/algoliasearch-client-dart/.gitignore
+++ b/clients/algoliasearch-client-dart/.gitignore
@@ -28,3 +28,6 @@ pubspec.lock
 
 # Melos
 pubspec_overrides.yaml
+
+# OpenAPI
+**.openapi-generator*

--- a/clients/algoliasearch-client-dart/.gitignore
+++ b/clients/algoliasearch-client-dart/.gitignore
@@ -29,5 +29,5 @@ pubspec.lock
 # Melos
 pubspec_overrides.yaml
 
-# OpenAPI
+# OpenAPI Generator
 **.openapi-generator*

--- a/clients/algoliasearch-client-java-2/.gitignore
+++ b/clients/algoliasearch-client-java-2/.gitignore
@@ -16,4 +16,5 @@ target
 .gradle
 build
 
-.openapi-generator
+# OpenAPI Generator
+**.openapi-generator*

--- a/clients/algoliasearch-client-kotlin/.gitignore
+++ b/clients/algoliasearch-client-kotlin/.gitignore
@@ -17,3 +17,6 @@ coverage-error.log
 
 # Java
 *.hprof
+
+# OpenAPI Generator
+**.openapi-generator*

--- a/clients/algoliasearch-client-php/.gitignore
+++ b/clients/algoliasearch-client-php/.gitignore
@@ -11,3 +11,6 @@ composer.phar
 
 .openapi-generator/
 composer.lock
+
+# OpenAPI Generator
+**.openapi-generator*


### PR DESCRIPTION
## 🧭 What and Why

OpenAPI generators metadata files are pushed (and removed) from API clients repositories, although not useful for those repos.

### Changes included:

Ignore OpenAPI generators metadata files.
