### PR TITLE
fix(specs): optional/required `query` and `params`

### DIFF
--- a/specs/recommend/common/schemas/RecommendationsResponse.yml
+++ b/specs/recommend/common/schemas/RecommendationsResponse.yml
@@ -11,6 +11,12 @@ recommendHits:
       type: array
       items:
         $ref: '#/recommendHit'
+    query:
+      $ref: '../../../common/schemas/SearchParams.yml#/query'    
+    params:
+      type: string
+      description: URL-encoded string of all search parameters.
+      example: query=a&hitsPerPage=20     
   required:
     - hits
 

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -32,7 +32,6 @@ baseSearchResponse:
     - hitsPerPage
     - processingTimeMS
     - exhaustiveNbHits
-    - params
   properties:
     abTestID:
       type: integer

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -11,8 +11,16 @@ searchHits:
       type: array
       items:
         $ref: 'Hit.yml#/hit'
+    query:
+      $ref: '../../../common/schemas/SearchParams.yml#/query'    
+    params:
+      type: string
+      description: URL-encoded string of all search parameters.
+      example: query=a&hitsPerPage=20  
   required:
     - hits
+    - query
+    - params
 
 baseSearchResponse:
   type: object
@@ -24,7 +32,6 @@ baseSearchResponse:
     - hitsPerPage
     - processingTimeMS
     - exhaustiveNbHits
-    - query
     - params
   properties:
     abTestID:
@@ -110,10 +117,6 @@ baseSearchResponse:
       example: 20
     page:
       $ref: '../../../common/schemas/SearchParams.yml#/page'
-    params:
-      type: string
-      description: URL-encoded string of all search parameters.
-      example: query=a&hitsPerPage=20
     redirect:
       type: object
       description: >
@@ -131,8 +134,6 @@ baseSearchResponse:
       type: integer
       description: Time the server took to process the request, in milliseconds.
       example: 20
-    query:
-      $ref: '../../../common/schemas/SearchParams.yml#/query'
     queryAfterRemoval:
       type: string
       description: Markup text indicating which parts of the original query have been removed to retrieve a non-empty result set.


### PR DESCRIPTION
## 🧭 What and Why

`query` and `params` are required for _Search_ (and _Browse_), but not for _Recommend_

### Changes included:

Set `query` and `params` as required for _Search_, and as optional for _Recommend_.
