### PR TITLE
chore: fix go cache path

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -127,6 +127,7 @@ runs:
       if: ${{ inputs.language == 'go' }}
       uses: actions/setup-go@v4
       with:
+        cache-dependency-path: clients/algoliasearch-client-go/go.sum
         go-version: ${{ steps.go-version.outputs.GO_VERSION }}
 
     # Dart deps


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

cache path is not found for go (see https://github.com/algolia/api-clients-automation/actions/runs/5607959724 on every CI runs)
