### PR TITLE
feat(ruby): add wait helpers

### DIFF
--- a/clients/algoliasearch-client-ruby/algolia.gemspec
+++ b/clients/algoliasearch-client-ruby/algolia.gemspec
@@ -1,3 +1,4 @@
+require 'English'
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'algolia/version'
@@ -20,7 +21,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.files         = `git ls-files`.split($/)
+  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.executables   = []
   s.require_paths = ['lib']
 

--- a/clients/algoliasearch-client-ruby/lib/algolia/api_client.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia/api_client.rb
@@ -119,7 +119,7 @@ module Algolia
     # @return [String] JSON string representation of the object
     def object_to_hash(obj)
       if obj.is_a?(Hash)
-        obj.map { |k, v| [k, object_to_hash(v)] }.to_h
+        obj.to_h { |k, v| [k, object_to_hash(v)] }
       elsif obj.respond_to?(:to_hash)
         obj.to_hash
       else

--- a/clients/algoliasearch-client-ruby/lib/algolia/transport/transport.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia/transport/transport.rb
@@ -56,7 +56,7 @@ module Algolia
           return response unless outcome == RETRY
         end
 
-        raise AlgoliaUnreachableHostError('Unreachable hosts')
+        raise Algolia::AlgoliaUnreachableHostError('Unreachable hosts')
       end
 
       private
@@ -112,10 +112,10 @@ module Algolia
       end
 
       def stringify_query_params(query_params)
-        query_params.map do |key, value|
+        query_params.to_h do |key, value|
           value = value.join(',') if value.is_a?(Array)
           [key, value.to_s]
-        end.to_h
+        end
       end
     end
   end

--- a/playground/ruby/search.rb
+++ b/playground/ruby/search.rb
@@ -6,3 +6,24 @@ Dotenv.load('../.env')
 client = Algolia::SearchClient.create(ENV['ALGOLIA_APPLICATION_ID'], ENV['ALGOLIA_ADMIN_KEY'])
 res = client.search_single_index('contacts', Algolia::Search::SearchParamsObject.new(query: 'Jimmie'))
 puts res
+
+=begin
+key = client.add_api_key(Algolia::Search::ApiKey.new(acl: ['search'], description: 'this is a test'))
+puts key
+
+created = client.wait_for_api_key('add', key.key)
+puts created
+
+new_key = Algolia::Search::ApiKey.new(description: 'this is another test')
+updated = client.update_api_key(key.key, new_key)
+puts updated
+
+aa = client.wait_for_api_key('update', key.key, new_key)
+puts aa
+
+deleted = client.delete_api_key(key.key)
+puts deleted
+
+waitfor = client.wait_for_api_key('delete', key.key)
+puts waitfor
+=end

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -206,6 +206,10 @@ module {{moduleName}}
 
 {{/-last}}
 {{/operation}}
+
+    {{#isSearchClient}}
+{{> search_helpers}}
+    {{/isSearchClient}}
   end
 {{/operations}}
 end

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -207,9 +207,9 @@ module {{moduleName}}
 {{/-last}}
 {{/operation}}
 
-    {{#isSearchClient}}
+{{#isSearchClient}}
 {{> search_helpers}}
-    {{/isSearchClient}}
+{{/isSearchClient}}
   end
 {{/operations}}
 end

--- a/templates/ruby/search_helpers.mustache
+++ b/templates/ruby/search_helpers.mustache
@@ -1,3 +1,11 @@
+# Helper: Wait for a task to be published (completed) for a given `index_name` and `task_id`.
+#
+# @param index_name [String] the `index_name` where the operation was performed. (required)
+# @param task_id [Integer] the `task_id` returned in the method response. (required)
+# @param max_retries [Integer] the maximum number of retries. (optional, default to 50)
+# @param timeout [Proc] the function to decide how long to wait between retries. (optional)
+# @param request_options [Hash] the requestOptions to send along with the query, they will be forwarded to the `get_task` method.
+# @return [Http::Response] the last get_task response
 def wait_for_task(index_name, task_id, max_retries = 50, timeout = -> (retry_count) { [retry_count * 200, 5000].min }, request_options = {})
   retries = 0
   while retries < max_retries
@@ -11,6 +19,16 @@ def wait_for_task(index_name, task_id, max_retries = 50, timeout = -> (retry_cou
   raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
 end
 
+
+# Helper: Wait for an API key to be added, updated or deleted based on a given `operation`.
+#
+# @param operation [String] the `operation` that was done on a `key`.
+# @param key [String] the `key` that has been added, deleted or updated.
+# @param api_key [Hash] necessary to know if an `update` operation has been processed, compare fields of the response with it.
+# @param max_retries [Integer] the maximum number of retries.
+# @param timeout [Proc] the function to decide how long to wait between retries.
+# @param request_options [Hash] the requestOptions to send along with the query, they will be forwarded to the `getApikey` method and merged with the transporter requestOptions.
+# @return [Http::Response] the last get_api_key response
 def wait_for_api_key(operation, key, api_key = {}, max_retries = 50, timeout = -> (retry_count) { [retry_count * 200, 5000].min }, request_options = {})
   retries = 0
   if operation == 'update'

--- a/templates/ruby/search_helpers.mustache
+++ b/templates/ruby/search_helpers.mustache
@@ -1,0 +1,50 @@
+def wait_for_task(index_name, task_id, max_retries = 50, timeout = -> (retry_count) { [retry_count * 200, 5000].min }, request_options = {})
+  retries = 0
+  while retries < max_retries
+    res = get_task(index_name, task_id, request_options)
+    if res.status == 'published'
+      return res
+    end
+    retries += 1
+    sleep(timeout.call(retries) / 1000.0)
+  end
+  raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
+end
+
+def wait_for_api_key(operation, key, api_key = {}, max_retries = 50, timeout = -> (retry_count) { [retry_count * 200, 5000].min }, request_options = {})
+  retries = 0
+  if operation == 'update'
+    raise ArgumentError, '`api_key` is required when waiting for an `update` operation.' if api_key.nil?
+    while retries < max_retries
+      begin
+        updatad_key = get_api_key(key, request_options)
+        updated_key_hash = updatad_key.to_hash
+        equals = true
+        api_key.to_hash.each do |k, v|
+          equals &&= updated_key_hash[k] == v
+        end
+      
+        return updatad_key if equals
+      rescue AlgoliaError => e
+        raise e unless e.code == 404
+      end
+
+      retries += 1
+      sleep(timeout.call(retries) / 1000.0)
+    end
+  
+    raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
+  end
+
+  while retries < max_retries
+    begin
+      res = get_api_key(key, request_options)
+      return res if operation == 'add'
+    rescue AlgoliaError => e
+      return res if operation == 'delete' && e.code == 404
+    end
+    retries += 1
+    sleep(timeout.call(retries) / 1000.0)
+  end
+  raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
+end


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-1744](https://algolia.atlassian.net/browse/DI-1744)

First batch of helpers for ruby, with `wait_for_task` and `wait_for_api_key` !

[DI-1744]: https://algolia.atlassian.net/browse/DI-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ