### PR TITLE
chore: support fish for setup

### DIFF
--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 
 export NODE_VERSION=$(cat .nvmrc)
-find config -name '.*-version' | xargs -I{} sh -c 'l=$(echo "{}" | sed -e "s/-/_/;s/config\/\.//" | tr "[a-z]" "[A-Z]");echo "export $l=$(cat {})"'
+
+while read line; do
+  arr=($line)
+  export $(echo ${arr[1]} | sed -e "s/-/_/;s/config\/\.//" | tr "[a-z]" "[A-Z]")=${arr[0]}
+done < <(find config -name '.*-version' -exec jq --raw-input -r '. + " " + input_filename' {} \;)
+
 docker compose up -d


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

you can't setup docker with fish actually because it sets the env var from substitutions, but with bass (fish plugin) it works if we use export directly in the script we are running