### PR TITLE
chore: prepare release 2024-01-04

### DIFF
--- a/clients/algoliasearch-client-csharp/CHANGELOG.md
+++ b/clients/algoliasearch-client-csharp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [7.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-csharp/compare/7.0.0-alpha.1...7.0.0-alpha.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [7.0.0-alpha.1](https://github.com/algolia/algoliasearch-client-csharp/compare/7.0.0-alpha.0...7.0.0-alpha.1)
 
 - [30014c7c6](https://github.com/algolia/api-clients-automation/commit/30014c7c6) refactor(csharp): remove useless code ([#2377](https://github.com/algolia/api-clients-automation/pull/2377)) by [@morganleroi](https://github.com/morganleroi/)

--- a/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.2.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.2.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
+++ b/clients/algoliasearch-client-dart/packages/client_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Algolia Client Core is a Dart package for seamless Algolia API integration,
   offering HTTP request handling, retry strategy, and robust exception
   management.
-version: 1.2.1
+version: 1.2.2
 homepage: https://www.algolia.com/doc/
 repository: >-
   https://github.com/algolia/algoliasearch-client-dart/tree/main/packages/client_core

--- a/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_insights/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.2.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_recommend/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.2.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
+++ b/clients/algoliasearch-client-dart/packages/client_search/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.2](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.1...1.2.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [1.2.1](https://github.com/algolia/algoliasearch-client-dart/compare/1.2.0...1.2.1)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-go/CHANGELOG.md
+++ b/clients/algoliasearch-client-go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.39](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.38...4.0.0-alpha.39)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.38](https://github.com/algolia/algoliasearch-client-go/compare/4.0.0-alpha.37...4.0.0-alpha.38)
 
 - [1bb2667a3](https://github.com/algolia/api-clients-automation/commit/1bb2667a3) chore(go): use golangci-lint ([#2437](https://github.com/algolia/api-clients-automation/pull/2437)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-java/CHANGELOG.md
+++ b/clients/algoliasearch-client-java/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-beta.14](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.13...4.0.0-beta.14)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-beta.13](https://github.com/algolia/algoliasearch-client-java/compare/4.0.0-beta.12...4.0.0-beta.13)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.0-alpha.95](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.94...5.0.0-alpha.95)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+- [4546090b2](https://github.com/algolia/api-clients-automation/commit/4546090b2) feat(javascript): add cache TTL and fix support message ([#2474](https://github.com/algolia/api-clients-automation/pull/2474)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.94](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.93...5.0.0-alpha.94)
 
 - [ae80c666c](https://github.com/algolia/api-clients-automation/commit/ae80c666c) chore(javascript): remove some non needed props from generators ([#2412](https://github.com/algolia/api-clients-automation/pull/2412)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.92",
-    "@algolia/client-analytics": "5.0.0-alpha.92",
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/client-personalization": "5.0.0-alpha.92",
-    "@algolia/client-search": "5.0.0-alpha.92",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-abtesting": "5.0.0-alpha.93",
+    "@algolia/client-analytics": "5.0.0-alpha.93",
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/client-personalization": "5.0.0-alpha.93",
+    "@algolia/client-search": "5.0.0-alpha.93",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.7",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.94",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.66",
+  "version": "1.0.0-alpha.67",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.20",
+  "version": "1.0.0-alpha.21",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.92",
+  "version": "5.0.0-alpha.93",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.93",
-    "@algolia/requester-node-http": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.94",
+    "@algolia/requester-node-http": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@types/node": "20.10.6",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.94",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.7",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.94",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.7",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.93",
+  "version": "5.0.0-alpha.94",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.93"
+    "@algolia/client-common": "5.0.0-alpha.94"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.7",

--- a/clients/algoliasearch-client-kotlin/CHANGELOG.md
+++ b/clients/algoliasearch-client-kotlin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.0-beta.8](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.7...3.0.0-beta.8)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [3.0.0-beta.7](https://github.com/algolia/algoliasearch-client-kotlin/compare/3.0.0-beta.6...3.0.0-beta.7)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-php/CHANGELOG.md
+++ b/clients/algoliasearch-client-php/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0-alpha.89](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.88...4.0.0-alpha.89)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0-alpha.88](https://github.com/algolia/algoliasearch-client-php/compare/4.0.0-alpha.87...4.0.0-alpha.88)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0a5](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a4...4.0.0a5)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [4.0.0a4](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a3...4.0.0a4)
 
 - [959974537](https://github.com/algolia/api-clients-automation/commit/959974537) fix(python): release ([#2472](https://github.com/algolia/api-clients-automation/pull/2472)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-ruby/CHANGELOG.md
+++ b/clients/algoliasearch-client-ruby/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.0.alpha.2](https://github.com/algolia/algoliasearch-client-ruby/compare/3.0.0.alpha.1...3.0.0.alpha.2)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [3.0.0.alpha.1](https://github.com/algolia/algoliasearch-client-ruby/tree/3.0.0.alpha.1)
 
 - [9f4f17585](https://github.com/algolia/api-clients-automation/commit/9f4f17585) fix(ruby): support ruby alpha format ([#2447](https://github.com/algolia/api-clients-automation/pull/2447)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-scala/CHANGELOG.md
+++ b/clients/algoliasearch-client-scala/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.0-alpha.3](https://github.com/algolia/algoliasearch-client-scala/compare/2.0.0-alpha.2...2.0.0-alpha.3)
+
+- [ae6adfbf7](https://github.com/algolia/api-clients-automation/commit/ae6adfbf7) fix(specs): port recommend changes ([#2476](https://github.com/algolia/api-clients-automation/pull/2476)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [2.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-scala/compare/2.0.0-alpha.1...2.0.0-alpha.2)
 
 - [8d71c2b69](https://github.com/algolia/api-clients-automation/commit/8d71c2b69) fix(specs): provide non clashing names for custom methods ([#2369](https://github.com/algolia/api-clients-automation/pull/2369)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -2,7 +2,7 @@
   "java": {
     "folder": "clients/algoliasearch-client-java",
     "gitRepoId": "algoliasearch-client-java",
-    "packageVersion": "4.0.0-beta.13",
+    "packageVersion": "4.0.0-beta.14",
     "modelFolder": "algoliasearch/src/main/java/com/algolia/model",
     "apiFolder": "algoliasearch/src/main/java/com/algolia/api",
     "customGenerator": "algolia-java",
@@ -15,7 +15,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.94",
+    "packageVersion": "5.0.0-alpha.95",
     "modelFolder": "model",
     "apiFolder": "src",
     "customGenerator": "algolia-javascript",
@@ -27,7 +27,7 @@
   "php": {
     "folder": "clients/algoliasearch-client-php",
     "gitRepoId": "algoliasearch-client-php",
-    "packageVersion": "4.0.0-alpha.88",
+    "packageVersion": "4.0.0-alpha.89",
     "modelFolder": "lib/Model",
     "customGenerator": "algolia-php",
     "apiFolder": "lib/Api",
@@ -39,7 +39,7 @@
   "go": {
     "folder": "clients/algoliasearch-client-go",
     "gitRepoId": "algoliasearch-client-go",
-    "packageVersion": "4.0.0-alpha.38",
+    "packageVersion": "4.0.0-alpha.39",
     "modelFolder": "algolia",
     "apiFolder": "algolia",
     "customGenerator": "algolia-go",
@@ -51,7 +51,7 @@
   "kotlin": {
     "folder": "clients/algoliasearch-client-kotlin",
     "gitRepoId": "algoliasearch-client-kotlin",
-    "packageVersion": "3.0.0-beta.7",
+    "packageVersion": "3.0.0-beta.8",
     "modelFolder": "client/src/commonMain/kotlin/com/algolia/client/model",
     "apiFolder": "client/src/commonMain/kotlin/com/algolia/client/api",
     "customGenerator": "algolia-kotlin",
@@ -63,7 +63,7 @@
   "dart": {
     "folder": "clients/algoliasearch-client-dart",
     "gitRepoId": "algoliasearch-client-dart",
-    "packageVersion": "1.2.1",
+    "packageVersion": "1.2.2",
     "modelFolder": "lib/src/model",
     "apiFolder": "lib/src/api",
     "customGenerator": "algolia-dart",
@@ -75,7 +75,7 @@
   "python": {
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0a4",
+    "packageVersion": "4.0.0a5",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",
@@ -87,7 +87,7 @@
   "ruby": {
     "folder": "clients/algoliasearch-client-ruby",
     "gitRepoId": "algoliasearch-client-ruby",
-    "packageVersion": "3.0.0.alpha.1",
+    "packageVersion": "3.0.0.alpha.2",
     "modelFolder": "lib/algolia/models",
     "apiFolder": "lib/algolia/api",
     "customGenerator": "algolia-ruby",
@@ -99,7 +99,7 @@
   "scala": {
     "folder": "clients/algoliasearch-client-scala",
     "gitRepoId": "algoliasearch-client-scala",
-    "packageVersion": "2.0.0-alpha.2",
+    "packageVersion": "2.0.0-alpha.3",
     "modelFolder": "src/main/scala/algoliasearch",
     "apiFolder": "src/main/scala/algoliasearch/api",
     "customGenerator": "algolia-scala",
@@ -111,7 +111,7 @@
   "csharp": {
     "folder": "clients/algoliasearch-client-csharp",
     "gitRepoId": "algoliasearch-client-csharp",
-    "packageVersion": "7.0.0-alpha.1",
+    "packageVersion": "7.0.0-alpha.2",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-csharp",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- javascript: 5.0.0-alpha.94 -> **`prerelease` _(e.g. 5.0.0-alpha.95)_**
- java: 4.0.0-beta.13 -> **`prerelease` _(e.g. 4.0.0-beta.14)_**
- php: 4.0.0-alpha.88 -> **`prerelease` _(e.g. 4.0.0-alpha.89)_**
- go: 4.0.0-alpha.38 -> **`prerelease` _(e.g. 4.0.0-alpha.39)_**
- kotlin: 3.0.0-beta.7 -> **`prerelease` _(e.g. 3.0.0-beta.8)_**
- dart: 1.2.1 -> **`patch` _(e.g. 1.2.2)_**
- python: 4.0.0a4 -> **`patch` _(e.g. 4.0.0a5)_**
- ruby: 3.0.0.alpha.1 -> **`patch` _(e.g. 3.0.0.alpha.2)_**
- scala: 2.0.0-alpha.2 -> **`prerelease` _(e.g. 2.0.0-alpha.3)_**
- csharp: 7.0.0-alpha.1 -> **`prerelease` _(e.g. 7.0.0-alpha.2)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(ci): compute shouldRun after filtering (#2475)
- fix(generators): add generic to top level (#2413)
</details>