### PR TITLE
chore: prepare release 2023-07-25

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.1.1+4...0.1.2)
+
+- [81ae3c73c](https://github.com/algolia/api-clients-automation/commit/81ae3c73c) feat(dart): rely on common changelog ([#1788](https://github.com/algolia/api-clients-automation/pull/1788)) by [@shortcuts](https://github.com/shortcuts/)
+- [3ff73cf0c](https://github.com/algolia/api-clients-automation/commit/3ff73cf0c) chore(dart): use melos to publish packages ([#1786](https://github.com/algolia/api-clients-automation/pull/1786)) by [@aallam](https://github.com/aallam/)
+
 ## 0.1.1+4
 
  - Update a dependency to the latest release.

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.1.1+4...0.1.2)
+
+- [81ae3c73c](https://github.com/algolia/api-clients-automation/commit/81ae3c73c) feat(dart): rely on common changelog ([#1788](https://github.com/algolia/api-clients-automation/pull/1788)) by [@shortcuts](https://github.com/shortcuts/)
+- [3ff73cf0c](https://github.com/algolia/api-clients-automation/commit/3ff73cf0c) chore(dart): use melos to publish packages ([#1786](https://github.com/algolia/api-clients-automation/pull/1786)) by [@aallam](https://github.com/aallam/)
+
 ## 0.1.1+4
 
  - Update a dependency to the latest release.

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.1.1+3...0.1.2)
+
+- [81ae3c73c](https://github.com/algolia/api-clients-automation/commit/81ae3c73c) feat(dart): rely on common changelog ([#1788](https://github.com/algolia/api-clients-automation/pull/1788)) by [@shortcuts](https://github.com/shortcuts/)
+- [3ff73cf0c](https://github.com/algolia/api-clients-automation/commit/3ff73cf0c) chore(dart): use melos to publish packages ([#1786](https://github.com/algolia/api-clients-automation/pull/1786)) by [@aallam](https://github.com/aallam/)
+
 ## 0.1.1+3
 
  - Update a dependency to the latest release.

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.75](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.74...5.0.0-alpha.75)
+
+- [96ab1c384](https://github.com/algolia/api-clients-automation/commit/96ab1c384) fix(javascript): publish script esm ([#1787](https://github.com/algolia/api-clients-automation/pull/1787)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.74](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.73...5.0.0-alpha.74)
 
 - [333368a3b](https://github.com/algolia/api-clients-automation/commit/333368a3b) feat(specs): query suggestions ([#1740](https://github.com/algolia/api-clients-automation/pull/1740)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.74",
-    "@algolia/client-analytics": "5.0.0-alpha.74",
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/client-personalization": "5.0.0-alpha.74",
-    "@algolia/client-search": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-abtesting": "5.0.0-alpha.75",
+    "@algolia/client-analytics": "5.0.0-alpha.75",
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/client-personalization": "5.0.0-alpha.75",
+    "@algolia/client-search": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.48",
+  "version": "1.0.0-alpha.49",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/predict/package.json
+++ b/clients/algoliasearch-client-javascript/packages/predict/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/predict",
-  "version": "1.0.0-alpha.74",
+  "version": "1.0.0-alpha.75",
   "description": "JavaScript client for predict",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.74",
-    "@algolia/requester-node-http": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.75",
+    "@algolia/requester-node-http": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/node": "18.17.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.74",
+  "version": "5.0.0-alpha.75",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.74"
+    "@algolia/client-common": "5.0.0-alpha.75"
   },
   "devDependencies": {
     "@types/jest": "29.5.3",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.74",
+    "packageVersion": "5.0.0-alpha.75",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.1.1+4",
+    "packageVersion": "0.1.2",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -173,19 +173,19 @@
       "dart-algoliasearch": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/algoliasearch",
         "additionalProperties": {
-          "packageVersion": "0.1.1+4"
+          "packageVersion": "0.1.2"
         }
       },
       "dart-search": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_search",
         "additionalProperties": {
-          "packageVersion": "0.1.1+3"
+          "packageVersion": "0.1.2"
         }
       },
       "dart-insights": {
         "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_insights",
         "additionalProperties": {
-          "packageVersion": "0.1.1+4"
+          "packageVersion": "0.1.2"
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.74 -> **`prerelease` _(e.g. 5.0.0-alpha.75)_**
- ~java: 4.0.0-SNAPSHOT (no commit)~
- ~php: 4.0.0-alpha.72 (no commit)~
- ~go: 4.0.0-alpha.21 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- dart: 0.1.1+4 -> **`minor` _(e.g. 0.2.0)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: fix renovate for Dart (#1831)
- chore: fix go cache path (#1785)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2023-07-24 (#1792)
- chore(deps): upgrade to gradle 8 (#1789)
- fix(playground): reflect spec changes (#1790)
</details>