### PR TITLE
fix(go): check for NPE

### DIFF
--- a/templates/go/api.mustache
+++ b/templates/go/api.mustache
@@ -418,6 +418,10 @@ func (c *APIClient) WaitForTaskWithContext(
       return c.GetTaskWithContext(ctx, c.NewApiGetTaskRequest(indexName, taskID), opts...)
     },
     func(response *GetTaskResponse, err error) bool {
+      if err != nil || response == nil {
+        return false
+      }
+
       return response.Status == TASKSTATUS_PUBLISHED
     },
     maxRetries,


### PR DESCRIPTION
## 🧭 What and Why

Discovered during the hackathon, the response from algolia can be null if there is an error.