### PR TITLE
fix(scripts): esm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:clean": "docker stop api-clients-automation; docker rm -f api-clients-automation; docker image rm -f api-clients-automation",
     "docker:exec": "docker exec -it api-clients-automation bash -lc \"$*\"",
     "docker:mount": "./scripts/docker/mount.sh",
-    "docker:release": "docker exec -e GITHUB_TOKEN=$GITHUB_TOKEN -it api-clients-automation bash -lc \"yarn release\"",
+    "docker:release": "docker exec --env-file=.env -it api-clients-automation bash -lc \"yarn release\"",
     "docker:setup": "yarn docker:clean && yarn docker:build && yarn docker:mount",
     "fix:json": "eslint --ext=json . --fix",
     "github-actions:lint": "eslint --ext=yml .github/",

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -3,8 +3,8 @@ import chalk from 'chalk';
 import dotenv from 'dotenv';
 import semver from 'semver';
 
-import generationCommitText from '../ci/codegen/text';
-import { getNbGitDiff } from '../ci/utils';
+import generationCommitText from '../ci/codegen/text.js';
+import { getNbGitDiff } from '../ci/utils.js';
 import {
   LANGUAGES,
   ROOT_ENV_PATH,
@@ -19,11 +19,11 @@ import {
   gitBranchExists,
   setVerbose,
   configureGitHubAuthor,
-} from '../common';
-import { getPackageVersionDefault } from '../config';
+} from '../common.js';
+import { getPackageVersionDefault } from '../config.js';
 
-import { RELEASED_TAG } from './common';
-import TEXT from './text';
+import { RELEASED_TAG } from './common.js';
+import TEXT from './text.js';
 import type {
   Versions,
   VersionsBeforeBump,
@@ -31,8 +31,8 @@ import type {
   Commit,
   Scope,
   Changelog,
-} from './types';
-import { updateAPIVersions, updateDartPackages } from './updateAPIVersions';
+} from './types.js';
+import { updateAPIVersions, updateDartPackages } from './updateAPIVersions.js';
 
 dotenv.config({ path: ROOT_ENV_PATH });
 

--- a/scripts/release/types.ts
+++ b/scripts/release/types.ts
@@ -1,6 +1,6 @@
 import type { ReleaseType } from 'semver';
 
-import type { Language } from '../types';
+import type { Language } from '../types.js';
 
 export type Version = {
   current: string;

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -15,16 +15,16 @@ import {
   LANGUAGES,
   CI,
   setVerbose,
-} from '../common';
+} from '../common.js';
 import {
   getClientsConfigField,
   getGitHubUrl,
   getLanguageFolder,
-} from '../config';
-import type { Language } from '../types';
+} from '../config.js';
+import type { Language } from '../types.js';
 
-import { RELEASED_TAG, writeJsonFile } from './common';
-import type { Changelog, Versions, VersionsToRelease } from './types';
+import { RELEASED_TAG, writeJsonFile } from './common.js';
+import type { Changelog, Versions, VersionsToRelease } from './types.js';
 
 dotenv.config({ path: ROOT_ENV_PATH });
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

See https://github.com/algolia/api-clients-automation/actions/runs/5584120552/jobs/10205172965, it seems like I forgot to convert the release script to esm.

Also use `--env-file` instead of inline `env` for the release, so that it matches what we recommend in the [release process](https://api-clients-automation.netlify.app/docs/contributing/release-process/)