### PR TITLE
fix(ci): setup dart deps for release

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           type: minimal
+          language: dart # we need the dart deps because we use melos to bump dependencies for its client
 
       - run: yarn release
         env:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

See https://github.com/algolia/api-clients-automation/actions/runs/5587125378/jobs/10212057849, we need to allow dart deps in the setup of the scheduled release to make it work