### PR TITLE
chore: prepare release 2024-01-02

### DIFF
--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0a4](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a3...4.0.0a4)
+
+- [959974537](https://github.com/algolia/api-clients-automation/commit/959974537) fix(python): release ([#2472](https://github.com/algolia/api-clients-automation/pull/2472)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0a3](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a2...4.0.0a3)
 
 - [271eb792c](https://github.com/algolia/api-clients-automation/commit/271eb792c) feat(python): add browse helpers ([#2452](https://github.com/algolia/api-clients-automation/pull/2452)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -75,7 +75,7 @@
   "python": {
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0a3",
+    "packageVersion": "4.0.0a4",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~javascript: 5.0.0-alpha.94 (no commit)~
- ~java: 4.0.0-beta.13 (no commit)~
- ~php: 4.0.0-alpha.88 (no commit)~
- ~go: 4.0.0-alpha.38 (no commit)~
- ~kotlin: 3.0.0-beta.7 (no commit)~
- ~dart: 1.2.1 (no commit)~
- python: 4.0.0a3 -> **`patch` _(e.g. 4.0.0a4)_**
- ~ruby: 3.0.0.alpha.1 (no commit)~
- ~scala: 2.0.0-alpha.2 (no commit)~
- ~csharp: 7.0.0-alpha.1 (no commit)~

### Skipped Commits

_(None)_