### PR TITLE
chore: renovate for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
     "regex",
     "pub",
     "gomod",
-    "poetry",
     "pip_requirements",
     "gradle-wrapper",
     "bundler"
@@ -54,7 +53,7 @@
     {
       "description": "Update poetry.toml mustache devDeps",
       "fileMatch": [
-        "poetry.mustache"
+        "pyproject.mustache"
       ],
       "matchStrings": [
         "(?<depName>.*?)=\\s*\"(?<currentValue>.*?)\""


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

just realized it did not worked because that's not the correct filename, also remove `poetry` from the automated managers because we only want to update the templates