### PR TITLE
chore: prepare release 2024-01-16

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.0.0-alpha.99](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.98...5.0.0-alpha.99)
+
+- [3d7c5e617](https://github.com/algolia/api-clients-automation/commit/3d7c5e617) fix(javascript): lock ([#2548](https://github.com/algolia/api-clients-automation/pull/2548)) by [@shortcuts](https://github.com/shortcuts/)
+
 ## [5.0.0-alpha.98](https://github.com/algolia/algoliasearch-client-javascript/compare/5.0.0-alpha.97...5.0.0-alpha.98)
 
 - [7c5ba3288](https://github.com/algolia/api-clients-automation/commit/7c5ba3288) feat(specs): update Insights API spec ([#2376](https://github.com/algolia/api-clients-automation/pull/2376)) by [@kai687](https://github.com/kai687/)

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "A fully-featured and blazing-fast JavaScript API client to interact with Algolia API.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -60,13 +60,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-abtesting": "5.0.0-alpha.96",
-    "@algolia/client-analytics": "5.0.0-alpha.96",
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/client-personalization": "5.0.0-alpha.96",
-    "@algolia/client-search": "5.0.0-alpha.96",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-abtesting": "5.0.0-alpha.97",
+    "@algolia/client-analytics": "5.0.0-alpha.97",
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/client-personalization": "5.0.0-alpha.97",
+    "@algolia/client-search": "5.0.0-alpha.97",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.8",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-abtesting",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-abtesting",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-analytics",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-analytics",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.0.0-alpha.97",
+  "version": "5.0.0-alpha.98",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-insights",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-insights",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-personalization",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-personalization",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-query-suggestions",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-query-suggestions",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-search",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for client-search",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/ingestion",
-  "version": "1.0.0-alpha.70",
+  "version": "1.0.0-alpha.71",
   "description": "JavaScript client for ingestion",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/monitoring",
-  "version": "1.0.0-alpha.24",
+  "version": "1.0.0-alpha.25",
   "description": "JavaScript client for monitoring",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/recommend",
-  "version": "5.0.0-alpha.96",
+  "version": "5.0.0-alpha.97",
   "description": "JavaScript client for recommend",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -39,9 +39,9 @@
     "clean": "rm -rf ./dist || true"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97",
-    "@algolia/requester-browser-xhr": "5.0.0-alpha.97",
-    "@algolia/requester-node-http": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98",
+    "@algolia/requester-browser-xhr": "5.0.0-alpha.98",
+    "@algolia/requester-node-http": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@types/node": "20.11.1",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.0.0-alpha.97",
+  "version": "5.0.0-alpha.98",
   "description": "Promise-based request library for browser using xhr.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.0.0-alpha.97",
+  "version": "5.0.0-alpha.98",
   "description": "Promise-based request library using Fetch.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.8",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.0.0-alpha.97",
+  "version": "5.0.0-alpha.98",
   "description": "Promise-based request library for node using the native http module.",
   "repository": "algolia/algoliasearch-client-javascript",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@algolia/client-common": "5.0.0-alpha.97"
+    "@algolia/client-common": "5.0.0-alpha.98"
   },
   "devDependencies": {
     "@babel/preset-env": "7.23.8",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -156,7 +156,7 @@
     "folder": "clients/algoliasearch-client-javascript",
     "npmNamespace": "@algolia",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.0.0-alpha.98",
+    "packageVersion": "5.0.0-alpha.99",
     "modelFolder": "model",
     "apiFolder": "src",
     "dockerImage": "apic_base",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~csharp: 7.0.0-alpha.4 (no commit)~
- ~dart: 1.4.0 (no commit)~
- ~go: 4.0.0-alpha.42 (no commit)~
- ~java: 4.0.0-beta.17 (no commit)~
- javascript: 5.0.0-alpha.98 -> **`prerelease` _(e.g. 5.0.0-alpha.99)_**
- ~kotlin: 3.0.0-beta.11 (no commit)~
- ~php: 4.0.0-alpha.92 (no commit)~
- ~python: 4.0.0b2 (no commit)~
- ~ruby: 3.0.0.alpha.5 (no commit)~
- ~scala: 2.0.0-alpha.5 (no commit)~
- ~swift: 9.0.0-alpha.1 (no commit)~

### Skipped Commits

_(None)_