### PR TITLE
chore(ci): compute shouldRun after filtering

### DIFF
--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -139,14 +139,14 @@ async function createClientMatrix(baseBranch: string): Promise<void> {
     });
   }
 
-  const shouldRun = clientMatrix.client.length > 0;
-
   const javascriptData = clientMatrix.client.find((c) => c.language === 'javascript');
   if (javascriptData) {
     core.setOutput('JAVASCRIPT_DATA', JSON.stringify(javascriptData));
     core.setOutput('RUN_GEN_JAVASCRIPT', true);
     clientMatrix.client = clientMatrix.client.filter((c) => c.language !== 'javascript');
   }
+
+  const shouldRun = clientMatrix.client.length > 0;
 
   core.setOutput('RUN_GEN', shouldRun);
   core.setOutput('GEN_MATRIX', JSON.stringify(shouldRun ? clientMatrix : EMPTY_MATRIX));


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

see ci failure on main: https://github.com/algolia/api-clients-automation/actions/runs/7400572570/attempts/1

the ci thinks it should run `client_gen` because `shouldRun` is `true` since it is computed computed before we filter javascript from the matrix to put it in its own