### PR TITLE
chore: prepare release 2023-11-06

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.0.0...1.1.0)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [1.0.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.6.0...1.0.0)
 
 - [e1b51f8d](https://github.com/algolia/api-clients-automation/commit/e1b51f8d) feat(dart): promote to stable [BREAKING CHANGE] ([#2152](https://github.com/algolia/api-clients-automation/pull/2152)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.0.0...1.1.0)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [1.0.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.6.0...1.0.0)
 
 - [e1b51f8d](https://github.com/algolia/api-clients-automation/commit/e1b51f8d) feat(dart): promote to stable [BREAKING CHANGE] ([#2152](https://github.com/algolia/api-clients-automation/pull/2152)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 1.0.0
+version: 1.1.0
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.0.0...1.1.0)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [1.0.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.6.0...1.0.0)
 
 - [e1b51f8d](https://github.com/algolia/api-clients-automation/commit/e1b51f8d) feat(dart): promote to stable [BREAKING CHANGE] ([#2152](https://github.com/algolia/api-clients-automation/pull/2152)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.0.0...1.1.0)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [1.0.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.6.0...1.0.0)
 
 - [e1b51f8d](https://github.com/algolia/api-clients-automation/commit/e1b51f8d) feat(dart): promote to stable [BREAKING CHANGE] ([#2152](https://github.com/algolia/api-clients-automation/pull/2152)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.0.0...1.1.0)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [1.0.0](https://github.com/algolia/algoliasearch-client-dart/compare/0.6.0...1.0.0)
 
 - [e1b51f8d](https://github.com/algolia/api-clients-automation/commit/e1b51f8d) feat(dart): promote to stable [BREAKING CHANGE] ([#2152](https://github.com/algolia/api-clients-automation/pull/2152)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0-alpha.34](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.33...4.0.0-alpha.34)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [daa9867cf](https://github.com/algolia/api-clients-automation/commit/daa9867cf) fix(go): fix the spec and update the base model template ([#2145](https://github.com/algolia/api-clients-automation/pull/2145)) by [@Fluf22](https://github.com/Fluf22/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [4.0.0-alpha.33](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.32...4.0.0-alpha.33)
 
 - [d25921cb](https://github.com/algolia/api-clients-automation/commit/d25921cb) fix(specs): Change trigger input for task update ([#2147](https://github.com/algolia/api-clients-automation/pull/2147)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-beta.11](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.10...4.0.0-beta.11)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [4.0.0-beta.10](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.9...4.0.0-beta.10)
 
 - [c3a9aceb](https://github.com/algolia/api-clients-automation/commit/c3a9aceb) feat(java): add search helpers `searchForHits` and `searchForFacets` ([#2150](https://github.com/algolia/api-clients-automation/pull/2150)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.0.0-alpha.91](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.90...5.0.0-alpha.91)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [6fa5a402e](https://github.com/algolia/api-clients-automation/commit/6fa5a402e) fix(javascript): algoliaseach bundling ([#2185](https://github.com/algolia/api-clients-automation/pull/2185)) by [@millotp](https://github.com/millotp/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [5.0.0-alpha.90](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.89...5.0.0-alpha.90)
 
 - [d25921cb](https://github.com/algolia/api-clients-automation/commit/d25921cb) fix(specs): Change trigger input for task update ([#2147](https://github.com/algolia/api-clients-automation/pull/2147)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.88",
-    "@algolia/client-analytics": "5.0.0-alpha.88",
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/client-personalization": "5.0.0-alpha.88",
-    "@algolia/client-search": "5.0.0-alpha.88",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-abtesting": "5.0.0-alpha.89",
+    "@algolia/client-analytics": "5.0.0-alpha.89",
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/client-personalization": "5.0.0-alpha.89",
+    "@algolia/client-search": "5.0.0-alpha.89",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.89",
+  "version": "5.0.0-alpha.90",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.62",
+  "version": "1.0.0-alpha.63",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.16",
+  "version": "1.0.0-alpha.17",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.88",
+  "version": "5.0.0-alpha.89",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.89",
-    "@algolia/requester-node-http": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.90",
+    "@algolia/requester-node-http": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.89",
+  "version": "5.0.0-alpha.90",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.89",
+  "version": "5.0.0-alpha.90",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.89",
+  "version": "5.0.0-alpha.90",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.89"
+    "@algolia/client-common": "5.0.0-alpha.90"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.0.0-beta.4](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.3...3.0.0-beta.4)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [3.0.0-beta.3](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.2...3.0.0-beta.3)
 
 - [928057e3](https://github.com/algolia/api-clients-automation/commit/928057e3) feat(kotlin): add search helpers `searchForHits` and `searchForFacets` ([#2149](https://github.com/algolia/api-clients-automation/pull/2149)) by [@aallam](https://github.com/aallam/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.85](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.84...4.0.0-alpha.85)
+
+- [ebc2a0c4d](https://github.com/algolia/api-clients-automation/commit/ebc2a0c4d) chore(specs): remove unused spec file ([#2186](https://github.com/algolia/api-clients-automation/pull/2186)) by [@shortcuts](https://github.com/shortcuts/)
+- [517f9cb72](https://github.com/algolia/api-clients-automation/commit/517f9cb72) revert(specs): insights identify ([#2182](https://github.com/algolia/api-clients-automation/pull/2182)) by [@aallam](https://github.com/aallam/)
+- [fa326a50e](https://github.com/algolia/api-clients-automation/commit/fa326a50e) feat(specs): add `authenticatedUserToken` and `Identify` to insights ([#2151](https://github.com/algolia/api-clients-automation/pull/2151)) by [@aallam](https://github.com/aallam/)
+
 ## [4.0.0-alpha.84](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.83...4.0.0-alpha.84)
 
 - [d25921cb](https://github.com/algolia/api-clients-automation/commit/d25921cb) fix(specs): Change trigger input for task update ([#2147](https://github.com/algolia/api-clients-automation/pull/2147)) by [@damcou](https://github.com/damcou/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.10",
+    "packageVersion": "4.0.0-beta.11",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.90",
+    "packageVersion": "5.0.0-alpha.91",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.84",
+    "packageVersion": "4.0.0-alpha.85",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.33",
+    "packageVersion": "4.0.0-alpha.34",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -51,7 +51,7 @@
   "kotlin": {
     "folder": "clients/algoliasearch-client-kotlin",
     "gitRepoId": "algoliasearch-client-kotlin",
-    "packageVersion": "3.0.0-beta.3",
+    "packageVersion": "3.0.0-beta.4",
     "modelFolder": "client/src/commonMain/kotlin/com/algolia/client/model",
     "apiFolder": "client/src/commonMain/kotlin/com/algolia/client/api",
     "customGenerator": "algolia-kotlin",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "1.0.0",
+    "packageVersion": "1.1.0",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.90 -> **`prerelease` _(e.g. 5.0.0-alpha.91)_**
- java: 4.0.0-beta.10 -> **`prerelease` _(e.g. 4.0.0-beta.11)_**
- php: 4.0.0-alpha.84 -> **`prerelease` _(e.g. 4.0.0-alpha.85)_**
- go: 4.0.0-alpha.33 -> **`prerelease` _(e.g. 4.0.0-alpha.34)_**
- kotlin: 3.0.0-beta.3 -> **`prerelease` _(e.g. 3.0.0-beta.4)_**
- dart: 1.0.0 -> **`minor` _(e.g. 1.1.0)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2023-10-30 (#2187)
- chore(scripts): upgrade node and yarn (#2184)
- refactor(generators): update openapi generator to v7 (#2115)
- chore(deps): dependencies 2023-10-23 (#2154)
</details>