### PR TITLE
feat(specs): add inference ACL to API key object

### DIFF
--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -124,6 +124,7 @@ acl:
     `deleteIndex`: required to delete indices.
     `deleteObject`: required to delete records.
     `editSettings`: required to change index settings.
+    `inference`: required to access the Inference API.
     `listIndexes`: required to list indices.
     `logs`: required to access logs of search and indexing operations.
     `recommendation`: required to access the Personalization and Recommend APIs.
@@ -138,6 +139,7 @@ acl:
     - deleteObject
     - deleteIndex
     - editSettings
+    - inference
     - listIndexes
     - logs
     - personalization


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: 
[AIE-512](https://algolia.atlassian.net/browse/AIE-512)

The `1/keys` endpoint supports the `inference` ACL and has been deployed to production. See [SRCH-6617](https://algolia.atlassian.net/browse/SRCH-6617). This change updates clients accordingly.

### Changes included:

- Add `inference` ACL option

## 🧪 Test
 run cts tests

[AIE-512]: https://algolia.atlassian.net/browse/AIE-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SRCH-6617]: https://algolia.atlassian.net/browse/SRCH-6617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ