### PR TITLE
chore(ci): remove gradle wrapper validation from all languages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,7 +28,7 @@ runs:
         cache: gradle
 
     - name: Validate gradle wrapper
-      if: inputs.type != 'minimal'
+      if: ${{ inputs.language == 'java' }}
       uses: gradle/wrapper-validation-action@v1
 
     - name: Download Java formatter


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

I don't think it improves the CI time but we download the bundle validation for java on every clients which it isn't needed