### PR TITLE
chore: prepare release 2023-11-29

### DIFF
--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.37](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.36...4.0.0-alpha.37)
+
+- [2ba2d6bf9](https://github.com/algolia/api-clients-automation/commit/2ba2d6bf9) fix(go): check for NPE ([#2307](https://github.com/algolia/api-clients-automation/pull/2307)) by [@millotp](https://github.com/millotp/)
+
 ## [4.0.0-alpha.36](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.35...4.0.0-alpha.36)
 
 - [5a7a8aeb4](https://github.com/algolia/api-clients-automation/commit/5a7a8aeb4) chore(specs): publish docs specs ([#2255](https://github.com/algolia/api-clients-automation/pull/2255)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [4.0.0-alpha.1](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0-alpha.0...4.0.0-alpha.1)
+
+- [a46b959fe](https://github.com/algolia/api-clients-automation/commit/a46b959fe) fix(python): template cleanup and playgrounds ([#2286](https://github.com/algolia/api-clients-automation/pull/2286)) by [@shortcuts](https://github.com/shortcuts/)
+- [e815b9721](https://github.com/algolia/api-clients-automation/commit/e815b9721) feat(python): initial setup for new API client ([#2283](https://github.com/algolia/api-clients-automation/pull/2283)) by [@shortcuts](https://github.com/shortcuts/)
+

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.36",
+    "packageVersion": "4.0.0-alpha.37",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -75,7 +75,7 @@
   "python": {
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0-alpha.0",
+    "packageVersion": "4.0.0-alpha.1",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~javascript: 5.0.0-alpha.93 (no commit)~
- ~java: 4.0.0-beta.12 (no commit)~
- ~php: 4.0.0-alpha.87 (no commit)~
- go: 4.0.0-alpha.36 -> **`prerelease` _(e.g. 4.0.0-alpha.37)_**
- ~kotlin: 3.0.0-beta.6 (no commit)~
- ~dart: 1.2.0 (no commit)~
- python: 4.0.0-alpha.0 -> **`prerelease` _(e.g. 4.0.0-alpha.1)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: next branch generation tutorial (#2287)
- docs: use the correct client version (#2282)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): dependencies 2023-11-27 (#2288)
- chore(deps): dependencies 2023-11-20 (#2266)
</details>