### PR TITLE
fix(dart): custom calls path and deserialization

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
+++ b/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
@@ -81,6 +81,7 @@ class DioRequester implements Requester {
       options: Options(
         method: request.method,
         headers: request.headers,
+        contentType: request.body != null ? Headers.jsonContentType: null,
         sendTimeout: request.timeout,
         receiveTimeout: request.timeout,
       ),

--- a/templates/dart/api.mustache
+++ b/templates/dart/api.mustache
@@ -100,8 +100,13 @@ final class {{classname}} implements ApiClient {
     {{/isFreeFormObject}}
     {{/requiredParams}}
     final request = ApiRequest(
-        method: RequestMethod.{{#lambda.snakecase}}{{httpMethod}}{{/lambda.snakecase}}, 
+        method: RequestMethod.{{#lambda.snakecase}}{{httpMethod}}{{/lambda.snakecase}},
+        {{^vendorExtensions.x-is-custom-request}}
         path: r'{{{path}}}'{{#pathParams}}.replaceAll('{' r'{{{baseName}}}' '}', Uri.encodeComponent({{{paramName}}}.toString())){{/pathParams}},
+        {{/vendorExtensions.x-is-custom-request}}
+        {{#vendorExtensions.x-is-custom-request}}
+        path: r'{{{path}}}'{{#pathParams}}.replaceAll('{' r'{{{baseName}}}' '}', {{{paramName}}}){{/pathParams}},
+        {{/vendorExtensions.x-is-custom-request}}
         {{#vendorExtensions.x-use-read-transporter}}
         isRead : {{{vendorExtensions.x-use-read-transporter}}},
         {{/vendorExtensions.x-use-read-transporter}}

--- a/templates/dart/serialization/json_serializable/deserialize.mustache
+++ b/templates/dart/serialization/json_serializable/deserialize.mustache
@@ -58,6 +58,9 @@ final _regMap = RegExp(r'^Map<String,(.*)>$');
               value.values.map((dynamic v) => deserialize<BaseType, BaseType>(v, targetType, growable: growable)),
             ) as ReturnType;
           }
+          if (targetType == 'Object') {
+            return value;
+          }
           break;
     } 
     throw Exception('Cannot deserialize');


### PR DESCRIPTION
## 🧭 What and Why

Custom calls  (.e.g. `post`) can encounter failure due to several factors, which include:
- Issues with path encoding
- Problems during response deserialization
- Absence of required request headers

### Changes included:

- Path encoding is now skipped
- Raw response is returned, rather than deserialized data
- The `Content-Type` header is now added by default if a request body is provided
