### PR TITLE
fix(ruby): exclude vendor from bundled gem

### DIFF
--- a/clients/algoliasearch-client-ruby/algolia.gemspec
+++ b/clients/algoliasearch-client-ruby/algolia.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.files         = `find *`.split("\n").uniq.sort.reject(&:empty?)
+  s.files         = `git ls-files`.split($/)
   s.executables   = []
   s.require_paths = ['lib']
 


### PR DESCRIPTION
## 🧭 What and Why

The published gem was 5.4MB instead of the expected `300KB`, because I forgot to remove files excluded by git.