### PR TITLE
chore: prepare release 2023-10-12

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.4.0...0.5.0)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [0.4.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.4.0)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.4.0...0.5.0)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [0.4.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.4.0)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 0.4.0
+version: 0.5.0
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.4.0...0.5.0)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [0.4.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.4.0)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.4.0...0.5.0)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [0.4.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.4.0)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.4.0...0.5.0)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [0.4.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.3.0...0.4.0)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.32](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.31...4.0.0-alpha.32)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [4.0.0-alpha.31](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.30...4.0.0-alpha.31)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-beta.8](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.7...4.0.0-beta.8)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [4.0.0-beta.7](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.6...4.0.0-beta.7)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.89](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.88...5.0.0-alpha.89)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [5.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.87...5.0.0-alpha.88)
 
 - [2c58deae3](https://github.com/algolia/api-clients-automation/commit/2c58deae3) fix(javascript): release process ([#2106](https://github.com/algolia/api-clients-automation/pull/2106)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.86",
-    "@algolia/client-analytics": "5.0.0-alpha.86",
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/client-personalization": "5.0.0-alpha.86",
-    "@algolia/client-search": "5.0.0-alpha.86",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-abtesting": "5.0.0-alpha.87",
+    "@algolia/client-analytics": "5.0.0-alpha.87",
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/client-personalization": "5.0.0-alpha.87",
+    "@algolia/client-search": "5.0.0-alpha.87",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.87",
+  "version": "5.0.0-alpha.88",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.60",
+  "version": "1.0.0-alpha.61",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.14",
+  "version": "1.0.0-alpha.15",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.86",
+  "version": "5.0.0-alpha.87",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.87",
-    "@algolia/requester-node-http": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.88",
+    "@algolia/requester-node-http": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/node": "18.18.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.87",
+  "version": "5.0.0-alpha.88",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.87",
+  "version": "5.0.0-alpha.88",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.87",
+  "version": "5.0.0-alpha.88",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.87"
+    "@algolia/client-common": "5.0.0-alpha.88"
   },
   "devDependencies": {
     "@types/jest": "29.5.5",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
 
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
+## [3.0.0-SNAPSHOT](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-SNAPSHOT...3.0.0-SNAPSHOT)
+
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)
 - [f8e79a1e2](https://github.com/algolia/api-clients-automation/commit/f8e79a1e2) fix(specs): search `insideBoundingBox` type ([#2098](https://github.com/algolia/api-clients-automation/pull/2098)) by [@aallam](https://github.com/aallam/)
 - [d38619103](https://github.com/algolia/api-clients-automation/commit/d38619103) feat(specs): add new events type for insights ([#2080](https://github.com/algolia/api-clients-automation/pull/2080)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.83](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.82...4.0.0-alpha.83)
+
+- [b5ec54151](https://github.com/algolia/api-clients-automation/commit/b5ec54151) feat(specs): revenue and filterEffects typing updates ([#2105](https://github.com/algolia/api-clients-automation/pull/2105)) by [@cdhawke](https://github.com/cdhawke/)
+
 ## [4.0.0-alpha.82](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.81...4.0.0-alpha.82)
 
 - [e3b7e2ab6](https://github.com/algolia/api-clients-automation/commit/e3b7e2ab6) feat(specs): synchronize specs for all client ([#2103](https://github.com/algolia/api-clients-automation/pull/2103)) by [@Fluf22](https://github.com/Fluf22/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.7",
+    "packageVersion": "4.0.0-beta.8",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.88",
+    "packageVersion": "5.0.0-alpha.89",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.82",
+    "packageVersion": "4.0.0-alpha.83",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.31",
+    "packageVersion": "4.0.0-alpha.32",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "0.4.0",
+    "packageVersion": "0.5.0",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.88 -> **`prerelease` _(e.g. 5.0.0-alpha.89)_**
- java: 4.0.0-beta.7 -> **`prerelease` _(e.g. 4.0.0-beta.8)_**
- php: 4.0.0-alpha.82 -> **`prerelease` _(e.g. 4.0.0-alpha.83)_**
- go: 4.0.0-alpha.31 -> **`prerelease` _(e.g. 4.0.0-alpha.32)_**
- kotlin: 3.0.0-SNAPSHOT -> **`minor` _(e.g. 3.0.0-SNAPSHOT)_**
- dart: 0.4.0 -> **`minor` _(e.g. 0.5.0)_**

### Skipped Commits

_(None)_