### PR TITLE
chore: prepare release 2023-10-11

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.87...5.0.0-alpha.88)
+
+- [2c58deae3](https://github.com/algolia/api-clients-automation/commit/2c58deae3) fix(javascript): release process ([#2106](https://github.com/algolia/api-clients-automation/pull/2106)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.87](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.86...5.0.0-alpha.87)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.85",
-    "@algolia/client-analytics": "5.0.0-alpha.85",
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/client-personalization": "5.0.0-alpha.85",
-    "@algolia/client-search": "5.0.0-alpha.85",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-abtesting": "5.0.0-alpha.86",
+    "@algolia/client-analytics": "5.0.0-alpha.86",
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/client-personalization": "5.0.0-alpha.86",
+    "@algolia/client-search": "5.0.0-alpha.86",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.59",
+  "version": "1.0.0-alpha.60",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.85",
+  "version": "5.0.0-alpha.86",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.86",
-    "@algolia/requester-node-http": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
+    "@algolia/requester-node-http": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.86"
+    "@algolia/client-common": "5.0.0-alpha.87"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.87",
+    "packageVersion": "5.0.0-alpha.88",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "cleanGeneratedBranch": "ts-node ci/codegen/cleanGeneratedBranch.ts",
     "createMatrix": "ts-node ci/githubActions/createMatrix.ts",
-    "createReleasePR": "NODE_NO_WARNINGS=1 ts-node release/createReleasePR.ts",
+    "createReleasePR": "NODE_NO_WARNINGS=1 RELEASE=true ts-node release/createReleasePR.ts",
     "lint": "eslint --ext=ts,js,mjs,cjs .",
     "lint:deadcode": "knip",
     "pre-commit": "node ./ci/husky/pre-commit.mjs",

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -415,7 +415,7 @@ async function createReleasePR(): Promise<void> {
   if (process.env.LOCAL_TEST_DEV) {
     await run(`git commit -m "${commitMessage} [skip ci]"`);
   } else {
-    await run(`CI=false RELEASE=true git commit -m "${commitMessage}"`);
+    await run(`CI=false git commit -m "${commitMessage}"`);
   }
 
   // cleanup all the changes to the generated files (the ones not commited because of the pre-commit hook)


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.87 -> **`prerelease` _(e.g. 5.0.0-alpha.88)_**
- ~java: 4.0.0-beta.7 (no commit)~
- ~php: 4.0.0-alpha.82 (no commit)~
- ~go: 4.0.0-alpha.31 (no commit)~
- ~kotlin: 3.0.0-SNAPSHOT (no commit)~
- ~dart: 0.4.0 (no commit)~

### Skipped Commits

_(None)_