### PR TITLE
feat(generators): differentiate requests/clients test files

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
@@ -35,6 +35,11 @@ public class TestsClient extends TestsGenerator {
     if (!available()) {
       return;
     }
+
+    if (this.language.equals("python")) {
+      extension = "_client" + extension;
+    }
+
     supportingFiles.add(
       new SupportingFile("client/suite.mustache", outputFolder + "/client", Helpers.createClientName(client, language) + extension)
     );

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -35,6 +35,11 @@ public class TestsRequest extends TestsGenerator {
     if (!available()) {
       return;
     }
+
+    if (this.language.equals("python")) {
+      extension = "_requests" + extension;
+    }
+
     supportingFiles.add(
       new SupportingFile(
         "requests/requests.mustache",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

test file names should differ for Python otherwise the runner won't start the tests due to ambiguity, I only applied this to python but wdyt of adding such suffix to every files just for simplicity?