### PR TITLE
chore(java): use new gradle syntax

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -144,6 +144,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cache '${{ matrix.client }}' client folder
+        if: ${{ github.ref != 'refs/heads/main' }}
         id: cache
         uses: actions/cache@v3
         with:
@@ -192,6 +193,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cache clients folder
+        if: ${{ github.ref != 'refs/heads/main' }}
         id: cache
         uses: actions/cache@v3
         with:

--- a/clients/algoliasearch-client-java/algoliasearch/build.gradle
+++ b/clients/algoliasearch-client-java/algoliasearch/build.gradle
@@ -8,8 +8,10 @@ repositories {
     mavenCentral()
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -7,8 +7,8 @@ version = '1.0.0'
 description = 'algolia-java-openapi-generator'
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_18
-  targetCompatibility = JavaVersion.VERSION_18
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {

--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -5,7 +5,11 @@ plugins {
 group = 'org.openapitools'
 version = '1.0.0'
 description = 'algolia-java-openapi-generator'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_18
+  targetCompatibility = JavaVersion.VERSION_18
+}
 
 repositories {
     mavenCentral()

--- a/playground/java/build.gradle
+++ b/playground/java/build.gradle
@@ -17,8 +17,8 @@ version = '1.0'
 description = 'java-playground'
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_18
-  targetCompatibility = JavaVersion.VERSION_18
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {

--- a/playground/java/build.gradle
+++ b/playground/java/build.gradle
@@ -15,7 +15,11 @@ dependencies {
 group = 'com.algolia'
 version = '1.0'
 description = 'java-playground'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_18
+  targetCompatibility = JavaVersion.VERSION_18
+}
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -269,6 +269,7 @@ export function createClientName(client: string, language: string): string {
   switch (language) {
     case 'javascript':
       return camelize(client);
+    case 'dart':
     case 'go':
       return client;
     default:

--- a/templates/java/tests/build.mustache
+++ b/templates/java/tests/build.mustache
@@ -16,7 +16,11 @@ dependencies {
 group = 'com.algolia'
 version = '1.0'
 description = 'java-tests'
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_18
+  targetCompatibility = JavaVersion.VERSION_18
+}
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/templates/java/tests/build.mustache
+++ b/templates/java/tests/build.mustache
@@ -18,8 +18,8 @@ version = '1.0'
 description = 'java-tests'
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_18
-  targetCompatibility = JavaVersion.VERSION_18
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
## 🧭 What and Why

Gradle 9 will deprecate the `sourceVersion` so we need to use the new syntax.
Also disable the `generate client` cache on main to always build and run tests.