### PR TITLE
fix(javascript): publish script esm

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -10,7 +10,7 @@
     "build:many": "lerna run build --include-dependencies --scope ${0:-'{@algolia/*,algoliasearch}'}",
     "clean": "lerna run clean --include-dependencies",
     "release:bump": "lerna version ${0:-patch} --no-changelog --no-git-tag-version --no-push --exact --force-publish --yes",
-    "release:publish": "ts-node --project tsconfig.script.json scripts/publish.ts",
+    "release:publish": "ts-node --esm --project tsconfig.script.json scripts/publish.ts",
     "test:size": "bundlesize"
   },
   "devDependencies": {

--- a/clients/algoliasearch-client-javascript/scripts/publish.ts
+++ b/clients/algoliasearch-client-javascript/scripts/publish.ts
@@ -1,29 +1,13 @@
-import fsp from 'fs/promises';
-import path from 'path';
-
-import execa from 'execa';
+import { execaCommand } from 'execa';
 import semver from 'semver';
 
+import packageJSON from "../packages/algoliasearch/package.json" assert { type: "json" };
+
 async function publish(): Promise<void> {
-  // Read the local version of `algoliasearch/package.json`
-  const { version } = JSON.parse(
-    (
-      await fsp.readFile(
-        path.resolve(
-          __dirname,
-          '..',
-          'packages',
-          'algoliasearch',
-          'package.json'
-        )
-      )
-    ).toString()
-  );
-
   // Get tag like `alpha`, `beta`, ...
-  const tag = semver.prerelease(version)?.[0];
+  const tag = semver.prerelease(packageJSON.version)?.[0];
 
-  await execa.command(
+  await execaCommand(
     `lerna exec --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access public ${
       tag ? `--tag ${tag}` : ''
     }`,

--- a/clients/algoliasearch-client-javascript/tsconfig.script.json
+++ b/clients/algoliasearch-client-javascript/tsconfig.script.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

publish failed (see https://github.com/algolia/algoliasearch-client-javascript/actions/runs/5608097896/jobs/10260028906) as it was expecting a commonjs file