### PR TITLE
fix(scripts): prevent branch exists error

### DIFF
--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -450,7 +450,7 @@ async function createReleasePR(): Promise<void> {
     await run(`git push -d origin ${headBranch}`);
   }
 
-  await run(`git checkout -b ${headBranch}`);
+  await run(`git checkout -B ${headBranch}`);
 
   setVerbose(true);
   console.log(`Pushing updated changes to: ${headBranch}`);


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

release can fail if the branch already exists, we now force and reset the branch if it's the case.