### PR TITLE
chore: prepare release 2023-07-19

### DIFF
--- a/clients/algoliasearch-client-dart/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2023-07-19
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`algolia_client_core` - `v0.1.1+3`](#algolia_client_core---v0113)
+ - [`algolia_client_search` - `v0.1.1+3`](#algolia_client_search---v0113)
+ - [`algolia_client_insights` - `v0.1.1+4`](#algolia_client_insights---v0114)
+ - [`algoliasearch` - `v0.1.1+4`](#algoliasearch---v0114)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `algolia_client_search` - `v0.1.1+3`
+ - `algolia_client_insights` - `v0.1.1+4`
+ - `algoliasearch` - `v0.1.1+4`
+
+---
+
+#### `algolia_client_core` - `v0.1.1+3`
+
+ - **FIX**(dart): custom calls path and deserialization (#1780).
+
+
 ## 2023-07-04
 
 ### Changes

--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+4
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+3
 
  - **DOCS**(dart): update changelog formatting (#1684).

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+3
+
+ - **FIX**(dart): custom calls path and deserialization (#1780).
+
 ## 0.1.1+2
 
  - **DOCS**(dart): update changelog formatting (#1684).

--- a/clients/algoliasearch-client-dart/packages/client_core/lib/src/version.dart
+++ b/clients/algoliasearch-client-dart/packages/client_core/lib/src/version.dart
@@ -1,2 +1,2 @@
 /// Current package version
-const packageVersion = '0.1.1+2';
+const packageVersion = '0.1.1+3';

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: algolia_client_core
 description: Algolia Client Core is a Dart package for seamless Algolia API integration, offering HTTP request handling, retry strategy, and robust exception management.
-version: 0.1.1+2
+version: 0.1.1+3
 homepage: https://www.algolia.com/doc/
 repository: https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core
 

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+4
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+3
 
  - **DOCS**(dart): update changelog formatting (#1684).

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+3
+
+ - Update a dependency to the latest release.
+
 ## 0.1.1+2
 
  - **DOCS**(dart): update changelog formatting (#1684).

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.0-alpha.21](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.20...4.0.0-alpha.21)
+
+- [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)
+- [f15457fd1](https://github.com/algolia/api-clients-automation/commit/f15457fd1) feat(specs): Review OpenAPI common specs ([#1692](https://github.com/algolia/api-clients-automation/pull/1692)) by [@gazconroy](https://github.com/gazconroy/)
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.20](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.19...4.0.0-alpha.20)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/clients/algoliasearch-client-java-2/CHANGELOG.md
+++ b/clients/algoliasearch-client-java-2/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
 
+- [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)
+- [f15457fd1](https://github.com/algolia/api-clients-automation/commit/f15457fd1) feat(specs): Review OpenAPI common specs ([#1692](https://github.com/algolia/api-clients-automation/pull/1692)) by [@gazconroy](https://github.com/gazconroy/)
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [529f4c636](https://github.com/algolia/api-clients-automation/commit/529f4c636) docs(java): add migration guides code snippets ([#1691](https://github.com/algolia/api-clients-automation/pull/1691)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
+## [4.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-java-2/compare/4.0.0-SNAPSHOT...4.0.0-SNAPSHOT)
+
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)
 - [b7c71def](https://github.com/algolia/api-clients-automation/commit/b7c71def) feat(specs): add new outlier count properties to variant payload ([#1656](https://github.com/algolia/api-clients-automation/pull/1656)) by [@febeck](https://github.com/febeck/)
 - [b703dea4](https://github.com/algolia/api-clients-automation/commit/b703dea4) docs(specs): review Insights API spec ([#1647](https://github.com/algolia/api-clients-automation/pull/1647)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [5.0.0-alpha.74](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.73...5.0.0-alpha.74)
+
+- [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)
+- [f15457fd1](https://github.com/algolia/api-clients-automation/commit/f15457fd1) feat(specs): Review OpenAPI common specs ([#1692](https://github.com/algolia/api-clients-automation/pull/1692)) by [@gazconroy](https://github.com/gazconroy/)
+- [550313a8b](https://github.com/algolia/api-clients-automation/commit/550313a8b) fix(javascript): allow package.json to be pushed ([#1781](https://github.com/algolia/api-clients-automation/pull/1781)) by [@shortcuts](https://github.com/shortcuts/)
+- [d97511a66](https://github.com/algolia/api-clients-automation/commit/d97511a66) fix(javascript): release process ([#1779](https://github.com/algolia/api-clients-automation/pull/1779)) by [@shortcuts](https://github.com/shortcuts/)
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [5.0.0-alpha.73](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.72...5.0.0-alpha.73)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.73",
-    "@algolia/client-analytics": "5.0.0-alpha.73",
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/client-personalization": "5.0.0-alpha.73",
-    "@algolia/client-search": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-abtesting": "5.0.0-alpha.74",
+    "@algolia/client-analytics": "5.0.0-alpha.74",
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/client-personalization": "5.0.0-alpha.74",
+    "@algolia/client-search": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.47",
+  "version": "1.0.0-alpha.48",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/predict/package.json
+++ b/clients/algoliasearch-client-javascript/packages/predict/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/predict",
-  "version": "1.0.0-alpha.73",
+  "version": "1.0.0-alpha.74",
   "description": "JavaScript client for predict",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.73",
-    "@algolia/requester-node-http": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
+    "@algolia/requester-node-http": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/node": "18.16.19",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.73",
+  "version": "5.0.0-alpha.74",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.73"
+    "@algolia/client-common": "5.0.0-alpha.74"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
 
+- [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)
+- [f15457fd1](https://github.com/algolia/api-clients-automation/commit/f15457fd1) feat(specs): Review OpenAPI common specs ([#1692](https://github.com/algolia/api-clients-automation/pull/1692)) by [@gazconroy](https://github.com/gazconroy/)
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)
 - [b7c71def](https://github.com/algolia/api-clients-automation/commit/b7c71def) feat(specs): add new outlier count properties to variant payload ([#1656](https://github.com/algolia/api-clients-automation/pull/1656)) by [@febeck](https://github.com/febeck/)
 - [b703dea4](https://github.com/algolia/api-clients-automation/commit/b703dea4) docs(specs): review Insights API spec ([#1647](https://github.com/algolia/api-clients-automation/pull/1647)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.0-alpha.72](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.71...4.0.0-alpha.72)
+
+- [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)
+- [f15457fd1](https://github.com/algolia/api-clients-automation/commit/f15457fd1) feat(specs): Review OpenAPI common specs ([#1692](https://github.com/algolia/api-clients-automation/pull/1692)) by [@gazconroy](https://github.com/gazconroy/)
+- [8765f6d47](https://github.com/algolia/api-clients-automation/commit/8765f6d47) feat(specs): add OpenAPI spec for Monitoring API ([#1683](https://github.com/algolia/api-clients-automation/pull/1683)) by [@kai687](https://github.com/kai687/)
+- [dc0ff048a](https://github.com/algolia/api-clients-automation/commit/dc0ff048a) fix(specs): facet stats properties as double ([#1694](https://github.com/algolia/api-clients-automation/pull/1694)) by [@aallam](https://github.com/aallam/)
+- [7250930c7](https://github.com/algolia/api-clients-automation/commit/7250930c7) fix(specs): add input to authentication list ([#1688](https://github.com/algolia/api-clients-automation/pull/1688)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.71](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.70...4.0.0-alpha.71)
 
 - [15bc7618](https://github.com/algolia/api-clients-automation/commit/15bc7618) feat(specs): updated_at removed from Run response ([#1651](https://github.com/algolia/api-clients-automation/pull/1651)) by [@mehmetaligok](https://github.com/mehmetaligok/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.73",
+    "packageVersion": "5.0.0-alpha.74",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.71",
+    "packageVersion": "4.0.0-alpha.72",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.20",
+    "packageVersion": "4.0.0-alpha.21",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.1.1+3",
+    "packageVersion": "0.1.1+4",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -173,19 +173,19 @@
       "dart-algoliasearch": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/algoliasearch",
         "additionalProperties": {
-          "packageVersion": "0.1.1+3"
+          "packageVersion": "0.1.1+4"
         }
       },
       "dart-search": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_search",
         "additionalProperties": {
-          "packageVersion": "0.1.1+2"
+          "packageVersion": "0.1.1+3"
         }
       },
       "dart-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_insights",
         "additionalProperties": {
-          "packageVersion": "0.1.1+3"
+          "packageVersion": "0.1.1+4"
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.73 -> **`prerelease` _(e.g. 5.0.0-alpha.74)_**
- java: 4.0.0-SNAPSHOT -> **`minor` _(e.g. 4.0.0-SNAPSHOT)_**
- php: 4.0.0-alpha.71 -> **`prerelease` _(e.g. 4.0.0-alpha.72)_**
- go: 4.0.0-alpha.20 -> **`prerelease` _(e.g. 4.0.0-alpha.21)_**
- kotlin: 3.0.0-SNAPSHOT -> **`minor` _(e.g. 3.0.0-SNAPSHOT)_**
- dart: 0.1.1+3 -> **`minor` _(e.g. 0.2.0)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - docs: update release process (#1773)
- chore: optimize docker image (#1770)
- chore: refine renovate config (#1747)
- chore: deps upgrade (#1732)
- chore: only setup dart when required (#1731)
- chore: forward dart version (#1695)
- chore: add release using docker (#1690)
- docs: add migration guide for copyRules/settings/synonyms (#1686)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - fix(scripts): execa command for git commits (#1782)
- fix(scripts): release script with ssh (#1777)
- fix(ci): setup dart deps for release (#1775)
- fix(scripts): esm release (#1772)
- chore(deps): dependencies 2023-07-17 (#1748)
- chore(renovate): don't use includePaths (#1745)
- chore(renovate): add regex for most dependencies (#1744)
- chore(deps): dependencies 2023-07-10 (#1705)
- fix(cts): generate lock and package.json for javascript (#1721)
- fix(scripts): unused imports in go tests (#1719)
</details>