### PR TITLE
feat(scripts): sync dart client versions

### DIFF
--- a/clients/algoliasearch-client-dart/.github/workflows/publish.yml
+++ b/clients/algoliasearch-client-dart/.github/workflows/publish.yml
@@ -21,19 +21,37 @@ jobs:
       - name: Check versions
         run: melos test
 
-  publish:
+  publish_core:
     needs: check
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/client_core
+
+  publish_clients:
+    needs: 
+      - check
+      - publish_core
     strategy:
       matrix:
-        package: [
-          packages/client_core,
-          packages/client_search,
-          packages/client_insights,
-          packages/client_recommend,
-          packages/algoliasearch,
-        ]
+        package:
+          - packages/client_search,
+          - packages/client_insights,
+          - packages/client_recommend,
     permissions:
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: ${{ matrix.package }}
+
+  publish_algoliasearch:
+    needs: 
+      - check
+      - publish_core
+      - publish_clients
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/algoliasearch

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: algolia_client_core
 description: Algolia Client Core is a Dart package for seamless Algolia API integration, offering HTTP request handling, retry strategy, and robust exception management.
-version: 0.2.0+1
+version: 0.2.1
 homepage: https://www.algolia.com/doc/
 repository: https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core
 

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.2.0+2",
+    "packageVersion": "0.2.1",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",

--- a/config/openapitools.json
+++ b/config/openapitools.json
@@ -159,28 +159,16 @@
         "output": "#{cwd}/clients/algoliasearch-client-kotlin"
       },
       "dart-algoliasearch": {
-        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/algoliasearch",
-        "additionalProperties": {
-          "packageVersion": "0.2.0+2"
-        }
+        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/algoliasearch"
       },
       "dart-search": {
-        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_search",
-        "additionalProperties": {
-          "packageVersion": "0.2.0+2"
-        }
+        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_search"
       },
       "dart-insights": {
-        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_insights",
-        "additionalProperties": {
-          "packageVersion": "0.2.0+2"
-        }
+        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_insights"
       },
       "dart-recommend": {
-        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_recommend",
-        "additionalProperties": {
-          "packageVersion": "0.2.0+2"
-        }
+        "output": "#{cwd}/clients/algoliasearch-client-dart/packages/client_recommend"
       }
     }
   }

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -30,7 +30,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
   public void processOpts() {
     String client = (String) additionalProperties.get("client");
     isAlgoliasearchClient = client.equals("algoliasearch");
-    String version = Utils.getPubspecVersion(client);
+    String version = Utils.getClientConfigField("dart", "packageVersion");
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
 
     // pubspec.yaml
@@ -72,8 +72,8 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     if (isAlgoliasearchClient) {
       supportingFiles.removeIf(file -> file.getTemplateFile().contains("lib"));
       supportingFiles.add(new SupportingFile("lib.mustache", libPath, "algoliasearch_lite.dart"));
-      additionalProperties.put("searchVersion", Utils.getPubspecVersion("search"));
-      additionalProperties.put("insightsVersion", Utils.getPubspecVersion("insights"));
+      additionalProperties.put("searchVersion", version);
+      additionalProperties.put("insightsVersion", version);
     }
 
     // disable documentation and tests
@@ -97,7 +97,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
 
     // Search config
     additionalProperties.put("isSearchClient", client.equals("search"));
-    additionalProperties.put("packageVersion", Utils.getClientConfigField("dart", "packageVersion"));
+    additionalProperties.put("packageVersion", version);
 
     // Generate server info
     Utils.generateServer(client, additionalProperties);

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -30,7 +30,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
   public void processOpts() {
     String client = (String) additionalProperties.get("client");
     isAlgoliasearchClient = client.equals("algoliasearch");
-    String version = Utils.getOpenApiToolsField("dart", client, "packageVersion");
+    String version = Utils.getPubspecVersion(client);
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
 
     // pubspec.yaml
@@ -72,8 +72,8 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     if (isAlgoliasearchClient) {
       supportingFiles.removeIf(file -> file.getTemplateFile().contains("lib"));
       supportingFiles.add(new SupportingFile("lib.mustache", libPath, "algoliasearch_lite.dart"));
-      additionalProperties.put("searchVersion", Utils.getOpenApiToolsField("dart", "search", "packageVersion"));
-      additionalProperties.put("insightsVersion", Utils.getOpenApiToolsField("dart", "insights", "packageVersion"));
+      additionalProperties.put("searchVersion", Utils.getPubspecVersion("search"));
+      additionalProperties.put("insightsVersion", Utils.getPubspecVersion("insights"));
     }
 
     // disable documentation and tests

--- a/generators/src/main/java/com/algolia/codegen/Utils.java
+++ b/generators/src/main/java/com/algolia/codegen/Utils.java
@@ -132,35 +132,6 @@ public class Utils {
 
   /**
    * Get the current version of the given client from the
-   * `clients/algoliasearch-client-dart/packages/${client}/pubspec.yaml` file, defaults to 0.0.1 if
-   * not found
-   */
-  public static String getPubspecVersion(String client) throws ConfigException {
-    try {
-      if (!client.startsWith("algoliasearch")) {
-        client = "client_" + client;
-      }
-
-      Yaml yaml = new Yaml();
-      Map<String, Object> pubspec = yaml.load(
-        new FileInputStream("clients/algoliasearch-client-dart/packages/" + client + "/pubspec.yaml")
-      );
-      String value = (String) pubspec.get("version");
-
-      if (value.isEmpty()) {
-        return "0.0.1";
-      }
-
-      return value;
-    } catch (ConfigException e) {
-      return "0.0.1";
-    } catch (Exception e) {
-      throw new ConfigException("Couldn't retrieve dart package version", e);
-    }
-  }
-
-  /**
-   * Get the current version of the given client from the
    * `clients/algoliasearch-client-javascript/packages/${client}/package.json` file, defaults to
    * 0.0.1 if not found
    */

--- a/generators/src/main/java/com/algolia/codegen/Utils.java
+++ b/generators/src/main/java/com/algolia/codegen/Utils.java
@@ -132,6 +132,35 @@ public class Utils {
 
   /**
    * Get the current version of the given client from the
+   * `clients/algoliasearch-client-dart/packages/${client}/pubspec.yaml` file, defaults to 0.0.1 if
+   * not found
+   */
+  public static String getPubspecVersion(String client) throws ConfigException {
+    try {
+      if (!client.startsWith("algoliasearch")) {
+        client = "client_" + client;
+      }
+
+      Yaml yaml = new Yaml();
+      Map<String, Object> pubspec = yaml.load(
+        new FileInputStream("clients/algoliasearch-client-dart/packages/" + client + "/pubspec.yaml")
+      );
+      String value = (String) pubspec.get("version");
+
+      if (value.isEmpty()) {
+        return "0.0.1";
+      }
+
+      return value;
+    } catch (ConfigException e) {
+      return "0.0.1";
+    } catch (Exception e) {
+      throw new ConfigException("Couldn't retrieve dart package version", e);
+    }
+  }
+
+  /**
+   * Get the current version of the given client from the
    * `clients/algoliasearch-client-javascript/packages/${client}/package.json` file, defaults to
    * 0.0.1 if not found
    */

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "docker:clean": "docker stop api-clients-automation; docker rm -f api-clients-automation; docker image rm -f api-clients-automation",
     "docker:exec": "docker exec -it api-clients-automation bash -lc \"$*\"",
     "docker:mount": "./scripts/docker/mount.sh",
-    "docker:release": "docker exec --env-file=.env -it api-clients-automation bash -lc \"yarn release\"",
     "docker:setup": "yarn docker:clean && yarn docker:build && yarn docker:mount",
     "fix:json": "eslint --ext=json . --fix",
     "github-actions:lint": "eslint --ext=yml .github/",

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -316,24 +316,25 @@ async function getCommits(): Promise<{
 
 /**
  * Ensure the release environment is correct before triggering.
+ *
+ * You can bypass blocking checks by setting LOCAL_TEST_DEV to true.
  */
 async function prepareGitEnvironment(): Promise<void> {
   ensureGitHubToken();
-
-  // We allow bypassing those requirements for local tests
-  if (process.env.LOCAL_TEST_DEV) {
-    return;
-  }
 
   if (CI) {
     await configureGitHubAuthor();
   }
 
-  if ((await run('git rev-parse --abbrev-ref HEAD')) !== MAIN_BRANCH) {
+  if (
+    !process.env.LOCAL_TEST_DEV &&
+    (await run('git rev-parse --abbrev-ref HEAD')) !== MAIN_BRANCH
+  ) {
     throw new Error(`You can run this script only from \`${MAIN_BRANCH}\` branch.`);
   }
 
   if (
+    !process.env.LOCAL_TEST_DEV &&
     (await getNbGitDiff({
       head: null,
     })) !== 0

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -151,6 +151,12 @@ async function updateDartPackages(changelog: string, nextVersion: string): Promi
 
   // update `clients.config.json` file for the utils version.
   await writeJsonFile(toAbsolutePath('config/clients.config.json'), clientsConfig);
+
+  // we've bumped generated clients but still need to do the manual ones.
+  await bumpPubspecVersion(
+    toAbsolutePath('clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml'),
+    nextVersion
+  );
 }
 
 /**
@@ -163,6 +169,22 @@ async function getPubspecField(filePath: string, field: string): Promise<string 
 
     return pubspec[field];
   } catch (error) {
-    throw new Error(`Error reading the file: ${error}`);
+    throw new Error(`Error reading file ${filePath}: ${error}`);
+  }
+}
+
+/**
+ * Bump 'version' of the given pubspec.yaml file path.
+ */
+async function bumpPubspecVersion(filePath: string, nextVersion: string): Promise<void> {
+  try {
+    const fileContent = await fsp.readFile(toAbsolutePath(filePath), 'utf8');
+    const pubspec = yaml.load(fileContent) as Record<string, any>;
+
+    pubspec.version = nextVersion;
+
+    await fsp.writeFile(filePath, yaml.dump(pubspec));
+  } catch (error) {
+    throw new Error(`Error writing file ${filePath}: ${error}`);
   }
 }

--- a/website/docs/contributing/release-process.md
+++ b/website/docs/contributing/release-process.md
@@ -15,8 +15,7 @@ GITHUB_TOKEN=<YOUR-PERSONAL-ACCESS-TOKEN>
 Once setup, you can run:
 
 ```bash
-# make sure to run `yarn docker:setup` first
-yarn docker:release
+yarn release
 ```
 
 It will create [a release PR](https://github.com/algolia/api-clients-automation/pull/545).


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Dart release process is broken, and since we now sync versions between all packages, we can keep the same package bumping logic as the other clients.

also close https://github.com/algolia/api-clients-automation/pull/1890