### PR TITLE
chore(cli): add apic alias to bypass yarn scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docker:setup": "yarn docker:clean && yarn docker:build && yarn docker:mount",
     "fix:json": "eslint --ext=json . --fix",
     "github-actions:lint": "eslint --ext=yml .github/",
-    "postinstall": "husky install && yarn workspace eslint-plugin-automation-custom build",
+    "postinstall": "husky install && yarn workspace eslint-plugin-automation-custom build && yarn workspace scripts tsc",
     "playground:browser": "yarn workspace javascript-browser-playground start",
     "release": "yarn workspace scripts createReleasePR",
     "scripts:lint": "yarn workspace scripts lint",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This scripts installs the apic cli shortcut, instead of doing `docker docker ...` which takes a long time to start
+# You can install this by running `source scripts/install.sh` or by adding this to your .bashrc/.zshrc:
+# [[ -s "$HOME/<path to api-clients-automation>/scripts/install.sh" ]] && source "$HOME/<path to api-clients-automation>/scripts/install.sh"
+
+export apic() {
+  docker exec -it api-clients-automation bash -lc "cd scripts && NODE_NO_WARNINGS=1 node dist/scripts/cli/index.js $*";
+}
+


### PR DESCRIPTION
## 🧭 What and Why

Add a bash alias for `yarn docker` named `apic`, you have to install it manually because we can't run bash built in like `source` in yarn script https://github.com/yarnpkg/berry/issues/2088.

The time goes from ~5s to launch the CLI to instantaneous !

Note: this runs the js directly, if you change the cli code you need to recompile with `tsc`, with I added to `yarn install` directly.
