### PR TITLE
fix(dart): correctly rethrow 4xx errors

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/retry_strategy.dart
+++ b/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/retry_strategy.dart
@@ -61,7 +61,7 @@ final class RetryStrategy {
         host.failed();
         errors.add(e);
       } on AlgoliaApiException catch (e) {
-        if (e.statusCode / 100 == 4) rethrow;
+        if (e.statusCode ~/ 100 == 4) rethrow;
         host.failed();
         errors.add(e);
       }


### PR DESCRIPTION
## 🧭 What and Why

The current error-throwing logic doesn't stop the retry operations, which it should.

### Changes included:

Correctly detect `4xx` errors to immediately stop retrying calls.