### PR TITLE
fix(dart): correct multiple additional typos in READMEs

### DIFF
--- a/clients/algoliasearch-client-dart/README.md
+++ b/clients/algoliasearch-client-dart/README.md
@@ -66,13 +66,13 @@ flutter pub add algoliasearch
 Now, you can import the `algoliasearch` package in your Dart code for all operations, including indexing, search, and personalization:
 
 ```dart
-import 'package:algolisearch/algolisearch.dart';
+import 'package:algoliasearch/algoliasearch.dart';
 ```
 
 Alternatively, you can import `algoliasearch_lite`, a **search-only** version of the library, if you do not need the full feature set:
 
 ```dart
-import 'package:algolisearch/algolisearch_lite.dart';
+import 'package:algoliasearch/algoliasearch_lite.dart';
 ```
 
 ## 📄 License

--- a/clients/algoliasearch-client-dart/packages/algoliasearch/README.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/README.md
@@ -58,7 +58,7 @@ dart pub add algoliasearch
 #### For Flutter projects:
 
 ```shell
-flutter pub add algolisearch
+flutter pub add algoliasearch
 ```
 
 ### Step 2: Import the Package
@@ -66,13 +66,13 @@ flutter pub add algolisearch
 Now, you can import the `algoliasearch` package in your Dart code for all operations, including indexing, search, and personalization:
 
 ```dart
-import 'package:algolisearch/algolisearch.dart';
+import 'package:algoliasearch/algoliasearch.dart';
 ```
 
 Alternatively, you can import `algoliasearch_lite`, a **search-only** version of the library, if you do not need the full feature set:
 
 ```dart
-import 'package:algolisearch/algolisearch_lite.dart';
+import 'package:algoliasearch/algoliasearch_lite.dart';
 ```
 
 ## 📄 License


### PR DESCRIPTION
## 🧭 What and Why

I found some more typos in various README for the dart client:

```
find . -type f -exec grep -li 'algolis' \{\} \;
./clients/algoliasearch-client-dart/README.md
./clients/algoliasearch-client-dart/packages/algoliasearch/README.md
```

### Changes included:

- Corrected all remaining instances of `algolisearch` in README files.

## 🧪 Test
