### PR TITLE
fix(javascript): move `cjs.js` to `cjs`

### DIFF
--- a/clients/algoliasearch-client-javascript/base.rollup.config.js
+++ b/clients/algoliasearch-client-javascript/base.rollup.config.js
@@ -78,7 +78,7 @@ function createBundlers({ output, isLiteClient }) {
     },
     cjs: {
       ...commonOptions,
-      file: `${path}/${output}.cjs.js`,
+      file: `${path}/${output}.cjs`,
       format: 'cjs',
     },
   };

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -12,8 +12,8 @@
       "node": {
         "import": "./dist/algoliasearch.esm.node.js",
         "module": "./dist/algoliasearch.esm.node.js",
-        "require": "./dist/algoliasearch.cjs.js",
-        "default": "./dist/algoliasearch.cjs.js"
+        "require": "./dist/algoliasearch.cjs",
+        "default": "./dist/algoliasearch.cjs"
       },
       "default": {
         "umd": "./dist/algoliasearch.umd.js",
@@ -27,8 +27,8 @@
       "node": {
         "import": "./dist/lite/lite.esm.node.js",
         "module": "./dist/lite/lite.esm.node.js",
-        "require": "./dist/lite/lite.cjs.js",
-        "default": "./dist/lite/lite.cjs.js"
+        "require": "./dist/lite/lite.cjs",
+        "default": "./dist/lite/lite.cjs"
       },
       "default": {
         "umd": "./dist/lite/lite.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-abtesting.esm.node.js",
         "module": "./dist/client-abtesting.esm.node.js",
-        "require": "./dist/client-abtesting.cjs.js",
-        "default": "./dist/client-abtesting.cjs.js"
+        "require": "./dist/client-abtesting.cjs",
+        "default": "./dist/client-abtesting.cjs"
       },
       "default": {
         "umd": "./dist/client-abtesting.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-analytics.esm.node.js",
         "module": "./dist/client-analytics.esm.node.js",
-        "require": "./dist/client-analytics.cjs.js",
-        "default": "./dist/client-analytics.cjs.js"
+        "require": "./dist/client-analytics.cjs",
+        "default": "./dist/client-analytics.cjs"
       },
       "default": {
         "umd": "./dist/client-analytics.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Algolia",
   "type": "module",
-  "main": "dist/client-common.cjs.js",
+  "main": "dist/client-common.cjs",
   "module": "dist/client-common.esm.node.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-insights.esm.node.js",
         "module": "./dist/client-insights.esm.node.js",
-        "require": "./dist/client-insights.cjs.js",
-        "default": "./dist/client-insights.cjs.js"
+        "require": "./dist/client-insights.cjs",
+        "default": "./dist/client-insights.cjs"
       },
       "default": {
         "umd": "./dist/client-insights.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-personalization.esm.node.js",
         "module": "./dist/client-personalization.esm.node.js",
-        "require": "./dist/client-personalization.cjs.js",
-        "default": "./dist/client-personalization.cjs.js"
+        "require": "./dist/client-personalization.cjs",
+        "default": "./dist/client-personalization.cjs"
       },
       "default": {
         "umd": "./dist/client-personalization.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-query-suggestions.esm.node.js",
         "module": "./dist/client-query-suggestions.esm.node.js",
-        "require": "./dist/client-query-suggestions.cjs.js",
-        "default": "./dist/client-query-suggestions.cjs.js"
+        "require": "./dist/client-query-suggestions.cjs",
+        "default": "./dist/client-query-suggestions.cjs"
       },
       "default": {
         "umd": "./dist/client-query-suggestions.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/client-search.esm.node.js",
         "module": "./dist/client-search.esm.node.js",
-        "require": "./dist/client-search.cjs.js",
-        "default": "./dist/client-search.cjs.js"
+        "require": "./dist/client-search.cjs",
+        "default": "./dist/client-search.cjs"
       },
       "default": {
         "umd": "./dist/client-search.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/ingestion.esm.node.js",
         "module": "./dist/ingestion.esm.node.js",
-        "require": "./dist/ingestion.cjs.js",
-        "default": "./dist/ingestion.cjs.js"
+        "require": "./dist/ingestion.cjs",
+        "default": "./dist/ingestion.cjs"
       },
       "default": {
         "umd": "./dist/ingestion.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/monitoring.esm.node.js",
         "module": "./dist/monitoring.esm.node.js",
-        "require": "./dist/monitoring.cjs.js",
-        "default": "./dist/monitoring.cjs.js"
+        "require": "./dist/monitoring.cjs",
+        "default": "./dist/monitoring.cjs"
       },
       "default": {
         "umd": "./dist/monitoring.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -11,8 +11,8 @@
       "node": {
         "import": "./dist/recommend.esm.node.js",
         "module": "./dist/recommend.esm.node.js",
-        "require": "./dist/recommend.cjs.js",
-        "default": "./dist/recommend.cjs.js"
+        "require": "./dist/recommend.cjs",
+        "default": "./dist/recommend.cjs"
       },
       "default": {
         "umd": "./dist/recommend.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Algolia",
   "type": "module",
-  "main": "dist/requester-browser-xhr.cjs.js",
+  "main": "dist/requester-browser-xhr.cjs",
   "module": "dist/requester-browser-xhr.esm.node.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Algolia",
   "type": "module",
-  "main": "dist/requester-fetch.cjs.js",
+  "main": "dist/requester-fetch.cjs",
   "module": "dist/requester-fetch.esm.node.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Algolia",
   "type": "module",
-  "main": "dist/requester-node-http.cjs.js",
+  "main": "dist/requester-node-http.cjs",
   "module": "dist/requester-node-http.esm.node.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/templates/javascript/clients/algoliasearch/lite.mustache
+++ b/templates/javascript/clients/algoliasearch/lite.mustache
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/no-commonjs,import/extensions
-module.exports = require('./dist/lite/lite.cjs.js');
+module.exports = require('./dist/lite/lite.cjs');

--- a/templates/javascript/clients/index.mustache
+++ b/templates/javascript/clients/index.mustache
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/no-commonjs,import/extensions
-module.exports = require('./dist/{{packageName}}.cjs.js');
+module.exports = require('./dist/{{packageName}}.cjs');

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -16,8 +16,8 @@
       "node": {
         "import": "./dist/{{packageName}}.esm.node.js",
         "module": "./dist/{{packageName}}.esm.node.js",
-        "require": "./dist/{{packageName}}.cjs.js",
-        "default": "./dist/{{packageName}}.cjs.js"
+        "require": "./dist/{{packageName}}.cjs",
+        "default": "./dist/{{packageName}}.cjs"
       },
       "default": {
         "umd": "./dist/{{packageName}}.umd.js",
@@ -65,8 +65,8 @@
       "node": {
         "import": "./dist/algoliasearch.esm.node.js",
         "module": "./dist/algoliasearch.esm.node.js",
-        "require": "./dist/algoliasearch.cjs.js",
-        "default": "./dist/algoliasearch.cjs.js"
+        "require": "./dist/algoliasearch.cjs",
+        "default": "./dist/algoliasearch.cjs"
       },
       "default": {
         "umd": "./dist/algoliasearch.umd.js",
@@ -80,8 +80,8 @@
       "node": {
         "import": "./dist/lite/lite.esm.node.js",
         "module": "./dist/lite/lite.esm.node.js",
-        "require": "./dist/lite/lite.cjs.js",
-        "default": "./dist/lite/lite.cjs.js"
+        "require": "./dist/lite/lite.cjs",
+        "default": "./dist/lite/lite.cjs"
       },
       "default": {
         "umd": "./dist/lite/lite.umd.js",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

contributes to https://github.com/algolia/api-clients-automation/issues/1893, https://github.com/algolia/api-clients-automation/issues/1884

It seems like the issue is to resolve the `cjs.js` extensions, I'll try with full `cjs` output and see how it goes.