### PR TITLE
fix(java): correct url for monitoring client

### DIFF
--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -12,7 +12,6 @@ repositories {
 
 dependencies {
     compileOnly 'org.openapitools:openapi-generator:7.2.0'
-    compileOnly 'org.yaml:snakeyaml:2.2'
 }
 
 tasks.withType(JavaCompile) {

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
@@ -3,6 +3,7 @@ package com.algolia.codegen;
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
 import com.algolia.codegen.utils.OneOf;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.IOException;
@@ -121,13 +122,12 @@ public class AlgoliaCSharpGenerator extends CSharpClientCodegen {
     supportingFiles.add(new SupportingFile("netcore_project.mustache", "Algolia.Search.csproj"));
     supportingFiles.add(new SupportingFile("AbstractOpenAPISchema.mustache", "Models", "AbstractSchema.cs"));
     supportingFiles.add(new SupportingFile("gitignore.mustache", "../", ".gitignore"));
+  }
 
-    try {
-      Helpers.generateServer(CLIENT, additionalProperties);
-    } catch (GeneratorException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -3,6 +3,7 @@ package com.algolia.codegen;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import com.algolia.codegen.utils.*;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.*;
@@ -102,9 +103,12 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     // Search config
     additionalProperties.put("isSearchClient", client.equals("search"));
     additionalProperties.put("packageVersion", version);
+  }
 
-    // Generate server info
-    Helpers.generateServer(client, additionalProperties);
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaGoGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaGoGenerator.java
@@ -3,6 +3,7 @@ package com.algolia.codegen;
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
 import com.algolia.codegen.utils.OneOf;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.File;
@@ -53,12 +54,17 @@ public class AlgoliaGoGenerator extends GoClientCodegen {
     supportingFiles.add(new SupportingFile("client.mustache", "", "client.go"));
 
     try {
-      Helpers.generateServer(client, additionalProperties);
       additionalProperties.put("packageVersion", Helpers.getClientConfigField("go", "packageVersion"));
     } catch (GeneratorException e) {
       e.printStackTrace();
       System.exit(1);
     }
+  }
+
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
@@ -4,6 +4,7 @@ import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
 import com.algolia.codegen.utils.OneOf;
 import com.samskivert.mustache.Mustache;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
@@ -52,13 +53,17 @@ public class AlgoliaJavaGenerator extends JavaClientCodegen {
     additionalProperties.put("lambda.type-to-name", (Mustache.Lambda) (fragment, writer) -> writer.write(typeToName(fragment.execute())));
 
     try {
-      Helpers.generateServer(client, additionalProperties);
-
       additionalProperties.put("packageVersion", Helpers.getClientConfigField("java", "packageVersion"));
     } catch (GeneratorException e) {
       e.printStackTrace();
       System.exit(1);
     }
+  }
+
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -2,6 +2,7 @@ package com.algolia.codegen;
 
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
@@ -161,6 +162,12 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
   }
 
   @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
+  }
+
+  @Override
   public Map<String, ModelsMap> postProcessAllModels(Map<String, ModelsMap> objs) {
     Map<String, ModelsMap> models = super.postProcessAllModels(objs);
     GenericPropagator.propagateGenericsToModels(models);
@@ -174,7 +181,6 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
 
     setDefaultGeneratorOptions();
     try {
-      Helpers.generateServer((String) additionalProperties.get("client"), additionalProperties);
       additionalProperties.put("utilsPackageVersion", Helpers.getPackageJsonVersion("client-common"));
       additionalProperties.put("npmNamespace", Helpers.getClientConfigField("javascript", "npmNamespace"));
     } catch (GeneratorException e) {

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
@@ -1,9 +1,9 @@
 package com.algolia.codegen;
 
-import com.algolia.codegen.exceptions.GeneratorException;
 import com.algolia.codegen.utils.*;
 import com.algolia.codegen.utils.OneOf;
 import com.samskivert.mustache.Mustache;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.File;
@@ -114,14 +114,6 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     supportingFiles.add(new SupportingFile("README_BOM.mustache", "client-bom", "README.md"));
 
     additionalProperties.put("packageVersion", Helpers.getClientConfigField("kotlin", "packageVersion"));
-
-    try {
-      Helpers.generateServer(client, additionalProperties);
-      hostForKotlin();
-    } catch (GeneratorException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
   }
 
   /** Convert a Seq type to a valid class name. */
@@ -129,7 +121,11 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     return content.trim().replace("<", "Of").replace(">", "").replace(", ", "").replace(".", "");
   }
 
-  private void hostForKotlin() {
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
+
     String host = (String) additionalProperties.get("regionalHost");
     if (host != null) {
       String hostForKotlin = host.replaceAll("\\{([^}]+)}", "\\$$1");

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPhpGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPhpGenerator.java
@@ -2,6 +2,7 @@ package com.algolia.codegen;
 
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
@@ -49,12 +50,17 @@ public class AlgoliaPhpGenerator extends PhpClientCodegen {
 
     setDefaultGeneratorOptions(client);
     try {
-      Helpers.generateServer(client, additionalProperties);
       additionalProperties.put("packageVersion", Helpers.getClientConfigField("php", "packageVersion"));
     } catch (GeneratorException e) {
       e.printStackTrace();
       System.exit(1);
     }
+  }
+
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -2,6 +2,7 @@ package com.algolia.codegen;
 
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.*;
@@ -83,13 +84,12 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     supportingFiles.add(new SupportingFile("__init__.mustache", packageName + "/models", "__init__.py"));
     supportingFiles.add(new SupportingFile("__init__.mustache", "http", "__init__.py"));
     supportingFiles.add(new SupportingFile("config.mustache", packageName, "config.py"));
+  }
 
-    try {
-      Helpers.generateServer(CLIENT, additionalProperties);
-    } catch (GeneratorException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaRubyGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaRubyGenerator.java
@@ -2,6 +2,7 @@ package com.algolia.codegen;
 
 import com.algolia.codegen.exceptions.*;
 import com.algolia.codegen.utils.*;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.*;
@@ -60,15 +61,12 @@ public class AlgoliaRubyGenerator extends RubyClientCodegen {
       file.getTemplateFile().equals("spec_helper.mustache") ||
       file.getTemplateFile().equals("rubocop.mustache")
     );
+  }
 
-    // repository
-
-    try {
-      Helpers.generateServer(CLIENT, additionalProperties);
-    } catch (GeneratorException e) {
-      e.printStackTrace();
-      System.exit(1);
-    }
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaScalaGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaScalaGenerator.java
@@ -3,6 +3,7 @@ package com.algolia.codegen;
 import com.algolia.codegen.exceptions.GeneratorException;
 import com.algolia.codegen.utils.*;
 import com.samskivert.mustache.Mustache;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.File;
@@ -77,7 +78,6 @@ public class AlgoliaScalaGenerator extends ScalaSttpClientCodegen {
     nameMapping.putAll(NAME_MAPPING);
 
     try {
-      Helpers.generateServer(client, additionalProperties);
       additionalProperties.put("packageVersion", Helpers.getClientConfigField("scala", "packageVersion"));
     } catch (GeneratorException e) {
       logger.severe(e.getMessage());
@@ -88,6 +88,12 @@ public class AlgoliaScalaGenerator extends ScalaSttpClientCodegen {
   /** Convert a Seq type to a valid class name. */
   private String typeToName(String content) {
     return content.trim().replace("[", "Of").replace("]", "").replace(".", "").replace(", ", "");
+  }
+
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaSwiftGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaSwiftGenerator.java
@@ -7,6 +7,7 @@ import com.algolia.codegen.utils.GenericPropagator;
 import com.algolia.codegen.utils.Helpers;
 import com.algolia.codegen.utils.OneOf;
 import com.samskivert.mustache.Mustache;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -116,7 +117,6 @@ public class AlgoliaSwiftGenerator extends Swift5ClientCodegen {
     Helpers.setGenerationBanner(additionalProperties);
 
     try {
-      Helpers.generateServer(CLIENT, additionalProperties);
       additionalProperties.put("packageVersion", Helpers.getClientConfigField("swift", "packageVersion"));
       additionalProperties.put("packageList", Helpers.getClientListForLanguage("swift"));
     } catch (GeneratorException e) {
@@ -185,6 +185,12 @@ public class AlgoliaSwiftGenerator extends Swift5ClientCodegen {
       model.vendorExtensions.put("x-is-one-of", true);
       model.vendorExtensions.put("x-one-of-explicit-name", Helpers.shouldUseExplicitOneOfName(model.oneOf));
     }
+  }
+
+  @Override
+  public void processOpenAPI(OpenAPI openAPI) {
+    super.processOpenAPI(openAPI);
+    Helpers.generateServers(super.fromServers(openAPI.getServers()), additionalProperties);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.swagger.v3.core.util.Json;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenOperation;
-import org.yaml.snakeyaml.Yaml;
+import org.openapitools.codegen.CodegenServer;
+import org.openapitools.codegen.CodegenServerVariable;
 
 public class Helpers {
 
@@ -86,70 +87,62 @@ public class Helpers {
   }
 
   /** Inject server info into the client to generate the right URL */
-  public static void generateServer(String clientKebab, Map<String, Object> additionalProperties) throws ConfigException {
-    Yaml yaml = new Yaml();
+  public static void generateServers(List<CodegenServer> servers, Map<String, Object> bundle) throws ConfigException {
     try {
-      Map<String, Object> spec = yaml.load(new FileInputStream("specs/bundled/" + clientKebab + ".yml"));
-      List<Map<String, Object>> servers = (List<Map<String, Object>>) spec.get("servers");
-
       boolean hasRegionalHost = false;
       boolean fallbackToAliasHost = false;
       String regionalHost = "";
       String hostWithFallback = "";
       Set<String> allowedRegions = new HashSet<>();
-      for (Map<String, Object> server : servers) {
-        if (!server.containsKey("url")) {
+      for (CodegenServer server : servers) {
+        if (server.url.isEmpty()) {
           throw new ConfigException("Invalid server, does not contains 'url'");
         }
 
         // Determine if the current URL with `region` also have an alias without
         // variables.
-        for (Map<String, Object> otherServer : servers) {
+        for (CodegenServer otherServer : servers) {
           if (server == otherServer) {
             continue;
           }
-          String otherUrl = (String) otherServer.getOrDefault("url", "");
-          if (otherUrl.replace(".{region}", "").equals(server.get("url"))) {
-            URL fallbackURL = new URL(otherUrl.replace(".{region}", ""));
+          if (otherServer.url.replace(".{region}", "").equals(server.url)) {
+            URL fallbackURL = new URL(otherServer.url.replace(".{region}", ""));
             fallbackToAliasHost = true;
             hostWithFallback = fallbackURL.getHost();
             break;
           }
         }
 
-        if (!server.containsKey("variables")) {
+        if (server.variables == null || server.variables.isEmpty()) {
+          continue;
+        }
+        CodegenServerVariable regionVar = server.variables.stream().filter(v -> v.name.equals("region")).findFirst().orElse(null);
+        if (regionVar == null || regionVar.enumValues == null || regionVar.enumValues.isEmpty()) {
           continue;
         }
 
-        Map<String, Map<String, Object>> variables = (Map<String, Map<String, Object>>) server.get("variables");
-
-        if (!variables.containsKey("region") || !variables.get("region").containsKey("enum")) {
-          continue;
-        }
-        ArrayList<String> regions = (ArrayList<String>) variables.get("region").get("enum");
         hasRegionalHost = true;
-
-        for (String region : regions) {
+        for (String region : regionVar.enumValues) {
           allowedRegions.add(region);
         }
 
         // This is used for hosts like `insights` that uses `.io`
-        URL url = new URL((String) server.get("url"));
+        URL url = new URL(server.url);
         regionalHost = url.getHost();
       }
 
       if (servers.size() == 1 && hostWithFallback.isEmpty() && !hasRegionalHost) {
-        URL url = new URL((String) servers.get(0).get("url"));
-        additionalProperties.put("uniqueHost", url.getHost());
+        URL url = new URL(servers.get(0).url);
+        bundle.put("uniqueHost", url.getHost());
       }
 
-      additionalProperties.put("hostWithFallback", hostWithFallback);
-      additionalProperties.put("hasRegionalHost", hasRegionalHost);
-      additionalProperties.put("fallbackToAliasHost", fallbackToAliasHost);
-      additionalProperties.put("regionalHost", regionalHost);
-      additionalProperties.put("allowedRegions", allowedRegions.toArray(new String[0]));
-    } catch (Exception e) {
-      throw new ConfigException("Couldn't generate servers", e);
+      bundle.put("hostWithFallback", hostWithFallback);
+      bundle.put("hasRegionalHost", hasRegionalHost);
+      bundle.put("fallbackToAliasHost", fallbackToAliasHost);
+      bundle.put("regionalHost", regionalHost);
+      bundle.put("allowedRegions", allowedRegions.toArray(new String[0]));
+    } catch (MalformedURLException e) {
+      throw new ConfigException("Invalid server URL", e);
     }
   }
 

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -59,11 +59,11 @@ public class {{classname}} extends ApiClient {
     }
 
     public {{classname}}(String appId, String apiKey, ClientOptions options) {
-      super(appId, apiKey, "{{{baseName}}}", options, getDefaultHosts(appId));
+      super(appId, apiKey, "{{{baseName}}}", options, getDefaultHosts({{^uniqueHost}}appId{{/uniqueHost}}));
     }
     {{/hasRegionalHost}}
 
-    {{^hasRegionalHost}}
+    {{^uniqueHost}}{{^hasRegionalHost}}
     private static List<Host> getDefaultHosts(String appId) {
       List<Host> hosts = new ArrayList<>();
       hosts.add(new Host(appId + "-dsn.algolia.net", EnumSet.of(CallType.READ)));
@@ -103,7 +103,15 @@ public class {{classname}} extends ApiClient {
       hosts.add(new Host(url, EnumSet.of(CallType.READ, CallType.WRITE)));
       return hosts;
     }
-    {{/hasRegionalHost}}
+    {{/hasRegionalHost}}{{/uniqueHost}}
+    
+    {{#uniqueHost}}
+    private static List<Host> getDefaultHosts() {
+      List<Host> hosts = new ArrayList<>();
+      hosts.add(new Host("{{{.}}}", EnumSet.of(CallType.READ, CallType.WRITE)));
+      return hosts;
+    }
+    {{/uniqueHost}}
 
     {{#operation}}
     /**


### PR DESCRIPTION
## 🧭 What and Why

Following #2561, use the correct url for java, and rework the generators to use the already read spec file, and the correct types for servers.