### PR TITLE
chore(scripts): replace config path

### DIFF
--- a/scripts/configReplacer.cjs
+++ b/scripts/configReplacer.cjs
@@ -1,0 +1,1 @@
+exports.default = ({ orig }) => orig.replace(/\.\.\/config\//, '../../../config/');

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cli & yarn build:actions",
     "build:actions": "cd ci/actions/restore-artifacts && ncc build src/index.ts --source-map --transpile-only --minify -o builddir",
-    "build:cli": "tsc",
+    "build:cli": "tsc && tsc-alias",
     "cleanGeneratedBranch": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/cleanGeneratedBranch.js",
     "createMatrix": "NODE_NO_WARNINGS=1 node dist/scripts/ci/githubActions/createMatrix.js",
     "createReleasePR": "NODE_NO_WARNINGS=1 RELEASE=true node dist/scripts/release/createReleasePR.js",
@@ -48,6 +48,7 @@
     "micromatch": "4.0.5",
     "semver": "7.5.4",
     "spinnies": "0.5.1",
+    "tsc-alias": "1.8.8",
     "typescript": "5.3.3",
     "vitest": "1.1.3"
   }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -8,6 +8,15 @@
     "lib": ["esnext", "dom"],
     "outDir": "dist"
   },
-  "include": ["**/*.ts", "./.eslintrc.cjs", "**/*.mjs"],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "replacers": {
+      "configReplacer": {
+        "enabled": true,
+        "file": "configReplacer.cjs"
+      }
+    }
+  },
+  "include": ["**/*.ts", "./**.cjs", "**/*.mjs"],
   "exclude": ["dist", "*.json", "node_modules", "**/*.test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,7 +5680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.1":
+"chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -5936,6 +5936,13 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 9973af10727ad4b44f26703bf3e9fdc323528660a7590efe3aa9ad5042b4584c0deed84ba443f61c9d6f02dade54a5a5d3c95e306a1e1630f8374ae6db16c06d
+  languageName: node
+  linkType: hard
+
+"commander@npm:^9.0.0":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: 41c49b3d0f94a1fbeb0463c85b13f15aa15a9e0b4d5e10a49c0a1d58d4489b549d62262b052ae0aa6cfda53299bee487bfe337825df15e342114dde543f82906
   languageName: node
   linkType: hard
 
@@ -7806,7 +7813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.1.0":
+"globby@npm:^11.0.4, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -10248,6 +10255,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mylas@npm:^2.1.9":
+  version: 2.1.13
+  resolution: "mylas@npm:2.1.13"
+  checksum: 37f335424463c422f48d50317aa0a34fe410fabb146cbf27b453a0aa743732b5626f56deaa190bca2ce29836f809d88759007976dc78d5d22b75918a00586577
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
@@ -11073,6 +11087,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plimit-lit@npm:^1.2.6":
+  version: 1.6.1
+  resolution: "plimit-lit@npm:1.6.1"
+  dependencies:
+    queue-lit: "npm:^1.5.1"
+  checksum: e4eaf018dc311fd4d452954c10992cd8a9eb72d168ec2274bb831d86558422703e1405a8978ffdd5c418654e6a25e10a0765a39bf3ce3a84dc799fe6268e0ea4
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -11306,6 +11329,13 @@ __metadata:
   version: 6.0.4
   resolution: "pure-rand@npm:6.0.4"
   checksum: 34fed0abe99d3db7ddc459c12e1eda6bff05db6a17f2017a1ae12202271ccf276fb223b442653518c719671c1b339bbf97f27ba9276dba0997c89e45c4e6a3bf
+  languageName: node
+  linkType: hard
+
+"queue-lit@npm:^1.5.1":
+  version: 1.5.2
+  resolution: "queue-lit@npm:1.5.2"
+  checksum: 8dd45c79bd25b33b0c7d587391eb0b4acc4deb797bf92fef62b2d8e7c03b64083f5304f09d52a18267d34d020cc67ccde97a88185b67590eeccb194938ff1f98
   languageName: node
   linkType: hard
 
@@ -11930,6 +11960,7 @@ __metadata:
     micromatch: "npm:4.0.5"
     semver: "npm:7.5.4"
     spinnies: "npm:0.5.1"
+    tsc-alias: "npm:1.8.8"
     typescript: "npm:5.3.3"
     vitest: "npm:1.1.3"
   languageName: unknown
@@ -12879,6 +12910,22 @@ __metadata:
     lodash: "npm:^4.17.15"
     prettier: "npm:^2.5.1"
   checksum: 3772a7117b402dcda2a4eb55ef639687b48e82ae37681da45c7321ada226bf7b433afc7a1669dcfda7a5196e62fbbd229b235d485cb7a0f71477862dbfe5d8c1
+  languageName: node
+  linkType: hard
+
+"tsc-alias@npm:1.8.8":
+  version: 1.8.8
+  resolution: "tsc-alias@npm:1.8.8"
+  dependencies:
+    chokidar: "npm:^3.5.3"
+    commander: "npm:^9.0.0"
+    globby: "npm:^11.0.4"
+    mylas: "npm:^2.1.9"
+    normalize-path: "npm:^3.0.0"
+    plimit-lit: "npm:^1.2.6"
+  bin:
+    tsc-alias: dist/bin/index.js
+  checksum: 145d7bb23a618e1136c8addd4b4ed23a1d503a37d3fc5b3698a993fea9331180a68853b0e78ff50fb3fb7ed95d4996a2d82f77395814bbd1c40adee8a9151d90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧭 What and Why

By default, we need to rebuild the scripts everytime we change the the config files, but this is less than ideal.
The only way I found to fix it was by using a library, `tsc-alias`, that will replace after the transpilation every reference to `../config` with `../../../config` to fetch the original file.
Using `paths`, or `dynamic import` didn't work