### PR TITLE
chore(cts): add index to default test name

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -74,7 +74,7 @@ public class TestsRequest extends TestsGenerator {
         Map<String, Object> test = new HashMap<>();
         Request req = op[i];
         test.put("method", operationId);
-        test.put("testName", req.testName == null ? operationId : req.testName);
+        test.put("testName", req.testName == null ? operationId + i : req.testName);
         test.put("testIndex", i);
 
         try {

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -35,7 +35,7 @@ async function runCtsOne(language: string): Promise<void> {
       await run('(cd tests/output/dart && dart test)');
       break;
     case 'python':
-      await run('poetry lock && poetry install --sync && poetry run pytest', {
+      await run('poetry lock --no-update && poetry install --sync && poetry run pytest', {
         cwd: 'tests/output/python',
       });
       break;

--- a/scripts/formatter.ts
+++ b/scripts/formatter.ts
@@ -38,7 +38,7 @@ export async function formatter(language: string, folder: string): Promise<void>
       }
       break;
     case 'python':
-      cmd = `(cd ${folder} && poetry lock && poetry install --sync && pip freeze > requirements.txt && poetry run autopep8 -r --in-place --aggressive . && poetry run autoflake -r --remove-unused-variables --remove-all-unused-imports --in-place . && poetry run isort . && poetry run black . && poetry run flake8 --ignore=E501,W503 .)`;
+      cmd = `(cd ${folder} && poetry lock --no-update && poetry install --sync && pip freeze > requirements.txt && poetry run autopep8 -r --in-place --aggressive . && poetry run autoflake -r --remove-unused-variables --remove-all-unused-imports --in-place . && poetry run isort . && poetry run black . && poetry run flake8 --ignore=E501,W503 .)`;
       break;
     case 'ruby':
       cmd = `cd ${folder} && bundle install && bundle exec rubocop -a --fail-level W`;

--- a/tests/output/python/poetry.lock
+++ b/tests/output/python/poetry.lock
@@ -111,7 +111,7 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "algoliasearch"
-version = "4.0.0-alpha.1"
+version = "4.0.0a1"
 description = "A fully-featured and blazing-fast Python API client to interact with Algolia."
 optional = false
 python-versions = "^3.8.1"


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

for simplicity, we can append the test index to the operationID when no test name are provided, this avoid tests having the same name and/or forcing the contributor to provide a testName (description)

discovered in https://github.com/algolia/api-clients-automation/pull/2411 and https://github.com/algolia/api-clients-automation/pull/2401