### PR TITLE
feat(specs): add `failureThreshold` to Ingestion API

### DIFF
--- a/specs/ingestion/common/schemas/run.yml
+++ b/specs/ingestion/common/schemas/run.yml
@@ -47,6 +47,8 @@ Run:
           type: integer
     outcome:
       $ref: '#/RunOutcome'
+    failureThrehsold:
+      $ref: './task.yml#/failureTreshold'
     reason:
       type: string
       description: 'Explains the result of outcome.'

--- a/specs/ingestion/common/schemas/run.yml
+++ b/specs/ingestion/common/schemas/run.yml
@@ -48,7 +48,7 @@ Run:
     outcome:
       $ref: '#/RunOutcome'
     failureThrehsold:
-      $ref: './task.yml#/failureTreshold'
+      $ref: './task.yml#/failureThreshold'
     reason:
       type: string
       description: 'Explains the result of outcome.'

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -284,4 +284,4 @@ failureThreshold:
   type: integer
   min: 0
   max: 100
-  description: A percentage representing the accepted failure threshold to determine if a `run` was succeeded or not.
+  description: A percentage representing the accepted failure threshold to determine if a `run` succeeded or not.

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -282,6 +282,6 @@ ScheduleDateUtilsInput:
 
 failureThreshold:
   type: integer
-  min: 0
-  max: 100
+  minimum: 0
+  maximum: 100
   description: A percentage representing the accepted failure threshold to determine if a `run` succeeded or not.

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -57,10 +57,7 @@ TaskCreate:
       type: boolean
       description: Whether the task is enabled or not.
     failureThreshold:
-      type: integer
-      min: 0
-      max: 100
-      description: A percentage representing the accepted failure threshold to determine if a `run` was succeeded or not.
+      $ref: '#/failureThreshold'
     input:
       $ref: '#/TaskInput'
     # lastCursorValue:
@@ -282,3 +279,9 @@ ScheduleDateUtilsInput:
       maximum: 30
   required:
     - timeframe
+
+failureThreshold:
+  type: integer
+  min: 0
+  max: 100
+  description: A percentage representing the accepted failure threshold to determine if a `run` was succeeded or not.

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -56,6 +56,11 @@ TaskCreate:
     enabled:
       type: boolean
       description: Whether the task is enabled or not.
+    failureThreshold:
+      type: integer
+      min: 0
+      max: 100
+      description: A percentage representing the accepted failure threshold to determine if a `run` was succeeded or not.
     input:
       $ref: '#/TaskInput'
     # lastCursorValue:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

Adds the new `failureThreshold` option to the Ingestion API.