### PR TITLE
feat(python): improve docstring and fix transporter errors

### DIFF
--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
@@ -1,4 +1,5 @@
 from asyncio import TimeoutError
+from json import loads
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlencode
 
@@ -147,7 +148,7 @@ class Transporter:
             elif decision == RetryOutcome.FAIL:
                 content = response.error_message
                 if response.data and "message" in response.data:
-                    content = response.content["message"]
+                    content = loads(response.data)["message"]
 
                 raise RequestException(content, response.status_code)
 

--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -80,6 +80,7 @@ export const patterns = [
   // Python
   'clients/algoliasearch-client-python/**',
   '!clients/algoliasearch-client-python/algoliasearch/http/**',
+  '!clients/algoliasearch-client-python/algoliasearch/py.typed',
   'clients/algoliasearch-client-python/algoliasearch/http/__init__.py',
   '!clients/algoliasearch-client-python/*',
   'clients/algoliasearch-client-python/pyproject.toml',

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -57,6 +57,7 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
       file.getTemplateFile().equals("setup.mustache") ||
       file.getTemplateFile().equals("pyproject.mustache") ||
       file.getTemplateFile().equals("gitignore.mustache") ||
+      file.getTemplateFile().equals("py.typed.mustache") ||
       file.getTemplateFile().equals("README.mustache") ||
       file.getTemplateFile().equals("api_test.mustache") ||
       file.getTemplateFile().equals("model_test.mustache") ||

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -79,6 +79,7 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     supportingFiles.add(new SupportingFile("pyproject.mustache", "../", "pyproject.toml"));
     supportingFiles.add(new SupportingFile("gitignore.mustache", "../", ".gitignore"));
     supportingFiles.add(new SupportingFile("__init__.mustache", "", "__init__.py"));
+    supportingFiles.add(new SupportingFile("py.typed.mustache", "", "py.typed"));
     supportingFiles.add(new SupportingFile("__init__.mustache", packageName, "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", packageName + "/models", "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", "http", "__init__.py"));

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -57,7 +57,6 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
       file.getTemplateFile().equals("setup.mustache") ||
       file.getTemplateFile().equals("pyproject.mustache") ||
       file.getTemplateFile().equals("gitignore.mustache") ||
-      file.getTemplateFile().equals("py.typed.mustache") ||
       file.getTemplateFile().equals("README.mustache") ||
       file.getTemplateFile().equals("api_test.mustache") ||
       file.getTemplateFile().equals("model_test.mustache") ||
@@ -79,7 +78,6 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     supportingFiles.add(new SupportingFile("pyproject.mustache", "../", "pyproject.toml"));
     supportingFiles.add(new SupportingFile("gitignore.mustache", "../", ".gitignore"));
     supportingFiles.add(new SupportingFile("__init__.mustache", "", "__init__.py"));
-    supportingFiles.add(new SupportingFile("py.typed.mustache", "", "py.typed"));
     supportingFiles.add(new SupportingFile("__init__.mustache", packageName, "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", packageName + "/models", "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", "http", "__init__.py"));

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -13,13 +13,14 @@ class {{classname}}:
     Args:
     app_id (str): The Algolia application ID to retrieve information from.
     api_key (str): The Algolia api key bound to the given `app_id`.
+    {{#hasRegionalHost}}region ({{#allowedRegions}}"{{.}}"{{^-last}} | {{/-last}}{{/allowedRegions}}): The region of your Algolia application.{{/hasRegionalHost}}
 
     Returns:
     The initialized API client.
 
     Usage:
-    _client = {{classname}}("MY_APP_ID", "MY_API_KEY"{{#hasRegionalHost}}, "THE_REGION_TO_TARGET"{{/hasRegionalHost}})
-    _client_with_named_args = {{classname}}(app_id="MY_APP_ID", api_key="MY_API_KEY"{{#hasRegionalHost}}, region="THE_REGION_TO_TARGET"{{/hasRegionalHost}})
+    _client = {{classname}}("YOUR_ALGOLIA_APP_ID", "YOUR_ALGOLIA_API_KEY"{{#hasRegionalHost}}, region="{{#allowedRegions}}'{{.}}'{{^-last}} or {{/-last}}{{/allowedRegions}}"{{/hasRegionalHost}})
+    _client_with_named_args = {{classname}}(app_id="YOUR_ALGOLIA_APP_ID", api_key="YOUR_ALGOLIA_API_KEY"{{#hasRegionalHost}}, region="{{#allowedRegions}}'{{.}}'{{^-last}} or {{/-last}}{{/allowedRegions}}"{{/hasRegionalHost}})
 
     See `{{classname}}.create_with_config` for advanced configuration.
     """

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -20,6 +20,8 @@ class {{classname}}:
     Usage:
     _client = {{classname}}("MY_APP_ID", "MY_API_KEY"{{#hasRegionalHost}}, "THE_REGION_TO_TARGET"{{/hasRegionalHost}})
     _client_with_named_args = {{classname}}(app_id="MY_APP_ID", api_key="MY_API_KEY"{{#hasRegionalHost}}, region="THE_REGION_TO_TARGET"{{/hasRegionalHost}})
+
+    See `{{classname}}.create_with_config` for advanced configuration.
     """
 
     _transporter: Transporter

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -18,7 +18,7 @@ class {{classname}}:
     Returns:
     The initialized API client.
 
-    Usage:
+    Example:
     _client = {{classname}}("YOUR_ALGOLIA_APP_ID", "YOUR_ALGOLIA_API_KEY"{{#hasRegionalHost}}, region="{{#allowedRegions}}'{{.}}'{{^-last}} or {{/-last}}{{/allowedRegions}}"{{/hasRegionalHost}})
     _client_with_named_args = {{classname}}(app_id="YOUR_ALGOLIA_APP_ID", api_key="YOUR_ALGOLIA_API_KEY"{{#hasRegionalHost}}, region="{{#allowedRegions}}'{{.}}'{{^-last}} or {{/-last}}{{/allowedRegions}}"{{/hasRegionalHost}})
 
@@ -52,7 +52,7 @@ class {{classname}}:
         Returns:
         The initialized API client.
 
-        Usage:
+        Example:
         _client_with_custom_config = {{classname}}.create_with_config(config={{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}(...))
         _client_with_custom_config_and_transporter = {{classname}}.create_with_config(config={{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}(...), transporter=Transporter(...))
         """

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -8,6 +8,20 @@ from algoliasearch.{{packageName}}.models.{{#lambda.snakecase}}{{{.}}}{{/lambda.
 
 {{#operations}}
 class {{classname}}:
+    """The Algolia '{{classname}}' class.
+
+    Args:
+    app_id (str): The Algolia application ID to retrieve information from.
+    api_key (str): The Algolia api key bound to the given `app_id`.
+
+    Returns:
+    The initialized API client.
+
+    Usage:
+    _client = {{classname}}("MY_APP_ID", "MY_API_KEY"{{#hasRegionalHost}}, "THE_REGION_TO_TARGET"{{/hasRegionalHost}})
+    _client_with_named_args = {{classname}}(app_id="MY_APP_ID", api_key="MY_API_KEY"{{#hasRegionalHost}}, region="THE_REGION_TO_TARGET"{{/hasRegionalHost}})
+    """
+
     _transporter: Transporter
     _config: {{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}
     _request_options: RequestOptions
@@ -26,12 +40,33 @@ class {{classname}}:
         self._transporter = transporter
 
     def create_with_config(config: {{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}, transporter: Optional[Transporter] = None) -> Self:
+        """Allows creating a client with a customized `{{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}` and `Transporter`. If `transporter` is not provided, the default one will be initialized from the given `config`.
+
+        Args:
+        config ({{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}): The config of the API client.
+        transporter (Transporter): The HTTP transporter, see `http/transporter.py` for implementation details.
+
+        Returns:
+        The initialized API client.
+
+        Usage:
+        _client_with_custom_config = {{classname}}.create_with_config(config={{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}(...))
+        _client_with_custom_config_and_transporter = {{classname}}.create_with_config(config={{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}(...), transporter=Transporter(...))
+        """
         if transporter is None:
             transporter = Transporter(config)
 
         return {{classname}}(app_id=config.app_id, api_key=config.api_key, {{#hasRegionalHost}}region=config.region, {{/hasRegionalHost}}transporter=transporter, config=config)
 
+    async def __aenter__(self) -> None:
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        """Closes the underlying `transporter` of the API client."""
+        await self.close()
+
     async def close(self) -> None:
+        """Closes the underlying `transporter` of the API client."""
         return await self._transporter.close()
 
     {{#isSearchClient}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

_This PR applies the feedback from @kai687's review_

- [x] provide some docstring comments to the main classes (I've followed https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
- [x] fix deserialize error in the transporter when the call fails
- [x] add a `py.typed` file at the root of the package for libraries like `mypy`

![Screenshot 2024-01-09 at 12 54 02](https://github.com/algolia/api-clients-automation/assets/20689156/db6ecb82-abe4-4867-a0cd-bf536bd8a117)
