### PR TITLE
feat(clients): deserialize in e2e and SFFV response

### DIFF
--- a/specs/search/common/schemas/SearchForFacetValuesResponse.yml
+++ b/specs/search/common/schemas/SearchForFacetValuesResponse.yml
@@ -3,6 +3,7 @@ searchForFacetValuesResponse:
   additionalProperties: false
   required:
     - facetHits
+    - exhaustiveFacetsCount
   x-discriminator-fields:
     - facetHits  
   properties:
@@ -26,3 +27,7 @@ searchForFacetValuesResponse:
           count:
             description: Number of records containing this facet value. This takes into account the extra search parameters specified in the query. Like for a regular search query, the [counts may not be exhaustive](https://support.algolia.com/hc/en-us/articles/4406975248145-Why-are-my-facet-and-hit-counts-not-accurate-).
             type: integer
+    exhaustiveFacetsCount:
+      $ref: 'SearchResponse.yml#/exhaustiveFacetsCount'
+    processingTimeMS:
+      $ref: 'SearchResponse.yml#/processingTimeMS'

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -74,9 +74,7 @@ baseSearchResponse:
           title: typo
           description: Whether the typo search was exhaustive (`true`) or approximate (`false`). An approximation is done when the typo search query part takes more than 10% of the query budget (ie. 5ms by default) to be processed (this can happen when a lot of typo alternatives exist for the query). This field will not be included when typo-tolerance is entirely disabled.
     exhaustiveFacetsCount:
-      type: boolean
-      description: See the `facetsCount` field of the `exhaustive` object in the response.
-      deprecated: true
+      $ref: '#/exhaustiveFacetsCount'
     exhaustiveNbHits:
       type: boolean
       description: See the `nbHits` field of the `exhaustive` object in the response.
@@ -149,9 +147,7 @@ baseSearchResponse:
       description: Post-[normalization](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/handling-natural-languages-nlp/#what-does-normalization-mean) query string that will be searched.
       example: 'george clo'
     processingTimeMS:
-      type: integer
-      description: Time the server took to process the request, in milliseconds.
-      example: 20
+      $ref: '#/processingTimeMS'
     processingTimingsMS:
       type: object
       description: Experimental. List of processing steps and their times, in milliseconds. You can use this list to investigate performance issues.
@@ -190,6 +186,16 @@ nbPages:
   type: integer
   description: Number of pages of results for the current query.
   example: 1
+
+exhaustiveFacetsCount:
+  type: boolean
+  description: See the `facetsCount` field of the `exhaustive` object in the response.
+  deprecated: true
+
+processingTimeMS:
+  type: integer
+  description: Time the server took to process the request, in milliseconds.
+  example: 20
 
 RedirectRuleIndexMetadata:
   type: object

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -50,14 +50,18 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         {{/request}}
 
         {{#response}}
-        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}_with_http_info({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+        {{#body}}
+        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+
+        _expected_body = loads("""{{{.}}}""")
+        assert self._helpers.union(_expected_body, loads(resp.to_json())) == _expected_body
+        {{/body}}
+        {{^body}}
+        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}_with_http_info{{/lambda.snakecase}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
   
         {{#statusCode}}
         assert resp.status_code == {{statusCode}}
         {{/statusCode}}
-        {{#body}}
-        _expected_body = loads("""{{{.}}}""")
-        assert self._helpers.union(_expected_body, loads(resp.raw_data)) == _expected_body
         {{/body}}
         {{/response}}
 

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -50,19 +50,15 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         {{/request}}
 
         {{#response}}
-        {{#body}}
-        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{^body}}_with_http_info{{/body}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
 
+        {{#body}}
         _expected_body = loads("""{{{.}}}""")
         assert self._helpers.union(_expected_body, loads(resp.to_json())) == _expected_body
         {{/body}}
-        {{^body}}
-        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}_with_http_info{{/lambda.snakecase}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
-  
         {{#statusCode}}
         assert resp.status_code == {{statusCode}}
         {{/statusCode}}
-        {{/body}}
         {{/response}}
 
     {{/tests}}

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -50,16 +50,15 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         {{/request}}
 
         {{#response}}
-        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{^body}}_with_http_info{{/body}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+        raw_resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}_with_http_info({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+        {{#statusCode}}
+        assert raw_resp.status_code == {{statusCode}}
+        {{/statusCode}}
 
         {{#body}}
+        resp = await SearchClient(self._e2e_app_id, self._e2e_api_key).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
         _expected_body = loads("""{{{.}}}""")
         assert self._helpers.union(_expected_body, loads(resp.to_json())) == _expected_body
-        {{/body}}
-        {{^body}}
-        {{#statusCode}}
-        assert resp.status_code == {{statusCode}}
-        {{/statusCode}}
         {{/body}}
         {{/response}}
 

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -56,9 +56,11 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         _expected_body = loads("""{{{.}}}""")
         assert self._helpers.union(_expected_body, loads(resp.to_json())) == _expected_body
         {{/body}}
+        {{^body}}
         {{#statusCode}}
         assert resp.status_code == {{statusCode}}
         {{/statusCode}}
+        {{/body}}
         {{/response}}
 
     {{/tests}}

--- a/tests/CTS/requests/search/getSettings.json
+++ b/tests/CTS/requests/search/getSettings.json
@@ -14,7 +14,6 @@
         "minWordSizefor2Typos": 8,
         "hitsPerPage": 20,
         "maxValuesPerFacet": 100,
-        "version": 1,
         "paginationLimitedTo": 10,
         "exactOnSingleWordQuery": "attribute",
         "ranking": [


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1748

### Changes included:

We now deserialize responses in the generated models for Python, pydantic would raise an error if it failed

Also fix the search for facet values response which was missing properties
