### PR TITLE
chore: prepare release 2023-07-18

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.21](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.20...4.0.0-alpha.21)
+
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.20](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.19...4.0.0-alpha.20)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [529f4c636](https://github.com/algolia/api-clients-automation/commit/529f4c636) docs(java): add migration guides code snippets ([#1691](https://github.com/algolia/api-clients-automation/pull/1691)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)
 - [b7c71def](https://github.com/algolia/api-clients-automation/commit/b7c71def) feat(specs): add new outlier count properties to variant payload ([#1656](https://github.com/algolia/api-clients-automation/pull/1656)) by [@febeck](https://github.com/febeck/)
 - [b703dea4](https://github.com/algolia/api-clients-automation/commit/b703dea4) docs(specs): review Insights API spec ([#1647](https://github.com/algolia/api-clients-automation/pull/1647)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.0.0-alpha.74](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.73...5.0.0-alpha.74)
+
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [5.0.0-alpha.73](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.72...5.0.0-alpha.73)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
 
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)
 - [b7c71def](https://github.com/algolia/api-clients-automation/commit/b7c71def) feat(specs): add new outlier count properties to variant payload ([#1656](https://github.com/algolia/api-clients-automation/pull/1656)) by [@febeck](https://github.com/febeck/)
 - [b703dea4](https://github.com/algolia/api-clients-automation/commit/b703dea4) docs(specs): review Insights API spec ([#1647](https://github.com/algolia/api-clients-automation/pull/1647)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.72](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.71...4.0.0-alpha.72)
+
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.71](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.70...4.0.0-alpha.71)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "utilsPackageVersion": "5.0.0-alpha.73",
+    "utilsPackageVersion": "5.0.0-alpha.74",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.71",
+    "packageVersion": "4.0.0-alpha.72",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.20",
+    "packageVersion": "4.0.0-alpha.21",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -6,80 +6,69 @@
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/algoliasearch",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "algoliasearch"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-search": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-search",
         "reservedWordsMappings": "queryParameters=queryParameters,requestOptions=requestOptions,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-search"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-recommend": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/recommend",
         "reservedWordsMappings": "queryParameters=queryParameters,delete=delete",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "recommend"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-personalization": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-personalization",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-personalization"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-analytics": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-analytics",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-analytics"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-insights",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-insights"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-abtesting": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-abtesting",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-abtesting"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-query-suggestions": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/client-query-suggestions",
         "additionalProperties": {
-          "packageVersion": "5.0.0-alpha.73",
-          "packageName": "client-query-suggestions"
+          "packageVersion": "5.0.0-alpha.74"
         }
       },
       "javascript-predict": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/predict",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.73",
-          "packageName": "predict"
+          "packageVersion": "1.0.0-alpha.74"
         }
       },
       "javascript-ingestion": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/ingestion",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.47",
-          "packageName": "ingestion"
+          "packageVersion": "1.0.0-alpha.48"
         }
       },
       "javascript-monitoring": {
         "output": "#{cwd}/clients/algoliasearch-client-javascript/packages/monitoring",
         "additionalProperties": {
-          "packageVersion": "1.0.0-alpha.1",
-          "packageName": "monitoring"
+          "packageVersion": "1.0.0-alpha.2"
         }
       },
       "java-search": {

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -221,7 +221,7 @@ export async function updateDartPackages(): Promise<void> {
 
   // Generate dart packages versions and changelogs
   await run(
-    `(cd ${cwd} && melos version --no-git-tag-version --yes --diff ${RELEASED_TAG})`
+    `(cd ${cwd} && dart pub get && melos version --no-git-tag-version --yes --diff ${RELEASED_TAG})`
   );
 
   // Update packages configs based on generated versions


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.73 -> **`prerelease` _(e.g. 5.0.0-alpha.74)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.71 -> **`prerelease` _(e.g. 4.0.0-alpha.72)_**
- go: 4.0.0-alpha.20 -> **`prerelease` _(e.g. 4.0.0-alpha.21)_**
- kotlin: 3.0.0-SNAPSHOT -> **`minor` _(e.g. 3.0.0-SNAPSHOT)_**
- dart: 0.1.1+3 -> **`minor` _(e.g. 0.2.0)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - docs: update release process (#1773)
- chore: optimize docker image (#1770)
- chore: refine renovate config (#1747)
- chore: deps upgrade (#1732)
- chore: only setup dart when required (#1731)
- chore: forward dart version (#1695)
- chore: add release using docker (#1690)
- docs: add migration guide for copyRules/settings/synonyms (#1686)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - fix(scripts): release script with ssh (#1777)
- fix(ci): setup dart deps for release (#1775)
- fix(scripts): esm release (#1772)
- chore(deps): dependencies 2023-07-17 (#1748)
- chore(renovate): don't use includePaths (#1745)
- chore(renovate): add regex for most dependencies (#1744)
- chore(deps): dependencies 2023-07-10 (#1705)
- fix(cts): generate lock and package.json for javascript (#1721)
- fix(scripts): unused imports in go tests (#1719)
</details>