### PR TITLE
fix(scripts): release with full hours

### DIFF
--- a/scripts/release/common.ts
+++ b/scripts/release/common.ts
@@ -8,7 +8,7 @@ export function getLastReleasedTag(): Promise<string> {
 }
 
 export function getNewReleasedTag(): string {
-  const now = new Date().toISOString().split('T')[0];
+  const now = new Date().toISOString();
 
   return `${config.releasedTag}-${now}`;
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

we can't release many times a day, see https://github.com/algolia/api-clients-automation/actions/runs/6811827099/job/18523360577 because of the tag pattern https://github.com/algolia/api-clients-automation/tags

let's go full date since those release tags are just used for internal purposes, it's fine