### PR TITLE
fix(dart): correct typo in readme

### DIFF
--- a/clients/algoliasearch-client-dart/README.md
+++ b/clients/algoliasearch-client-dart/README.md
@@ -58,7 +58,7 @@ dart pub add algoliasearch
 #### For Flutter projects:
 
 ```shell
-flutter pub add algolisearch
+flutter pub add algoliasearch
 ```
 
 ### Step 2: Import the Package


### PR DESCRIPTION
## 🧭 What and Why

- There is a typo in the flutter command for dart client

### Changes included:

- Correct typo (s/algoliasearch/algoliasearch) in README for dart client
