### PR TITLE
fix(ruby): support additionalProperties: true

### DIFF
--- a/templates/ruby/base_object.mustache
+++ b/templates/ruby/base_object.mustache
@@ -21,10 +21,10 @@
           transformed_hash[key.to_s] = _deserialize(type, attributes[attribute_map[key]])
         end
       end
-      {{#vendorExtensions.x-is-generic}}
+      {{#getAdditionalPropertiesIsAnyType}}
 
       transformed_hash.merge!(attributes.reject { |k, _| attribute_map.key?(k.to_sym) })
-      {{/vendorExtensions.x-is-generic}}
+      {{/getAdditionalPropertiesIsAnyType}}
       new(transformed_hash)
     end
 
@@ -96,13 +96,13 @@
 
         hash[param] = _to_hash(value)
       end
-      {{#vendorExtensions.x-is-generic}}
+      {{#getAdditionalPropertiesIsAnyType}}
 
       # also add attributes from additional_properties to hash
       self.additional_properties&.each_pair do |k, v|
         hash[k.to_sym] = _to_hash(v)
       end
-      {{/vendorExtensions.x-is-generic}}
+      {{/getAdditionalPropertiesIsAnyType}}
       hash
     end
 

--- a/templates/ruby/partial_model_generic.mustache
+++ b/templates/ruby/partial_model_generic.mustache
@@ -9,10 +9,10 @@
     attr_accessor :{{{name}}}
 
   {{/vars}}
-  {{#vendorExtensions.x-is-generic}}
+  {{#getAdditionalPropertiesIsAnyType}}
     attr_accessor :additional_properties
 
-  {{/vendorExtensions.x-is-generic}}
+  {{/getAdditionalPropertiesIsAnyType}}
 {{#hasEnums}}
     class EnumAttributeValidator
       attr_reader :datatype
@@ -118,7 +118,7 @@
         raise ArgumentError, "The input argument (attributes) must be a hash in `{{{moduleName}}}::{{{classname}}}` initialize method"
       end
 
-      {{^vendorExtensions.x-is-generic}}
+      {{^getAdditionalPropertiesIsAnyType}}
       # check to see if the attribute exists and convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h|
         if (!self.class.attribute_map.key?(k.to_sym))
@@ -127,7 +127,7 @@
         h[k.to_sym] = v
       }
 
-      {{/vendorExtensions.x-is-generic}}
+      {{/getAdditionalPropertiesIsAnyType}}
       {{#parent}}
       # call parent's initialize
       super(attributes)
@@ -154,12 +154,12 @@
       end
 
       {{/vars}}
-      {{#vendorExtensions.x-is-generic}}
+      {{#getAdditionalPropertiesIsAnyType}}
 
       # add extra attribute to additional_properties
       self.additional_properties ||= {}
       self.additional_properties.merge!(attributes.reject { |k, _| self.class.attribute_map.key?(k.to_sym) })
-      {{/vendorExtensions.x-is-generic}}
+      {{/getAdditionalPropertiesIsAnyType}}
     end
 
     {{#vars}}


### PR DESCRIPTION
## 🧭 What and Why

Some models can have arbitrary keys, my previous solution only worked for `x-is-generic`, but this works for everything.