### PR TITLE
chore: loose cache key

### DIFF
--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -54,12 +54,7 @@ async function createClientMatrix(baseBranch: string): Promise<void> {
 
     // if this language is not yet in the matrix, we initialize it with the client-specific files
     if (!(language in matrix)) {
-      const cacheToCompute: string[] = [
-        'tests/CTS',
-        `templates/${language}`,
-        'generators/src',
-        getVersionFileForLanguage(language),
-      ];
+      const cacheToCompute: string[] = [getVersionFileForLanguage(language)];
 
       for (const [, dependency] of Object.entries(COMMON_DEPENDENCIES)) {
         cacheToCompute.push(...dependency);

--- a/scripts/ci/githubActions/setRunVariables.ts
+++ b/scripts/ci/githubActions/setRunVariables.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import * as core from '@actions/core';
 
-import { CLIENTS_JS_UTILS, LANGUAGES, capitalize } from '../../common.js';
+import { CLIENTS_JS_UTILS, LANGUAGES } from '../../common.js';
 import { getLanguageFolder } from '../../config.js';
 import type { Language } from '../../types.js';
 
@@ -18,6 +18,10 @@ export const COMMON_DEPENDENCIES = {
     'config/openapitools.json',
     'config/clients.config.json',
     'config/release.config.json',
+    'generators',
+    'templates',
+    'tests/CTS',
+    '.nvmrc',
   ],
   COMMON_SPECS_CHANGED: ['specs/common'],
 };
@@ -53,24 +57,18 @@ export const DEPENDENCIES = LANGUAGES.reduce(
   (finalDependencies, lang) => {
     const key = `${lang.toUpperCase()}_CLIENT_CHANGED`;
     const langFolder = getLanguageFolder(lang);
-    const langGenerator = capitalize(lang);
 
-    return {
-      ...finalDependencies,
-      [key]: [
-        'generators/src/main/java/com/algolia/codegen/*/**',
-        'tests/CTS',
-        '.nvmrc',
-        ':!**node_modules',
-        // language related files
-        langFolder,
-        `templates/${lang}`,
-        `generators/src/main/java/com/algolia/codegen/Algolia${langGenerator}Generator.java`,
-        getVersionFileForLanguage(lang),
-        `:!${langFolder}/.github`,
-        `:!${langFolder}/README.md`,
-      ],
-    };
+    // eslint-disable-next-line no-param-reassign
+    finalDependencies[key] = [
+      ':!**node_modules',
+      // language related files
+      langFolder,
+      getVersionFileForLanguage(lang),
+      `:!${langFolder}/.github`,
+      `:!${langFolder}/README.md`,
+    ];
+
+    return finalDependencies;
   },
   {
     ...COMMON_DEPENDENCIES,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

this PR proposes to loose the cache key computing by providing more "common" dependencies to the jobs to run. In https://github.com/algolia/api-clients-automation/pull/2369 I had to bump the cache >3 times, which can be a blocker for new contributors and also slow us rather than speed up our CI builds since we need to run it many times.