### PR TITLE
chore(java): rename artifact to `algoliasearch`

### DIFF
--- a/clients/algoliasearch-client-java/algoliasearch/gradle.properties
+++ b/clients/algoliasearch-client-java/algoliasearch/gradle.properties
@@ -1,2 +1,2 @@
 POM_NAME=Algolia Search API Client for Java
-POM_ARTIFACT_ID=algoliasearch-client-java
+POM_ARTIFACT_ID=algoliasearch


### PR DESCRIPTION
## 🧭 What and Why

The current java client artifacts are published as `algoliasearch`, `algoliasearch-core`, `algoliasearch-apache`..etc.

### Changes included:

- Rename the artifact `algoliasearch` to match the current naming.
