### PR TITLE
chore: prepare release 2024-01-09

### DIFF
--- a/clients/algoliasearch-client-python/CHANGELOG.md
+++ b/clients/algoliasearch-client-python/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0b1](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a6...4.0.0b1)
+
+- Bump pre-release to beta.
+
 ## [4.0.0a7](https://github.com/algolia/algoliasearch-client-python/compare/4.0.0a6...4.0.0a7)
 
 - [4f51dff5d](https://github.com/algolia/api-clients-automation/commit/4f51dff5d) feat(python): improve docstring and fix transporter errors ([#2501](https://github.com/algolia/api-clients-automation/pull/2501)) by [@shortcuts](https://github.com/shortcuts/)

--- a/clients/algoliasearch-client-ruby/CHANGELOG.md
+++ b/clients/algoliasearch-client-ruby/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.0.alpha.4](https://github.com/algolia/algoliasearch-client-ruby/compare/3.0.0.alpha.3...3.0.0.alpha.4)
+
+- [b4ca09335](https://github.com/algolia/api-clients-automation/commit/b4ca09335) fix(ruby): release using Trusted Publishing ([#2504](https://github.com/algolia/api-clients-automation/pull/2504)) by [@millotp](https://github.com/millotp/)
+
 ## [3.0.0.alpha.3](https://github.com/algolia/algoliasearch-client-ruby/compare/3.0.0.alpha.2...3.0.0.alpha.3)
 
 - [ae20258c6](https://github.com/algolia/api-clients-automation/commit/ae20258c6) feat(clients): deserialize in e2e and SFFV response ([#2500](https://github.com/algolia/api-clients-automation/pull/2500)) by [@shortcuts](https://github.com/shortcuts/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -213,7 +213,7 @@
     ],
     "folder": "clients/algoliasearch-client-ruby",
     "gitRepoId": "algoliasearch-client-ruby",
-    "packageVersion": "3.0.0.alpha.3",
+    "packageVersion": "3.0.0.alpha.4",
     "modelFolder": "lib/algolia/models",
     "apiFolder": "lib/algolia/api",
     "customGenerator": "algolia-ruby",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -190,7 +190,7 @@
     ],
     "folder": "clients/algoliasearch-client-python",
     "gitRepoId": "algoliasearch-client-python",
-    "packageVersion": "4.0.0a7",
+    "packageVersion": "4.0.0b1",
     "modelFolder": "algoliasearch",
     "apiFolder": "algoliasearch",
     "customGenerator": "algolia-python",

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -176,11 +176,13 @@ export function getNextVersion(current: string, releaseType: semver.ReleaseType 
 
   let nextVersion: string | null = current;
 
-  // python alpha releases have a pattern like X.Y.ZaN
-  // where a means alpha and N can be any digit representing the alpha version
+  // python pre-releases have a pattern like `X.Y.ZaN` for alpha or `X.Y.ZbN` for beta
   // see https://peps.python.org/pep-0440/
-  // It also support ruby alpha like `X.Y.Z.alpha.N`
-  if (releaseType !== 'major' && /\d\.\d\.\d\.?a(lpha\.)?\d+$/.test(current)) {
+  // It also support ruby pre-releases like `X.Y.Z.alpha.N` for alpha or `X.Y.Z.beta.N` for beta
+  if (
+    releaseType !== 'major' &&
+    (/\d\.\d\.\d\.?a(lpha\.)?\d+$/.test(current) || /\d\.\d\.\d\.?b(eta\.)?\d+$/.test(current))
+  ) {
     nextVersion = current.replace(/\d+$/, (match) => `${parseInt(match, 10) + 1}`);
   } else if (current.endsWith('-SNAPSHOT')) {
     // snapshots should not be bumped


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~java: 4.0.0-beta.16 (no commit)~
- ~javascript: 5.0.0-alpha.97 (no commit)~
- ~php: 4.0.0-alpha.91 (no commit)~
- ~go: 4.0.0-alpha.41 (no commit)~
- ~kotlin: 3.0.0-beta.10 (no commit)~
- ~dart: 1.3.0 (no commit)~
- python: 4.0.0a7 -> **`patch` _(e.g. 4.0.0b1)_**
- ruby: 3.0.0.alpha.3 -> **`patch` _(e.g. 3.0.0.alpha.4)_**
- ~scala: 2.0.0-alpha.4 (no commit)~
- ~csharp: 7.0.0-alpha.3 (no commit)~

### Skipped Commits

_(None)_