### PR TITLE
feat(scripts): date monorepo released tags

### DIFF
--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -13,7 +13,7 @@ import {
   setVerbose,
 } from '../../common.js';
 import { getLanguageFolder, getPackageVersionDefault } from '../../config.js';
-import { RELEASED_TAG } from '../../release/common.js';
+import { getNewReleasedTag } from '../../release/common.js';
 import { cloneRepository, getNbGitDiff } from '../utils.js';
 
 import text, { commitStartRelease } from './text.js';
@@ -64,13 +64,8 @@ async function spreadGeneration(): Promise<void> {
   // At this point, we know the release will happen on at least one client
   // So we want to set the released tag at the monorepo level too.
   if (IS_RELEASE_COMMIT) {
-    console.log('Processing release commit, removing old `released` tag on the monorepo');
-    await run(`git fetch origin refs/tags/${RELEASED_TAG}:refs/tags/${RELEASED_TAG}`);
-    await run(`git tag -d ${RELEASED_TAG}`);
-    await run(`git push --delete origin ${RELEASED_TAG}`);
-
     console.log('Creating new `released` tag for latest commit');
-    await run(`git tag ${RELEASED_TAG}`);
+    await run(`git tag ${getNewReleasedTag()}`);
     await run('git push --tags');
   }
 

--- a/scripts/release/common.ts
+++ b/scripts/release/common.ts
@@ -3,8 +3,8 @@ import fsp from 'fs/promises';
 import config from '../../config/release.config.json' assert { type: 'json' };
 import { run } from '../common.js';
 
-export async function getLastReleasedTag(): Promise<string> {
-  return await run(`git describe --abbrev=0 --tags --match "${config.releasedTag}*"`);
+export function getLastReleasedTag(): Promise<string> {
+  return run(`git describe --abbrev=0 --tags --match "${config.releasedTag}*"`);
 }
 
 export function getNewReleasedTag(): string {

--- a/scripts/release/common.ts
+++ b/scripts/release/common.ts
@@ -1,8 +1,17 @@
 import fsp from 'fs/promises';
 
 import config from '../../config/release.config.json' assert { type: 'json' };
+import { run } from '../common.js';
 
-export const RELEASED_TAG = config.releasedTag;
+export async function getLastReleasedTag(): Promise<string> {
+  return await run(`git describe --abbrev=0 --tags --match "${config.releasedTag}*"`);
+}
+
+export function getNewReleasedTag(): string {
+  const now = new Date().toISOString().split('T')[0];
+
+  return `${config.releasedTag} - ${now}`;
+}
 
 export function getTargetBranch(language: string): string {
   return config.targetBranch[language] || config.defaultTargetBranch;

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -22,7 +22,7 @@ import {
 } from '../common.js';
 import { getPackageVersionDefault } from '../config.js';
 
-import { RELEASED_TAG } from './common.js';
+import { getLastReleasedTag } from './common.js';
 import TEXT from './text.js';
 import type {
   Versions,
@@ -269,7 +269,7 @@ async function getCommits(): Promise<{
 }> {
   // Reading commits since last release
   const latestCommits = (
-    await run(`git log --pretty=format:"%h|%ae|%s" ${RELEASED_TAG}..${MAIN_BRANCH}`)
+    await run(`git log --pretty=format:"%h|%ae|%s" ${await getLastReleasedTag()}..${MAIN_BRANCH}`)
   )
     .split('\n')
     .filter(Boolean);
@@ -341,7 +341,7 @@ async function prepareGitEnvironment(): Promise<void> {
     throw new Error('Working directory is not clean. Commit all the changes first.');
   }
 
-  await run(`git rev-parse --verify refs/tags/${RELEASED_TAG}`, {
+  await run(`git rev-parse --verify refs/tags/${await getLastReleasedTag()}`, {
     errorMessage: '`released` tag is missing in this repository.',
   });
 
@@ -349,11 +349,6 @@ async function prepareGitEnvironment(): Promise<void> {
   await run('git fetch origin');
   await run('git fetch --tags --force');
   await run('git pull');
-
-  // Remove the local tag, and fetch it from the remote.
-  // We move the `released` tag as we release, so we need to make it up-to-date.
-  await run(`git tag -d ${RELEASED_TAG}`);
-  await run(`git fetch origin refs/tags/${RELEASED_TAG}:refs/tags/${RELEASED_TAG}`);
 }
 
 async function createReleasePR(): Promise<void> {

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -19,7 +19,7 @@ import {
 import { getGitHubUrl, getLanguageFolder } from '../config.js';
 import type { Language } from '../types.js';
 
-import { RELEASED_TAG, writeJsonFile } from './common.js';
+import { getLastReleasedTag, writeJsonFile } from './common.js';
 import type { Changelog, Versions, VersionsToRelease } from './types.js';
 
 dotenv.config({ path: ROOT_ENV_PATH });
@@ -135,7 +135,7 @@ async function updateDartPackages(changelog: string, releaseType: ReleaseType): 
     }
 
     await run(
-      `melos version --manual-version=${packageName}:${releaseType} --no-changelog --no-git-tag-version --yes --diff ${RELEASED_TAG}`,
+      `melos version --manual-version=${packageName}:${releaseType} --no-changelog --no-git-tag-version --yes --diff ${await getLastReleasedTag()}`,
       { cwd: gen.output }
     );
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

somehow melos can't force pull tags which makes the script fail locally and requires us to update the tags manually

```
Unhandled exception:
ProcessException: Melos: Failed executing a git command:  From github.com:algolia/api-clients-automation
 ! [rejected]            released   -> released  (would clobber existing tag)
```

while we could automate this, it would be better if we had a tag for each release instead of overwriting it every time.