### PR TITLE
fix(clients): userToken max length

### DIFF
--- a/specs/insights/common/schemas/EventAttributes.yml
+++ b/specs/insights/common/schemas/EventAttributes.yml
@@ -19,7 +19,7 @@ index:
 userToken:
   type: string
   minLength: 1
-  maxLength: 128
+  maxLength: 129
   pattern: '[a-zA-Z0-9_=/+-]{1,129}'
   description: |
     Anonymous or pseudonymous user identifier. 


### PR DESCRIPTION
## 🧭 What and Why

Follow up of #2003. I forgot to update the `maxLength` attribute. 

### Changes included:

- Update the `maxLength` attribute of the `userToken` parameter for the Insights API
