### PR TITLE
chore: prepare release 2023-11-09

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 1.2.0
+version: 1.2.1
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.36](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.35...4.0.0-alpha.36)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.35](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.34...4.0.0-alpha.35)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-beta.13](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.12...4.0.0-beta.13)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-beta.12](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.11...4.0.0-beta.12)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.93](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.92...5.0.0-alpha.93)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.92](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.91...5.0.0-alpha.92)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.90",
-    "@algolia/client-analytics": "5.0.0-alpha.90",
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/client-personalization": "5.0.0-alpha.90",
-    "@algolia/client-search": "5.0.0-alpha.90",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-abtesting": "5.0.0-alpha.91",
+    "@algolia/client-analytics": "5.0.0-alpha.91",
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/client-personalization": "5.0.0-alpha.91",
+    "@algolia/client-search": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.64",
+  "version": "1.0.0-alpha.65",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.18",
+  "version": "1.0.0-alpha.19",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.90",
+  "version": "5.0.0-alpha.91",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
-    "@algolia/requester-node-http": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
+    "@algolia/requester-node-http": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.91"
+    "@algolia/client-common": "5.0.0-alpha.92"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.0-beta.6](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.5...3.0.0-beta.6)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [3.0.0-beta.5](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.4...3.0.0-beta.5)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.87](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.86...4.0.0-alpha.87)
+
+- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.86](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.85...4.0.0-alpha.86)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.12",
+    "packageVersion": "4.0.0-beta.13",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.92",
+    "packageVersion": "5.0.0-alpha.93",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.86",
+    "packageVersion": "4.0.0-alpha.87",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.35",
+    "packageVersion": "4.0.0-alpha.36",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -51,7 +51,7 @@
   "kotlin": {
     "folder": "clients/algoliasearch-client-kotlin",
     "gitRepoId": "algoliasearch-client-kotlin",
-    "packageVersion": "3.0.0-beta.5",
+    "packageVersion": "3.0.0-beta.6",
     "modelFolder": "client/src/commonMain/kotlin/com/algolia/client/model",
     "apiFolder": "client/src/commonMain/kotlin/com/algolia/client/api",
     "customGenerator": "algolia-kotlin",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "1.2.0",
+    "packageVersion": "1.2.1",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.92 -> **`prerelease` _(e.g. 5.0.0-alpha.93)_**
- java: 4.0.0-beta.12 -> **`prerelease` _(e.g. 4.0.0-beta.13)_**
- php: 4.0.0-alpha.86 -> **`prerelease` _(e.g. 4.0.0-alpha.87)_**
- go: 4.0.0-alpha.35 -> **`prerelease` _(e.g. 4.0.0-alpha.36)_**
- kotlin: 3.0.0-beta.5 -> **`prerelease` _(e.g. 3.0.0-beta.6)_**
- dart: 1.2.0 -> **`patch` _(e.g. 1.2.1)_**

### Skipped Commits

_(None)_