### PR TITLE
fix(specs): introduced SourceUpdateDocker

### DIFF
--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -130,7 +130,7 @@ DestinationIndexName:
 RecordType:
   type: string
   description: Determines the indexing strategy to use for a given e-commerce source.
-  enum: [ 'product', 'variant' ]
+  enum: ['product', 'variant']
 
 DestinationInput:
   oneOf:

--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -266,6 +266,8 @@ SourceDocker:
   type: object
   additionalProperties: false
   properties:
+    imageType:
+      $ref: '#/DockerImageType'
     registry:
       $ref: '#/DockerRegistry'
     image:
@@ -276,8 +278,6 @@ SourceDocker:
       type: string
       description: The version of the image, defaults to `latest`.
       example: v2.1.0
-    imageType:
-      $ref: '#/DockerImageType'
     configuration:
       type: object
       description: The configuration of the spec.
@@ -285,6 +285,26 @@ SourceDocker:
     - registry
     - image
     - imageType
+    - configuration
+
+SourceUpdateDocker:
+  type: object
+  additionalProperties: false
+  properties:
+    registry:
+      $ref: '#/DockerRegistry'
+    image:
+      type: string
+      description: The name of the image to pull.
+      example: algolia/zendesk
+    version:
+      type: string
+      description: The version of the image, defaults to `latest`.
+      example: v2.1.0
+    configuration:
+      type: object
+      description: The configuration of the spec.
+  required:
     - configuration
 
 DockerRegistry:
@@ -328,4 +348,4 @@ SourceUpdateInput:
     - $ref: '#/SourceJSON'
     - $ref: '#/SourceCSV'
     - $ref: '#/SourceBigQuery'
-    - $ref: '#/SourceDocker'
+    - $ref: '#/SourceUpdateDocker'


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

To improve clarity and code readability, the 'SourceDocker' was renamed to 'SourceUpdateDocker'. The required property 'configuration' was moved to SourceUpdateDocker, while the 'imageType' property now exists in both the SourceUpdateDocker and SourceDocker. In addition, SourceDocker now includes a reference to SourceUpdateDocker. These changes ensure a more logical and understandable schema structure.