### PR TITLE
fix(scripts): generate some core files

### DIFF
--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -65,9 +65,11 @@ export const patterns = [
   'clients/algoliasearch-client-dart/packages/*/pubspec.yaml',
   'clients/algoliasearch-client-dart/packages/*/lib/*.dart',
   'clients/algoliasearch-client-dart/packages/*/lib/src/*.dart',
+  'clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml',
   'clients/algoliasearch-client-dart/packages/*/lib/src/api/**',
   'clients/algoliasearch-client-dart/packages/*/lib/src/model/**',
   '!clients/algoliasearch-client-dart/packages/client_core/**',
+  'clients/algoliasearch-client-dart/packages/client_core/lib/src/version.dart',
   '!clients/algoliasearch-client-dart/packages/*/lib/src/extension.dart',
   '!clients/algoliasearch-client-dart/packages/algoliasearch/lib/algoliasearch.dart',
 ];

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -62,13 +62,18 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     setPubLibrary(libName);
     setPubRepository("https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/" + packageFolder);
 
+    // core package
+    additionalProperties.put("coreVersion", version);
+    final String srcFolder = libPath + sourceFolder;
+    supportingFiles.add(new SupportingFile("version.mustache", "../client_core/" + srcFolder, "version.dart"));
+
     // configs
     additionalProperties.put(CodegenConstants.SERIALIZATION_LIBRARY, SERIALIZATION_LIBRARY_JSON_SERIALIZABLE);
 
     super.processOpts();
 
     Arrays.asList("source", "get", "hide", "operator").forEach(reservedWords::remove); // reserved words from dart-keywords.txt
-
+    //
     if (isAlgoliasearchClient) {
       supportingFiles.removeIf(file -> file.getTemplateFile().contains("lib"));
       supportingFiles.add(new SupportingFile("lib.mustache", libPath, "algoliasearch_lite.dart"));
@@ -92,7 +97,6 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     supportingFiles.removeIf(file -> file.getTemplateFile().contains("analysis_options"));
     supportingFiles.removeIf(file -> file.getTemplateFile().contains("README"));
 
-    final String srcFolder = libPath + sourceFolder;
     supportingFiles.add(new SupportingFile("version.mustache", srcFolder, "version.dart"));
 
     // Search config

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -73,7 +73,6 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     super.processOpts();
 
     Arrays.asList("source", "get", "hide", "operator").forEach(reservedWords::remove); // reserved words from dart-keywords.txt
-    //
     if (isAlgoliasearchClient) {
       supportingFiles.removeIf(file -> file.getTemplateFile().contains("lib"));
       supportingFiles.add(new SupportingFile("lib.mustache", libPath, "algoliasearch_lite.dart"));

--- a/templates/dart/pubspec.mustache
+++ b/templates/dart/pubspec.mustache
@@ -16,7 +16,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  algolia_client_core: ^0.2.0
+  algolia_client_core: ^{{{coreVersion}}}
   {{#isAlgoliasearchClient}}
   algolia_client_search: ^{{{searchVersion}}}
   algolia_client_insights: ^{{{insightsVersion}}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

some `core` dart files were not generated on release, meaning their version is not bumped.

this PR adds them to the list so we don't have to do it manually anymore.