### PR TITLE
chore: prepare release 2023-08-22

### DIFF
--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-beta.2](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.1...4.0.0-beta.2)
+
+- [25d2d44d8](https://github.com/algolia/api-clients-automation/commit/25d2d44d8) chore(java): rename artifact to `algoliasearch` ([#1935](https://github.com/algolia/api-clients-automation/pull/1935)) by [@aallam](https://github.com/aallam/)
+
 ## [4.0.0-beta.1](https://github.com/algolia/algoliasearch-client-java-2/next)
 
 - [25d2d44d8](https://github.com/algolia/api-clients-automation/commit/25d2d44d8) chore(java): rename artifact to `algoliasearch` ([#1935](https://github.com/algolia/api-clients-automation/pull/1935)) by [@aallam](https://github.com/aallam/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.1",
+    "packageVersion": "4.0.0-beta.2",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~javascript: 5.0.0-alpha.80 (no commit)~
- java: 4.0.0-beta.1 -> **`prerelease` _(e.g. 4.0.0-beta.2)_**
- ~php: 4.0.0-alpha.77 (no commit)~
- ~go: 4.0.0-alpha.26 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- ~dart: 0.2.0+2 (no commit)~

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - fix: remove spaces from tag name (#1937)
- chore: release 2023-08-22 [skip ci]
- chore: prepare release 2023-08-22 (#1936)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - feat(scripts): date monorepo released tags (#1934)
- chore(ci): update java release CI (#1933)
</details>