### PR TITLE
feat(specs): spread to new world docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -423,3 +423,9 @@ jobs:
         run: yarn workspace scripts spreadGeneration
         env:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+
+      - name: Push specs to new worlds documentation
+        if: ${{ steps.pushGeneratedCode.exitcode == 0 && github.ref == 'refs/heads/main' }}
+        run: yarn workspace scripts pushSpecsToNewWorld
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}

--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -1,6 +1,7 @@
 export const patterns = [
   // Ignore the roots and go down the tree by negating hand written files
   'specs/bundled/*.yml',
+  'specs/bundled/*.json',
 
   'clients/**',
   'snippets/**',

--- a/scripts/buildSpecs.ts
+++ b/scripts/buildSpecs.ts
@@ -214,7 +214,6 @@ async function buildSpec(spec: string, outputFormat: string, useCache: boolean):
     });
   }
 
-  // Validate and lint the final bundle
   spinner.text = `validating '${spec}' bundled spec`;
   await run(`yarn openapi lint specs/bundled/${spec}.${outputFormat}`);
 
@@ -224,6 +223,9 @@ async function buildSpec(spec: string, outputFormat: string, useCache: boolean):
   if (!isAlgoliasearch) {
     spinner.text = `linting '${spec}' doc spec`;
     await run(`yarn specs:fix bundled/${spec}.doc.yml`);
+    await run(
+      `yarn openapi bundle specs/bundled/${spec}.doc.yml --output specs/bundled/${spec}.json --format json --ext json --dereferenced`
+    );
   }
 
   if (useCache) {

--- a/scripts/ci/codegen/pushSpecsToNewWorld.ts
+++ b/scripts/ci/codegen/pushSpecsToNewWorld.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+import fsp from 'fs/promises';
+import { resolve } from 'path';
+
+import {
+  emptyDirExceptForDotGit,
+  gitCommit,
+  run,
+  toAbsolutePath,
+  ensureGitHubToken,
+  configureGitHubAuthor,
+  setVerbose,
+} from '../../common.js';
+import { getNbGitDiff } from '../utils.js';
+
+import { commitStartRelease } from './text.js';
+
+async function pushToNewWorld(): Promise<void> {
+  const githubToken = ensureGitHubToken();
+
+  const lastCommitMessage = await run('git log -1 --format="%s"');
+  const author = (await run('git log -1 --format="Co-authored-by: %an <%ae>"')).trim();
+  const coAuthors = (await run('git log -1 --format="%(trailers:key=Co-authored-by)"'))
+    .split('\n')
+    .map((coAuthor) => coAuthor.trim())
+    .filter(Boolean);
+
+  if (!lastCommitMessage.startsWith(commitStartRelease)) {
+    return;
+  }
+
+  console.log('Pushing generated specs to https://github.com/algolia/new-world-docs');
+
+  const targetBranch = 'feat/automated-update-from-api-clients-automation-repository';
+  const githubURL = `https://${githubToken}:${githubToken}@github.com/algolia/new-world-docs`;
+  const tempGitDir = resolve(process.env.RUNNER_TEMP!, 'new-world-docs');
+  await fsp.rm(tempGitDir, { force: true, recursive: true });
+  await run(`git clone --depth 1 ${githubURL} ${tempGitDir}`);
+  await run(`git checkout -B ${targetBranch}`);
+
+  const dest = toAbsolutePath(`${tempGitDir}/apps/docs/public/specs`);
+  await emptyDirExceptForDotGit(dest);
+  await run(`cp ${toAbsolutePath('specs/bundled/*.json')} ${dest}`);
+
+  if ((await getNbGitDiff({ head: null, cwd: tempGitDir })) === 0) {
+    console.log(`❎ Skipping specs push because there is no change.`);
+  } else {
+    console.log(`✅ Push specs to the new-world-docs repository.`);
+  }
+
+  await configureGitHubAuthor(tempGitDir);
+
+  await run('git add .', { cwd: tempGitDir });
+  await gitCommit({
+    message: 'feat(specs): automated update from api-clients-automation repository',
+    coAuthors: [author, ...coAuthors],
+    cwd: tempGitDir,
+  });
+  await run('git push -f', { cwd: tempGitDir });
+}
+
+if (import.meta.url.endsWith(process.argv[1])) {
+  setVerbose(true);
+  pushToNewWorld();
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,6 +13,7 @@
     "lint:deadcode": "knip",
     "pre-commit": "node ./ci/husky/pre-commit.mjs",
     "pushGeneratedCode": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/pushGeneratedCode.js",
+    "pushSpecsToNewWorld": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/pushSpecsToNewWorld.js",
     "setRunVariables": "NODE_NO_WARNINGS=1 node dist/scripts/ci/githubActions/setRunVariables.js",
     "spreadGeneration": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/spreadGeneration.js",
     "start": "NODE_NO_WARNINGS=1 node dist/scripts/cli/index.js",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

Generate dereferenced JSON spec files for the New World documentation and add a script to make the CI push it when we release clients, you can try it out by filling env variables and running it the same way as the CI does.

To be merged after Crawler and Usage specs have been imported from their repository