### PR TITLE
chore(ci): use setup-gradle to handle cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,6 +33,8 @@ runs:
     - name: Setup gradle
       if: inputs.type != 'minimal'
       uses: gradle/actions/setup-gradle@v3
+      with:
+        cache-read-only: false
 
     - name: Download Java formatter
       if: inputs.type != 'minimal'
@@ -57,12 +59,6 @@ runs:
         path: ${{ steps.yarn-cache-dir.outputs.dir || '.yarn/cache' }}
         # let yarn handle the cache hash
         key: yarn-cache-${{ env.CACHE_VERSION }}
-
-    - name: Cache node modules
-      uses: actions/cache@v4
-      with:
-        path: node_modules
-        key: node-modules-${{ env.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
     - name: Install JavaScript dependencies
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,11 +25,14 @@ runs:
       with:
         distribution: zulu
         java-version-file: config/.java-version
-        cache: gradle
 
     - name: Validate gradle wrapper
       if: inputs.type != 'minimal'
       uses: gradle/wrapper-validation-action@v1
+
+    - name: Setup gradle
+      if: inputs.type != 'minimal'
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Download Java formatter
       if: inputs.type != 'minimal'
@@ -152,10 +155,8 @@ runs:
       if: ${{ inputs.language == 'kotlin' }}
       uses: actions/cache@v4
       with:
-        path: |
-          clients/algoliasearch-client-kotlin/.gradle
-          clients/algoliasearch-client-kotlin/client/build/spotless
-        key: gradle-${{ env.CACHE_VERSION }}-${{ hashFiles('clients/algoliasearch-client-kotlin/build.gradle.kts') }}
+        path: clients/algoliasearch-client-kotlin/client/build/spotless
+        key: spotless-${{ env.CACHE_VERSION }}-${{ hashFiles('clients/algoliasearch-client-kotlin/build.gradle.kts') }}
 
     # Dart
     - name: Install dart


### PR DESCRIPTION
## 🧭 What and Why

`setup-java` cache is a bit broken and takes more than 2 minutes in the `Post Setup` job to save to disk.
Using `setup-gradle` seems to be recommend, [here](https://github.com/gradle/gradle/issues/13510#issuecomment-1913366548) and [here](https://github.com/actions/setup-java/issues/588)