### PR TITLE
chore: prepare release 2023-12-28

### DIFF
--- a/clients/algoliasearch-client-csharp/CHANGELOG.md
+++ b/clients/algoliasearch-client-csharp/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [7.0.0-alpha.1](https://github.com/algolia/algoliasearch-client-csharp/compare/7.0.0-alpha.0...7.0.0-alpha.1)
+
+- [30014c7c6](https://github.com/algolia/api-clients-automation/commit/30014c7c6) refactor(csharp): remove useless code ([#2377](https://github.com/algolia/api-clients-automation/pull/2377)) by [@morganleroi](https://github.com/morganleroi/)
+- [167bcd243](https://github.com/algolia/api-clients-automation/commit/167bcd243) feat(csharp): add http transporter, serializer and configuration ([#2368](https://github.com/algolia/api-clients-automation/pull/2368)) by [@morganleroi](https://github.com/morganleroi/)
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [ac392f578](https://github.com/algolia/api-clients-automation/commit/ac392f578) fix(csharp): hardcode dotnet project uuid ([#2338](https://github.com/algolia/api-clients-automation/pull/2338)) by [@morganleroi](https://github.com/morganleroi/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+- [1e9d8ed9a](https://github.com/algolia/api-clients-automation/commit/1e9d8ed9a) feat(csharp): initial setup for new API client ([#2284](https://github.com/algolia/api-clients-automation/pull/2284)) by [@morganleroi](https://github.com/morganleroi/)
+

--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 1.2.0
+version: 1.2.1
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.0](https://github.com/algolia/algoliasearch-client-dart/compare/1.1.0...1.2.0)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.0.0-alpha.38](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.37...4.0.0-alpha.38)
+
+- [1bb2667a3](https://github.com/algolia/api-clients-automation/commit/1bb2667a3) chore(go): use golangci-lint ([#2437](https://github.com/algolia/api-clients-automation/pull/2437)) by [@millotp](https://github.com/millotp/)
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.37](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.36...4.0.0-alpha.37)
 
 - [2ba2d6bf9](https://github.com/algolia/api-clients-automation/commit/2ba2d6bf9) fix(go): check for NPE ([#2307](https://github.com/algolia/api-clients-automation/pull/2307)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-beta.13](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.12...4.0.0-beta.13)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-beta.12](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.11...4.0.0-beta.12)
 
 - [15b81fe64](https://github.com/algolia/api-clients-automation/commit/15b81fe64) feat(specs): add `window` parameter to observability responses ([#2223](https://github.com/algolia/api-clients-automation/pull/2223)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.0.0-alpha.94](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.93...5.0.0-alpha.94)
+
+- [ae80c666c](https://github.com/algolia/api-clients-automation/commit/ae80c666c) chore(javascript): remove some non needed props from generators ([#2412](https://github.com/algolia/api-clients-automation/pull/2412)) by [@shortcuts](https://github.com/shortcuts/)
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.93](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.92...5.0.0-alpha.93)
 
 - [5a7a8aeb4](https://github.com/algolia/api-clients-automation/commit/5a7a8aeb4) chore(specs): publish docs specs ([#2255](https://github.com/algolia/api-clients-automation/pull/2255)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.91",
-    "@algolia/client-analytics": "5.0.0-alpha.91",
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/client-personalization": "5.0.0-alpha.91",
-    "@algolia/client-search": "5.0.0-alpha.91",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-abtesting": "5.0.0-alpha.92",
+    "@algolia/client-analytics": "5.0.0-alpha.92",
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/client-personalization": "5.0.0-alpha.92",
+    "@algolia/client-search": "5.0.0-alpha.92",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.6",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.65",
+  "version": "1.0.0-alpha.66",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0-alpha.20",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.91",
+  "version": "5.0.0-alpha.92",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.92",
-    "@algolia/requester-node-http": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
+    "@algolia/requester-node-http": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@types/node": "20.10.5",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.92"
+    "@algolia/client-common": "5.0.0-alpha.93"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.6",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.0-beta.7](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.6...3.0.0-beta.7)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [3.0.0-beta.6](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.5...3.0.0-beta.6)
 
 - [5a7a8aeb4](https://github.com/algolia/api-clients-automation/commit/5a7a8aeb4) chore(specs): publish docs specs ([#2255](https://github.com/algolia/api-clients-automation/pull/2255)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.87...4.0.0-alpha.88)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.87](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.86...4.0.0-alpha.87)
 
 - [4f5c33108](https://github.com/algolia/api-clients-automation/commit/4f5c33108) feat(php): change PHP version for generated client ([#2263](https://github.com/algolia/api-clients-automation/pull/2263)) by [@damcou](https://github.com/damcou/)

--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [4.0.0a2](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a1...4.0.0a2)
+
+- [6641924aa](https://github.com/algolia/api-clients-automation/commit/6641924aa) fix(python): less breaking changes ([#2442](https://github.com/algolia/api-clients-automation/pull/2442)) by [@shortcuts](https://github.com/shortcuts/)
+- [19ddcb18f](https://github.com/algolia/api-clients-automation/commit/19ddcb18f) chore(python): cleanup and variable names ([#2416](https://github.com/algolia/api-clients-automation/pull/2416)) by [@shortcuts](https://github.com/shortcuts/)
+- [cdd936ad1](https://github.com/algolia/api-clients-automation/commit/cdd936ad1) feat(python): add clients CTS ([#2411](https://github.com/algolia/api-clients-automation/pull/2411)) by [@shortcuts](https://github.com/shortcuts/)
+- [1c7c0351a](https://github.com/algolia/api-clients-automation/commit/1c7c0351a) feat(python): add release process ([#2372](https://github.com/algolia/api-clients-automation/pull/2372)) by [@shortcuts](https://github.com/shortcuts/)
+- [f2692988c](https://github.com/algolia/api-clients-automation/commit/f2692988c) chore(python): improve serializer definition ([#2402](https://github.com/algolia/api-clients-automation/pull/2402)) by [@shortcuts](https://github.com/shortcuts/)
+- [3aa772522](https://github.com/algolia/api-clients-automation/commit/3aa772522) feat(python): add CTS ([#2373](https://github.com/algolia/api-clients-automation/pull/2373)) by [@shortcuts](https://github.com/shortcuts/)
+- [6c4dcb21c](https://github.com/algolia/api-clients-automation/commit/6c4dcb21c) fix(python): common response deserializer ([#2375](https://github.com/algolia/api-clients-automation/pull/2375)) by [@shortcuts](https://github.com/shortcuts/)
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [387960048](https://github.com/algolia/api-clients-automation/commit/387960048) fix(python): path encoding and request options ([#2367](https://github.com/algolia/api-clients-automation/pull/2367)) by [@shortcuts](https://github.com/shortcuts/)
+- [a2edb056e](https://github.com/algolia/api-clients-automation/commit/a2edb056e) fix(python): deserializer and unused helpers ([#2309](https://github.com/algolia/api-clients-automation/pull/2309)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+- [f99007898](https://github.com/algolia/api-clients-automation/commit/f99007898) feat(python): add Algolia transporter, response deserializer and config setup ([#2306](https://github.com/algolia/api-clients-automation/pull/2306)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.1](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0-alpha.0...4.0.0-alpha.1)
 
 - [a46b959fe](https://github.com/algolia/api-clients-automation/commit/a46b959fe) fix(python): template cleanup and playgrounds ([#2286](https://github.com/algolia/api-clients-automation/pull/2286)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-ruby/CHANGELOG.md
+++ b/clients/algoliasearch-client-ruby/CHANGELOG.md
@@ -1,0 +1,18 @@
+## [3.0.0.alpha.1](https://github.com/algolia/algoliasearch-client-ruby/compare/3.0.0.alpha.0...3.0.0.alpha.1)
+
+- [9f4f17585](https://github.com/algolia/api-clients-automation/commit/9f4f17585) fix(ruby): support ruby alpha format ([#2447](https://github.com/algolia/api-clients-automation/pull/2447)) by [@millotp](https://github.com/millotp/)
+- [443c8909a](https://github.com/algolia/api-clients-automation/commit/443c8909a) chore(ruby): setup release ([#2446](https://github.com/algolia/api-clients-automation/pull/2446)) by [@millotp](https://github.com/millotp/)
+- [1281c2d10](https://github.com/algolia/api-clients-automation/commit/1281c2d10) feat(ruby): client tests ([#2445](https://github.com/algolia/api-clients-automation/pull/2445)) by [@millotp](https://github.com/millotp/)
+- [e0527a573](https://github.com/algolia/api-clients-automation/commit/e0527a573) feat(ruby): e2e CTS ([#2439](https://github.com/algolia/api-clients-automation/pull/2439)) by [@millotp](https://github.com/millotp/)
+- [48c33a77e](https://github.com/algolia/api-clients-automation/commit/48c33a77e) feat(ruby): add CTS ([#2401](https://github.com/algolia/api-clients-automation/pull/2401)) by [@millotp](https://github.com/millotp/)
+- [916789e10](https://github.com/algolia/api-clients-automation/commit/916789e10) fix(ruby): support additionalProperties: true ([#2418](https://github.com/algolia/api-clients-automation/pull/2418)) by [@millotp](https://github.com/millotp/)
+- [c0279405d](https://github.com/algolia/api-clients-automation/commit/c0279405d) fix(ruby): customize linter ([#2409](https://github.com/algolia/api-clients-automation/pull/2409)) by [@millotp](https://github.com/millotp/)
+- [77b7a8ca8](https://github.com/algolia/api-clients-automation/commit/77b7a8ca8) feat(ruby): make hit generic ([#2400](https://github.com/algolia/api-clients-automation/pull/2400)) by [@millotp](https://github.com/millotp/)
+- [1e7c50d2f](https://github.com/algolia/api-clients-automation/commit/1e7c50d2f) feat(ruby): retry strategy ([#2383](https://github.com/algolia/api-clients-automation/pull/2383)) by [@millotp](https://github.com/millotp/)
+- [614d56ae8](https://github.com/algolia/api-clients-automation/commit/614d56ae8) fix(ruby): make the playground work ([#2379](https://github.com/algolia/api-clients-automation/pull/2379)) by [@millotp](https://github.com/millotp/)
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+- [a8f2565a0](https://github.com/algolia/api-clients-automation/commit/a8f2565a0) fix(ruby): add libraries in the Dockerfile ([#2333](https://github.com/algolia/api-clients-automation/pull/2333)) by [@millotp](https://github.com/millotp/)
+- [b97259611](https://github.com/algolia/api-clients-automation/commit/b97259611) chore(ruby): fix renovate config ([#2314](https://github.com/algolia/api-clients-automation/pull/2314)) by [@shortcuts](https://github.com/shortcuts/)
+- [833b489d1](https://github.com/algolia/api-clients-automation/commit/833b489d1) feat(ruby): setup client ([#2311](https://github.com/algolia/api-clients-automation/pull/2311)) by [@millotp](https://github.com/millotp/)
+

--- a/clients/algoliasearch-client-scala/CHANGELOG.md
+++ b/clients/algoliasearch-client-scala/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [2.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-scala/compare/2.0.0-alpha.1...2.0.0-alpha.2)
+
+- [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)
+- [5e4b815ee](https://github.com/algolia/api-clients-automation/commit/5e4b815ee) feat(scala): add cts ([#2310](https://github.com/algolia/api-clients-automation/pull/2310)) by [@aallam](https://github.com/aallam/)
+- [205519c6f](https://github.com/algolia/api-clients-automation/commit/205519c6f) fix(specs): highlight result map definition ([#2312](https://github.com/algolia/api-clients-automation/pull/2312)) by [@shortcuts](https://github.com/shortcuts/)
+- [75d11fe12](https://github.com/algolia/api-clients-automation/commit/75d11fe12) feat(scala):  api client setup and gen ([#2222](https://github.com/algolia/api-clients-automation/pull/2222)) by [@aallam](https://github.com/aallam/)
+

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.12",
+    "packageVersion": "4.0.0-beta.13",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.93",
+    "packageVersion": "5.0.0-alpha.94",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.87",
+    "packageVersion": "4.0.0-alpha.88",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.37",
+    "packageVersion": "4.0.0-alpha.38",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -51,7 +51,7 @@
   "kotlin": {
     "folder": "clients/algoliasearch-client-kotlin",
     "gitRepoId": "algoliasearch-client-kotlin",
-    "packageVersion": "3.0.0-beta.6",
+    "packageVersion": "3.0.0-beta.7",
     "modelFolder": "client/src/commonMain/kotlin/com/algolia/client/model",
     "apiFolder": "client/src/commonMain/kotlin/com/algolia/client/api",
     "customGenerator": "algolia-kotlin",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "1.2.0",
+    "packageVersion": "1.2.1",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",
@@ -75,7 +75,7 @@
   "python": {
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0a1",
+    "packageVersion": "4.0.0a2",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",
@@ -87,7 +87,7 @@
   "ruby": {
     "folder": "clients/algoliasearch-client-ruby",
     "gitRepoId": "algoliasearch-client-ruby",
-    "packageVersion": "3.0.0.alpha.0",
+    "packageVersion": "3.0.0.alpha.1",
     "modelFolder": "lib/algolia/models",
     "apiFolder": "lib/algolia/api",
     "customGenerator": "algolia-ruby",
@@ -99,7 +99,7 @@
   "scala": {
     "folder": "clients/algoliasearch-client-scala",
     "gitRepoId": "algoliasearch-client-scala",
-    "packageVersion": "2.0.0-alpha.1",
+    "packageVersion": "2.0.0-alpha.2",
     "modelFolder": "src/main/scala/algoliasearch",
     "apiFolder": "src/main/scala/algoliasearch/api",
     "customGenerator": "algolia-scala",
@@ -111,7 +111,7 @@
   "csharp": {
     "folder": "clients/algoliasearch-client-csharp",
     "gitRepoId": "algoliasearch-client-csharp",
-    "packageVersion": "7.0.0-alpha.0",
+    "packageVersion": "7.0.0-alpha.1",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-csharp",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.93 -> **`prerelease` _(e.g. 5.0.0-alpha.94)_**
- java: 4.0.0-beta.12 -> **`prerelease` _(e.g. 4.0.0-beta.13)_**
- php: 4.0.0-alpha.87 -> **`prerelease` _(e.g. 4.0.0-alpha.88)_**
- go: 4.0.0-alpha.37 -> **`prerelease` _(e.g. 4.0.0-alpha.38)_**
- kotlin: 3.0.0-beta.6 -> **`prerelease` _(e.g. 3.0.0-beta.7)_**
- dart: 1.2.0 -> **`patch` _(e.g. 1.2.1)_**
- python: 4.0.0a1 -> **`minor` _(e.g. 4.0.0a2)_**
- ruby: 3.0.0.alpha.0 -> **`minor` _(e.g. 3.0.0.alpha.1)_**
- scala: 2.0.0-alpha.1 -> **`prerelease` _(e.g. 2.0.0-alpha.2)_**
- csharp: 7.0.0-alpha.0 -> **`prerelease` _(e.g. 7.0.0-alpha.1)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - docs: add client helpers and e2e in docs (#2443)
- chore: go deps dependabot (#2406)
- chore: correctly delete python on pregen (#2399)
- chore: renovate for Python (#2381)
- chore: renovate for Python (#2380)
- docs: return code for objects endpoint (#2374)
- chore: loose cache key (#2371)
- docs: update path for Java package (#2340)
- chore: add missing files to cache computing (#2335)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(deps): update openapi-generator to v7.2.0 (#2430)
- chore(cli): bash autocomplete for apic (#2444)
- chore(cts): partial assert on e2e (#2441)
- chore(deps): dependencies 2023-12-25 (#2419)
- chore(cts): remove `methods` folder (#2438)
- feat(cts): add e2e (#2417)
- chore(ci): convert to js actions (#800)
- chore(cli): add apic alias to bypass yarn scripts (#2415)
- chore(cts): add index to default test name (#2414)
- feat(scripts): support Alpha releases (#2407)
- chore(deps): dependencies 2023-12-21 (#2382)
- chore(deps): dependencies 2023-12-11 (#2341)
- chore(deps): lock file maintenance (#2315)
- chore(deps): dependencies 2023-12-04 (#2313)
</details>