### PR TITLE
chore(dart): add recommend version test

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_recommend/test/version_test.dart
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/test/version_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:algolia_client_recommend/src/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  if (Directory.current.path.endsWith('/test')) {
+    Directory.current = Directory.current.parent;
+  }
+  test('package version matches pubspec', () {
+    final pubspecPath = '${Directory.current.path}/pubspec.yaml';
+    final pubspec = File(pubspecPath).readAsStringSync();
+    final regex = RegExp('version:s*(.*)');
+    final match = regex.firstMatch(pubspec);
+    expect(match, isNotNull);
+    expect(packageVersion, match?.group(1)?.trim());
+  });
+}


### PR DESCRIPTION
## 🧭 What and Why

Each package has a version test that checks if the version in `pubspec.yaml` is the same as the version inside `version.dart`.

### Changes included:

Added version test for the package `algolia_client_recommend`.