### PR TITLE
fix(specs): `exhaustiveNbHits` as optional

### DIFF
--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -31,7 +31,6 @@ baseSearchResponse:
     - nbPages
     - hitsPerPage
     - processingTimeMS
-    - exhaustiveNbHits
   properties:
     abTestID:
       type: integer


### PR DESCRIPTION
### Changes included:

- Mark `exhaustiveNbHits` as optional
