### PR TITLE
chore: prepare release 2024-01-02

### DIFF
--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.0a3](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a2...4.0.0a3)
+
+- [271eb792c](https://github.com/algolia/api-clients-automation/commit/271eb792c) feat(python): add browse helpers ([#2452](https://github.com/algolia/api-clients-automation/pull/2452)) by [@shortcuts](https://github.com/shortcuts/)
+- [2dfbd502a](https://github.com/algolia/api-clients-automation/commit/2dfbd502a) feat(python): add wait helpers ([#2448](https://github.com/algolia/api-clients-automation/pull/2448)) by [@shortcuts](https://github.com/shortcuts/)
+- [5d360fe3e](https://github.com/algolia/api-clients-automation/commit/5d360fe3e) docs(python): add migration guides ([#2455](https://github.com/algolia/api-clients-automation/pull/2455)) by [@shortcuts](https://github.com/shortcuts/)
+- [cee15c7ec](https://github.com/algolia/api-clients-automation/commit/cee15c7ec) chore(python): code cleanup ([#2456](https://github.com/algolia/api-clients-automation/pull/2456)) by [@shortcuts](https://github.com/shortcuts/)
+- [8f4b4102a](https://github.com/algolia/api-clients-automation/commit/8f4b4102a) fix(python): model parsing ([#2454](https://github.com/algolia/api-clients-automation/pull/2454)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0a2](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a1...4.0.0a2)
 
 - [6641924aa](https://github.com/algolia/api-clients-automation/commit/6641924aa) fix(python): less breaking changes ([#2442](https://github.com/algolia/api-clients-automation/pull/2442)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-ruby/CHANGELOG.md
+++ b/clients/algoliasearch-client-ruby/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.0.0.alpha.1](https://github.com/algolia/algoliasearch-client-ruby/compare/3.0.0.alpha.0...3.0.0.alpha.1)
+## [3.0.0.alpha.1](https://github.com/algolia/algoliasearch-client-ruby/tree/3.0.0.alpha.1)
 
 - [9f4f17585](https://github.com/algolia/api-clients-automation/commit/9f4f17585) fix(ruby): support ruby alpha format ([#2447](https://github.com/algolia/api-clients-automation/pull/2447)) by [@millotp](https://github.com/millotp/)
 - [443c8909a](https://github.com/algolia/api-clients-automation/commit/443c8909a) chore(ruby): setup release ([#2446](https://github.com/algolia/api-clients-automation/pull/2446)) by [@millotp](https://github.com/millotp/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -75,7 +75,7 @@
   "python": {
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0a2",
+    "packageVersion": "4.0.0a3",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~javascript: 5.0.0-alpha.94 (no commit)~
- ~java: 4.0.0-beta.13 (no commit)~
- ~php: 4.0.0-alpha.88 (no commit)~
- ~go: 4.0.0-alpha.38 (no commit)~
- ~kotlin: 3.0.0-beta.7 (no commit)~
- ~dart: 1.2.1 (no commit)~
- python: 4.0.0a2 -> **`minor` _(e.g. 4.0.0a3)_**
- ruby: 3.0.0.alpha.1
- ~scala: 2.0.0-alpha.2 (no commit)~
- ~csharp: 7.0.0-alpha.1 (no commit)~

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: python and ruby release (#2451)
- docs: add more helpers (#2450)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(ci): prevent unwanted ci runs (#2458)
- chore(deps): dependencies 2024-01-01 (#2457)
</details>