### PR TITLE
chore: revert failed releases

### DIFF
--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.3.0)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.3.0)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.3.0)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.3.0)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [1.3.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.3.0)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,13 +1,3 @@
-## [4.0.0-alpha.37](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.36...4.0.0-alpha.37)
-
-- [80a6f2bca](https://github.com/algolia/api-clients-automation/commit/80a6f2bca) chore(go): update go docs ([#2200](https://github.com/algolia/api-clients-automation/pull/2200)) by [@Fluf22](https://github.com/Fluf22/)
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [4.0.0-alpha.36](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.35...4.0.0-alpha.36)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [4.0.0-alpha.35](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.34...4.0.0-alpha.35)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [4.0.0-beta.14](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.13...4.0.0-beta.14)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [4.0.0-beta.13](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.12...4.0.0-beta.13)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [4.0.0-beta.12](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.11...4.0.0-beta.12)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [5.0.0-alpha.94](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.93...5.0.0-alpha.94)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [5.0.0-alpha.93](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.92...5.0.0-alpha.93)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [5.0.0-alpha.92](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.91...5.0.0-alpha.92)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.92",
-    "@algolia/client-analytics": "5.0.0-alpha.92",
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/client-personalization": "5.0.0-alpha.92",
-    "@algolia/client-search": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-abtesting": "5.0.0-alpha.90",
+    "@algolia/client-analytics": "5.0.0-alpha.90",
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/client-personalization": "5.0.0-alpha.90",
+    "@algolia/client-search": "5.0.0-alpha.90",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.91",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.66",
+  "version": "1.0.0-alpha.64",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.18",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.90",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.91",
+    "@algolia/requester-node-http": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@types/node": "20.8.10",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.91",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.91",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.91",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.91"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.2",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [3.0.0-beta.7](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.6...3.0.0-beta.7)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [3.0.0-beta.6](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.5...3.0.0-beta.6)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [3.0.0-beta.5](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.4...3.0.0-beta.5)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,12 +1,3 @@
-## [4.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.87...4.0.0-alpha.88)
-
-- [c2e9fb52c](https://github.com/algolia/api-clients-automation/commit/c2e9fb52c) feat(specs): add `startDate` and `endDate` query parameter to list events ([#2229](https://github.com/algolia/api-clients-automation/pull/2229)) by [@shortcuts](https://github.com/shortcuts/)
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
-## [4.0.0-alpha.87](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.86...4.0.0-alpha.87)
-
-- [472dc87c4](https://github.com/algolia/api-clients-automation/commit/472dc87c4) fix(specs): require `window` in list runs ([#2226](https://github.com/algolia/api-clients-automation/pull/2226)) by [@shortcuts](https://github.com/shortcuts/)
-
 ## [4.0.0-alpha.86](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.85...4.0.0-alpha.86)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.14",
+    "packageVersion": "4.0.0-beta.12",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.94",
+    "packageVersion": "5.0.0-alpha.92",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.88",
+    "packageVersion": "4.0.0-alpha.86",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.37",
+    "packageVersion": "4.0.0-alpha.35",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -51,7 +51,7 @@
   "kotlin": {
     "folder": "clients/algoliasearch-client-kotlin",
     "gitRepoId": "algoliasearch-client-kotlin",
-    "packageVersion": "3.0.0-beta.7",
+    "packageVersion": "3.0.0-beta.5",
     "modelFolder": "client/src/commonMain/kotlin/com/algolia/client/model",
     "apiFolder": "client/src/commonMain/kotlin/com/algolia/client/api",
     "customGenerator": "algolia-kotlin",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "1.3.0",
+    "packageVersion": "1.2.0",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1646

### Changes included:

this PR reverts the two failed releases, the last valid ones was https://github.com/algolia/api-clients-automation/releases/tag/released-2023-11-09, anything after that hasn't be published