### PR TITLE
fix(scripts): execa command for git commits

### DIFF
--- a/scripts/__tests__/common.test.ts
+++ b/scripts/__tests__/common.test.ts
@@ -4,6 +4,7 @@ import { getClientsConfigField } from '../config.js';
 
 jest.unstable_mockModule('execa', () => {
   return {
+    execaCommand: jest.fn(),
     execa: jest.fn(),
   };
 });

--- a/scripts/__tests__/common.test.ts
+++ b/scripts/__tests__/common.test.ts
@@ -4,14 +4,14 @@ import { getClientsConfigField } from '../config.js';
 
 jest.unstable_mockModule('execa', () => {
   return {
-    execaCommand: jest.fn(),
+    execa: jest.fn(),
   };
 });
 
 const { capitalize, createClientName, gitCommit } = await import(
   '../common.js'
 );
-const { execaCommand } = await import('execa');
+const { execa } = await import('execa');
 
 describe('gitCommit', () => {
   afterEach(() => {
@@ -20,9 +20,9 @@ describe('gitCommit', () => {
 
   it('commits with message', () => {
     gitCommit({ message: 'chore: does something' });
-    expect(execaCommand).toHaveBeenCalledTimes(1);
-    expect(execaCommand).toHaveBeenCalledWith(
-      'git commit -m "chore: does something"',
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith(
+      'git', ["commit", "-m", "chore: does something"],
       { cwd: expect.any(String) }
     );
   });
@@ -47,9 +47,9 @@ describe('gitCommit', () => {
       message: 'chore: does something',
       coAuthors: [author, ...coAuthors],
     });
-    expect(execaCommand).toHaveBeenCalledTimes(1);
-    expect(execaCommand).toHaveBeenCalledWith(
-      'git commit -m "chore: does something\n\n\nCo-authored-by: them <them@algolia.com>\nCo-authored-by: me <me@algolia.com>\nCo-authored-by: you <you@algolia.com>"',
+    expect(execa).toHaveBeenCalledTimes(1);
+    expect(execa).toHaveBeenCalledWith(
+      'git', ["commit", "-m", "chore: does something\n\n\nCo-authored-by: them <them@algolia.com>\nCo-authored-by: me <me@algolia.com>\nCo-authored-by: you <you@algolia.com>"],
       { cwd: expect.any(String) }
     );
   });

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -2,7 +2,7 @@ import fsp from 'fs/promises';
 import path from 'path';
 
 import { Octokit } from '@octokit/rest';
-import { execaCommand } from 'execa';
+import { execaCommand, execa } from 'execa';
 import type { ExecaError } from 'execa';
 import { hashElement } from 'folder-hash';
 import { remove } from 'fs-extra';
@@ -154,7 +154,7 @@ export async function gitCommit({
     ? `${message}\n\n\n${coAuthors.join('\n')}`
     : message;
 
-  await execaCommand(`git commit -m "${messageWithCoAuthors}"`, { cwd });
+  await execa('git', ['commit', '-m', messageWithCoAuthors], { cwd });
 }
 
 export async function checkForCache({


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

The spread logic is failing https://github.com/algolia/api-clients-automation/actions/runs/5598140574/jobs/10237573027, this is because the `execaCommand` doesn't seem to support multiline arguments, however the `execa` one does.
