### PR TITLE
fix(python): common response deserializer

### DIFF
--- a/clients/algoliasearch-client-python/algoliasearch/http/api_response.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/api_response.py
@@ -14,13 +14,6 @@ class ApiResponse(Generic[T]):
     """
 
     PRIMITIVE_TYPES = (float, bool, bytes, str, int)
-    NATIVE_TYPES_MAPPING = {
-        "int": int,
-        "float": float,
-        "str": str,
-        "bool": bool,
-        "object": object,
-    }
 
     def __init__(
         self,
@@ -67,9 +60,6 @@ class ApiResponse(Generic[T]):
                 return {
                     k: self.__deserialize(v, sub_kls) for k, v in self.raw_data.items()
                 }
-
-            if klass in self.NATIVE_TYPES_MAPPING:
-                klass = self.NATIVE_TYPES_MAPPING[klass]
 
         if klass in self.PRIMITIVE_TYPES:
             try:

--- a/clients/algoliasearch-client-python/algoliasearch/http/api_response.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/api_response.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from re import match
 from typing import Any, Dict, Generic, Optional, TypeVar
 
 T = TypeVar("T")
@@ -11,6 +12,15 @@ class ApiResponse(Generic[T]):
     """
     API response object
     """
+
+    PRIMITIVE_TYPES = (float, bool, bytes, str, int)
+    NATIVE_TYPES_MAPPING = {
+        "int": int,
+        "float": float,
+        "str": str,
+        "bool": bool,
+        "object": object,
+    }
 
     def __init__(
         self,
@@ -33,3 +43,42 @@ class ApiResponse(Generic[T]):
         self.is_timed_out_error = is_timed_out_error
         self.is_network_error = is_network_error
         self.model_config = model_config
+
+    def deserialize(self, klass: any = None) -> T:
+        """Deserializes dict, list, str into an object.
+
+        :param data: dict, list or str.
+        :param klass: class literal, or string of class name.
+
+        :return: object.
+        """
+        if self.raw_data is None:
+            return None
+
+        if isinstance(klass, str):
+            if klass.startswith("List["):
+                sub_kls = match(r"List\[(.*)]", klass).group(1)
+                return [
+                    self.__deserialize(sub_data, sub_kls) for sub_data in self.raw_data
+                ]
+
+            if klass.startswith("Dict["):
+                sub_kls = match(r"Dict\[([^,]*), (.*)]", klass).group(2)
+                return {
+                    k: self.__deserialize(v, sub_kls) for k, v in self.raw_data.items()
+                }
+
+            if klass in self.NATIVE_TYPES_MAPPING:
+                klass = self.NATIVE_TYPES_MAPPING[klass]
+
+        if klass in self.PRIMITIVE_TYPES:
+            try:
+                return klass(self.raw_data)
+            except UnicodeEncodeError:
+                return str(self.raw_data)
+            except TypeError:
+                return self.raw_data
+        elif klass == object:
+            return self.raw_data
+        else:
+            return klass.from_json(self.raw_data)

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -84,9 +84,7 @@ class {{classname}}:
             data=_param[0],
             request_options=_param[1],
             {{#vendorExtensions}}
-              {{#x-use-read-transporter}}
-            use_read_transporter=True,
-              {{/x-use-read-transporter}}
+            use_read_transporter={{#x-use-read-transporter}}True{{/x-use-read-transporter}}{{^x-use-read-transporter}}False{{/x-use-read-transporter}},
             {{/vendorExtensions}}
         )
 

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -11,15 +11,6 @@ except ImportError:
 
 {{#operations}}
 class {{classname}}:
-    PRIMITIVE_TYPES = (float, bool, bytes, str, int)
-    NATIVE_TYPES_MAPPING = {
-        "int": int,
-        "float": float,
-        "str": str,
-        "bool": bool,
-        "object": object,
-    }
-
     def app_id(self) -> str:
         return self._config.app_id
 
@@ -37,42 +28,6 @@ class {{classname}}:
 
     async def close(self) -> None:
         return await self._transporter.close()
-
-    def __deserialize(self, data: Optional[dict], klass: any = None) -> dict:
-        """Deserializes dict, list, str into an object.
-
-        :param data: dict, list or str.
-        :param klass: class literal, or string of class name.
-
-        :return: object.
-        """
-        if data is None:
-            return None
-
-        if isinstance(klass, str):
-            if klass.startswith("List["):
-                sub_kls = match(r"List\[(.*)]", klass).group(1)
-                return [self.__deserialize(sub_data, sub_kls) for sub_data in data]
-
-            if klass.startswith("Dict["):
-                sub_kls = match(r"Dict\[([^,]*), (.*)]", klass).group(2)
-                return {k: self.__deserialize(v, sub_kls) for k, v in data.items()}
-
-            if klass in self.NATIVE_TYPES_MAPPING:
-                klass = self.NATIVE_TYPES_MAPPING[klass]
-
-        if klass in self.PRIMITIVE_TYPES:
-            try:
-                return klass(data)
-            except UnicodeEncodeError:
-                return str(data)
-            except TypeError:
-                return data
-        elif klass == object:
-            return data
-        else:
-            return klass.from_json(data)
-
     {{#operation}}
 
     async def {{operationId}}_with_http_info{{>partial_api_args}} -> ApiResponse[str]:
@@ -159,6 +114,6 @@ class {{classname}}:
 
         response = await self.{{operationId}}_with_http_info({{#allParams}}{{paramName}},{{/allParams}}request_options)
 
-        return {{^returnType}}None{{/returnType}}{{#returnType}}self.__deserialize(response.raw_data, {{{returnType}}}){{/returnType}}
+        return {{^returnType}}None{{/returnType}}{{#returnType}}response.deserialize({{{returnType}}}){{/returnType}}
 {{/operation}}
 {{/operations}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Since the deserializing logic is fully hardcoded it can live in the API response class directly for easier usage and iterations

also fix missing parameter when not using the read transporter