### PR TITLE
fix(javascript): allow package.json to be pushed

### DIFF
--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -20,6 +20,7 @@ export const patterns = [
   '!clients/algoliasearch-client-javascript/.yarn/**',
   '!clients/algoliasearch-client-javascript/scripts/**',
   '!clients/algoliasearch-client-javascript/tests/**',
+  '!clients/algoliasearch-client-javascript/packages/**/package.json',
   '!clients/algoliasearch-client-javascript/packages/requester-*/**',
   '!clients/algoliasearch-client-javascript/packages/client-common/**',
   '!clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/**',


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1437

### Changes included:

now that we rely on lerna for version bumping, we should allow the package.json to be pushed, which allows us to let the generation read the updates when running `yarn docker:release`

alternatively, we could have this logic only for the release process I believe, but this would introduce much more logic change