### PR TITLE
fix(specs): remove duplicate objectID

### DIFF
--- a/specs/search/paths/rules/common/parameters.yml
+++ b/specs/search/paths/rules/common/parameters.yml
@@ -6,7 +6,7 @@ ClearExistingRules:
     type: boolean
   description: Indicates whether existing rules should be deleted before adding this batch.
 
-ObjectID:
+ObjectIDRule:
   in: path
   name: objectID
   description: Unique identifier of a rule object.

--- a/specs/search/paths/rules/rule.yml
+++ b/specs/search/paths/rules/rule.yml
@@ -6,7 +6,7 @@ get:
   description: Get a rule by its `objectID`. To find the `objectID` for rules, use the [`search` operation](#tag/Rules/operation/searchRules).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: 'common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectIDRule'
   responses:
     '200':
       description: OK
@@ -31,7 +31,7 @@ put:
   description: To create or update more than one rule, use the [`batch` operation](#tag/Rules/operation/saveRules).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: 'common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectIDRule'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'
   requestBody:
     required: true
@@ -63,7 +63,7 @@ delete:
   description: Delete a rule by its `objectID`. To find the `objectID` for rules, use the [`search` operation](#tag/Rules/operation/searchRules).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
-    - $ref: 'common/parameters.yml#/ObjectID'
+    - $ref: 'common/parameters.yml#/ObjectIDRule'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'
   responses:
     '200':


### PR DESCRIPTION
## 🧭 What and Why

this removes the warning discovered by @shortcuts, two parameters were named `objectID` and redocly didn't like that
