### PR TITLE
snippets: remove index from csharp

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Pull Request title rules
         uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: '^(docs|chore)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|playground|csharp|dart|go|java|javascript|kotlin|php|python|ruby|scala|swift|cts|specs|scripts|ci|templates|deps)\)): .+'
+          regexp: '^(docs|chore)|((?:feat|fix|docs|snippets|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|playground|csharp|dart|go|java|javascript|kotlin|php|python|ruby|scala|swift|cts|specs|scripts|ci|templates|deps)\)): .+'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Pull Request title rules
         uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: '^(docs|chore)|((?:feat|fix|docs|snippets|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|playground|csharp|dart|go|java|javascript|kotlin|php|python|ruby|scala|swift|cts|specs|scripts|ci|templates|deps)\)): .+'
+          regexp: '^(docs|chore|snippets)|((?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((?:clients|generators|playground|csharp|dart|go|java|javascript|kotlin|php|python|ruby|scala|swift|cts|specs|scripts|ci|templates|deps)\)): .+'

--- a/templates/csharp/snippets/method.mustache
+++ b/templates/csharp/snippets/method.mustache
@@ -13,7 +13,7 @@ public class Snippet{{client}}
   ///
   /// {{{description}}}
   /// </summary>
-  public async Task SnippetFor{{#lambda.pascalcase}}{{method}}{{testIndex}}{{/lambda.pascalcase}}()
+  public async Task SnippetFor{{client}}{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}()
   {
     // Initialize the client
     var client = new {{client}}(new {{clientPrefix}}Config("YOUR_APP_ID", "YOUR_API_KEY"{{#hasRegionalHost}},"YOUR_APP_ID_REGION"{{/hasRegionalHost}}));


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

snippets include index of the test which doesn't have much context here, we can use the client name instead to prevent duplicated defintions