### PR TITLE
chore: prepare release 2023-09-18

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.2...0.2.3)
+
+- [6911ec0b5](https://github.com/algolia/api-clients-automation/commit/6911ec0b5) fix(dart): reset only hosts w/ call type ([#2018](https://github.com/algolia/api-clients-automation/pull/2018)) by [@aallam](https://github.com/aallam/)
+- [966744949](https://github.com/algolia/api-clients-automation/commit/966744949) fix(dart): correct multiple additional typos in READMEs ([#2016](https://github.com/algolia/api-clients-automation/pull/2016)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [3622fdb83](https://github.com/algolia/api-clients-automation/commit/3622fdb83) fix(dart): correct typo in readme ([#2015](https://github.com/algolia/api-clients-automation/pull/2015)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [40ac5c702](https://github.com/algolia/api-clients-automation/commit/40ac5c702) chore(dart): update changelog generation ([#2014](https://github.com/algolia/api-clients-automation/pull/2014)) by [@aallam](https://github.com/aallam/)
+
 ## [0.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.1...0.2.2)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.2...0.2.3)
+
+- [6911ec0b5](https://github.com/algolia/api-clients-automation/commit/6911ec0b5) fix(dart): reset only hosts w/ call type ([#2018](https://github.com/algolia/api-clients-automation/pull/2018)) by [@aallam](https://github.com/aallam/)
+- [966744949](https://github.com/algolia/api-clients-automation/commit/966744949) fix(dart): correct multiple additional typos in READMEs ([#2016](https://github.com/algolia/api-clients-automation/pull/2016)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [3622fdb83](https://github.com/algolia/api-clients-automation/commit/3622fdb83) fix(dart): correct typo in readme ([#2015](https://github.com/algolia/api-clients-automation/pull/2015)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [40ac5c702](https://github.com/algolia/api-clients-automation/commit/40ac5c702) chore(dart): update changelog generation ([#2014](https://github.com/algolia/api-clients-automation/pull/2014)) by [@aallam](https://github.com/aallam/)
+
 ## [0.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.1...0.2.2)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 0.2.2
+version: 0.2.3
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.2...0.2.3)
+
+- [6911ec0b5](https://github.com/algolia/api-clients-automation/commit/6911ec0b5) fix(dart): reset only hosts w/ call type ([#2018](https://github.com/algolia/api-clients-automation/pull/2018)) by [@aallam](https://github.com/aallam/)
+- [966744949](https://github.com/algolia/api-clients-automation/commit/966744949) fix(dart): correct multiple additional typos in READMEs ([#2016](https://github.com/algolia/api-clients-automation/pull/2016)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [3622fdb83](https://github.com/algolia/api-clients-automation/commit/3622fdb83) fix(dart): correct typo in readme ([#2015](https://github.com/algolia/api-clients-automation/pull/2015)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [40ac5c702](https://github.com/algolia/api-clients-automation/commit/40ac5c702) chore(dart): update changelog generation ([#2014](https://github.com/algolia/api-clients-automation/pull/2014)) by [@aallam](https://github.com/aallam/)
+
 ## [0.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.1...0.2.2)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.2...0.2.3)
+
+- [6911ec0b5](https://github.com/algolia/api-clients-automation/commit/6911ec0b5) fix(dart): reset only hosts w/ call type ([#2018](https://github.com/algolia/api-clients-automation/pull/2018)) by [@aallam](https://github.com/aallam/)
+- [966744949](https://github.com/algolia/api-clients-automation/commit/966744949) fix(dart): correct multiple additional typos in READMEs ([#2016](https://github.com/algolia/api-clients-automation/pull/2016)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [3622fdb83](https://github.com/algolia/api-clients-automation/commit/3622fdb83) fix(dart): correct typo in readme ([#2015](https://github.com/algolia/api-clients-automation/pull/2015)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [40ac5c702](https://github.com/algolia/api-clients-automation/commit/40ac5c702) chore(dart): update changelog generation ([#2014](https://github.com/algolia/api-clients-automation/pull/2014)) by [@aallam](https://github.com/aallam/)
+
 ## [0.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.1...0.2.2)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.2.3](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.2...0.2.3)
+
+- [6911ec0b5](https://github.com/algolia/api-clients-automation/commit/6911ec0b5) fix(dart): reset only hosts w/ call type ([#2018](https://github.com/algolia/api-clients-automation/pull/2018)) by [@aallam](https://github.com/aallam/)
+- [966744949](https://github.com/algolia/api-clients-automation/commit/966744949) fix(dart): correct multiple additional typos in READMEs ([#2016](https://github.com/algolia/api-clients-automation/pull/2016)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [3622fdb83](https://github.com/algolia/api-clients-automation/commit/3622fdb83) fix(dart): correct typo in readme ([#2015](https://github.com/algolia/api-clients-automation/pull/2015)) by [@chuckmeyer](https://github.com/chuckmeyer/)
+- [40ac5c702](https://github.com/algolia/api-clients-automation/commit/40ac5c702) chore(dart): update changelog generation ([#2014](https://github.com/algolia/api-clients-automation/pull/2014)) by [@aallam](https://github.com/aallam/)
+
 ## [0.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/0.2.1...0.2.2)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.84](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.83...5.0.0-alpha.84)
+
+- [28c1a2118](https://github.com/algolia/api-clients-automation/commit/28c1a2118) feat(javascript): add batchSize to the observability event object ([#2029](https://github.com/algolia/api-clients-automation/pull/2029)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [5.0.0-alpha.83](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.82...5.0.0-alpha.83)
 
 - [265518125](https://github.com/algolia/api-clients-automation/commit/265518125) fix(specs): `exhaustiveNbHits` as optional ([#2007](https://github.com/algolia/api-clients-automation/pull/2007)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.82",
-    "@algolia/client-analytics": "5.0.0-alpha.82",
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/client-personalization": "5.0.0-alpha.82",
-    "@algolia/client-search": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-abtesting": "5.0.0-alpha.83",
+    "@algolia/client-analytics": "5.0.0-alpha.83",
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/client-personalization": "5.0.0-alpha.83",
+    "@algolia/client-search": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/jest": "29.5.4",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.56",
+  "version": "1.0.0-alpha.57",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.10",
+  "version": "1.0.0-alpha.11",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.82",
-    "@algolia/requester-node-http": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.83",
+    "@algolia/requester-node-http": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/node": "18.17.15",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/jest": "29.5.4",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/jest": "29.5.4",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.82",
+  "version": "5.0.0-alpha.83",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.82"
+    "@algolia/client-common": "5.0.0-alpha.83"
   },
   "devDependencies": {
     "@types/jest": "29.5.4",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.83",
+    "packageVersion": "5.0.0-alpha.84",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.2.2",
+    "packageVersion": "0.2.3",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.83 -> **`prerelease` _(e.g. 5.0.0-alpha.84)_**
- ~java: 4.0.0-beta.5 (no commit)~
- ~php: 4.0.0-alpha.80 (no commit)~
- ~go: 4.0.0-alpha.29 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- dart: 0.2.2 -> **`patch` _(e.g. 0.2.3)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2023-09-18 (#2017)
</details>