### PR TITLE
fix(specs): add 'critical' event status to enum

### DIFF
--- a/specs/ingestion/common/schemas/event.yml
+++ b/specs/ingestion/common/schemas/event.yml
@@ -29,7 +29,7 @@ Event:
 
 EventStatus:
   type: string
-  enum: ['created', 'started', 'retried', 'failed', 'succeeded']
+  enum: ['created', 'started', 'retried', 'failed', 'succeeded', 'critical']
 
 EventType:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

In the 'EventStatus' section of the event.yaml schema, the enum list of possible events has been expanded to include a new status, 'critical'. This change is designed to more accurately categorize and track the nature of events for better system monitoring and debugging.