### PR TITLE
fix(clients): user token character limit

### DIFF
--- a/specs/insights/common/schemas/EventAttributes.yml
+++ b/specs/insights/common/schemas/EventAttributes.yml
@@ -20,7 +20,7 @@ userToken:
   type: string
   minLength: 1
   maxLength: 128
-  pattern: '[a-zA-Z0-9_=/+-]{1,128}'
+  pattern: '[a-zA-Z0-9_=/+-]{1,129}'
   description: |
     Anonymous or pseudonymous user identifier. 
 


### PR DESCRIPTION
## 🧭 What and Why

The character limit for a user token in the Insights API is 129 characters.
I don't know when this was changed, but I tested to verify.

🎟 JIRA Ticket: N/A

### Changes included:

- Fix the `pattern` of the `userToken` parameter in the Insights API to allow up to 129 characters

## 🧪 Test
