### PR TITLE
chore: prepare release 2023-10-11

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.87...5.0.0-alpha.88)
+
+- [2c58deae3](https://github.com/algolia/api-clients-automation/commit/2c58deae3) fix(javascript): release process ([#2106](https://github.com/algolia/api-clients-automation/pull/2106)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.87](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.86...5.0.0-alpha.87)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.87",
+    "packageVersion": "5.0.0-alpha.88",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.87 -> **`prerelease` _(e.g. 5.0.0-alpha.88)_**
- ~java: 4.0.0-beta.7 (no commit)~
- ~php: 4.0.0-alpha.82 (no commit)~
- ~go: 4.0.0-alpha.31 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- ~dart: 0.4.0 (no commit)~

### Skipped Commits

_(None)_