### PR TITLE
fix(cts): add test for _snippetResult

### DIFF
--- a/specs/common/schemas/HighlightResult.yml
+++ b/specs/common/schemas/HighlightResult.yml
@@ -41,10 +41,17 @@ highlightResultOptionMap:
   additionalProperties:
     $ref: '#/highlightResultOption'
 
+highlightResultArray:
+  type: array
+  description: Show highlighted section and words matched on a query.
+  items:
+    $ref: '#/highlightResultOption'
+
 highlightResult:
   oneOf:
     - $ref: '#/highlightResultOption'
     - $ref: '#/highlightResultOptionMap'
+    - $ref: '#/highlightResultArray'
 
 highlightResultMap:
   type: object

--- a/specs/common/schemas/HighlightResult.yml
+++ b/specs/common/schemas/HighlightResult.yml
@@ -2,10 +2,6 @@ highlightResultOption:
   type: object
   description: Show highlighted section and words matched on a query.
   additionalProperties: false
-  x-discriminator-fields:
-    - matchLevel
-    - value
-    - matchedWords
   properties:
     value:
       $ref: '#/highlightedValue'

--- a/specs/common/schemas/HighlightResult.yml
+++ b/specs/common/schemas/HighlightResult.yml
@@ -41,7 +41,7 @@ highlightResultOptionMap:
   additionalProperties:
     $ref: '#/highlightResultOption'
 
-highlightResultArray:
+highlightResultOptionArray:
   type: array
   description: Show highlighted section and words matched on a query.
   items:
@@ -51,7 +51,7 @@ highlightResult:
   oneOf:
     - $ref: '#/highlightResultOption'
     - $ref: '#/highlightResultOptionMap'
-    - $ref: '#/highlightResultArray'
+    - $ref: '#/highlightResultOptionArray'
 
 highlightResultMap:
   type: object

--- a/specs/common/schemas/SnippetResult.yml
+++ b/specs/common/schemas/SnippetResult.yml
@@ -17,7 +17,7 @@ snippetResultOptionMap:
   additionalProperties:
     $ref: '#/snippetResultOption'
 
-snippetResultArray:
+snippetResultOptionArray:
   type: array
   description: Snippeted attributes show parts of the matched attributes. Only returned when attributesToSnippet is non-empty.
   items:
@@ -27,7 +27,7 @@ snippetResult:
   oneOf:
     - $ref: '#/snippetResultOption'
     - $ref: '#/snippetResultOptionMap'
-    - $ref: '#/snippetResultArray'
+    - $ref: '#/snippetResultOptionArray'
 
 snippetResultMap:
   type: object

--- a/specs/common/schemas/SnippetResult.yml
+++ b/specs/common/schemas/SnippetResult.yml
@@ -17,10 +17,17 @@ snippetResultOptionMap:
   additionalProperties:
     $ref: '#/snippetResultOption'
 
+snippetResultArray:
+  type: array
+  description: Snippeted attributes show parts of the matched attributes. Only returned when attributesToSnippet is non-empty.
+  items:
+    $ref: '#/snippetResultOption'
+
 snippetResult:
   oneOf:
     - $ref: '#/snippetResultOption'
     - $ref: '#/snippetResultOptionMap'
+    - $ref: '#/snippetResultArray'
 
 snippetResultMap:
   type: object

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -302,7 +302,7 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 }
 
 {{#isAdditionalPropertiesTrue}}
-func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 {{#parent}}
 {{^isMap}}
 	type {{classname}}WithoutEmbeddedStruct struct {
@@ -377,9 +377,12 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#isMap}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
-	}
+  err := json.Unmarshal(bytes, &var{{{classname}}})
+  if err != nil {
+    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
+  }
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]any)
 
@@ -399,9 +402,12 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{^parent}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
-		*o = {{{classname}}}(var{{{classname}}})
-	}
+  err := json.Unmarshal(bytes, &var{{{classname}}})
+  if err != nil {
+    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
+  }
+
+	*o = {{{classname}}}(var{{{classname}}})
 
 	additionalProperties := make(map[string]any)
 
@@ -421,7 +427,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 {{/isAdditionalPropertiesTrue}}
 {{#isArray}}
-func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	return json.Unmarshal(bytes, &o.Items)
 }
 

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -472,7 +472,7 @@ public CompletableFuture<List<SearchForFacetValuesResponse>> searchForFacetsAsyn
     final SearchMethodParams params = new SearchMethodParams()
             .setRequests(searchQueries)
             .setStrategy(strategy);
-    return searchAsync(params, Object.class)
+    return searchAsync(params, Hit.class)
             .thenApply(searchResponses -> searchResponses
                     .getResults()
                     .stream()

--- a/templates/java/snippets/method.mustache
+++ b/templates/java/snippets/method.mustache
@@ -14,7 +14,7 @@ class Snippet{{client}} {
     {{client}} client = new {{client}}("YOUR_APP_ID", "YOUR_API_KEY"{{#hasRegionalHost}}, "YOUR_APP_ID_REGION"{{/hasRegionalHost}});
 
     // Call the API
-    client.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Object.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
+    client.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Hit.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
       {{#requestOptions.queryParameters.parametersWithDataType}}
         .addExtraQueryParameters("{{{key}}}", {{> tests/generateInnerParams}})
       {{/requestOptions.queryParameters.parametersWithDataType}}

--- a/templates/java/tests/requests/requests.mustache
+++ b/templates/java/tests/requests/requests.mustache
@@ -62,7 +62,7 @@ class {{client}}RequestsTests {
     @DisplayName("{{{testName}}}")
     void {{method}}Test{{testIndex}}() {
         assertDoesNotThrow(() -> {
-            client.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Object.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
+            client.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Hit.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
               {{#requestOptions.queryParameters.parametersWithDataType}}
                 .addExtraQueryParameters("{{{key}}}", {{> tests/generateInnerParams}})
               {{/requestOptions.queryParameters.parametersWithDataType}}
@@ -116,7 +116,7 @@ class {{client}}RequestsTests {
         {{/request}}
 
         {{#response}}
-        var res = clientE2E.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Object.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
+        var res = clientE2E.{{method}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#isGeneric}}, Hit.class{{/isGeneric}}{{#hasRequestOptions}}, new RequestOptions()
               {{#requestOptions.queryParameters.parametersWithDataType}}
                 .addExtraQueryParameters("{{{key}}}", {{> tests/generateInnerParams}})
               {{/requestOptions.queryParameters.parametersWithDataType}}

--- a/templates/javascript/tests/package.mustache
+++ b/templates/javascript/tests/package.mustache
@@ -2,7 +2,7 @@
   "name": "javascript-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "tsc && jest dist --passWithNoTests"
+    "test": "rm -rf dist || true && tsc && jest dist --passWithNoTests"
   },
   "dependencies": {
     {{#packageDependencies}}

--- a/tests/CTS/requests/search/searchSingleIndex.json
+++ b/tests/CTS/requests/search/searchSingleIndex.json
@@ -49,7 +49,7 @@
     "parameters": {
       "indexName": "cts_e2e_browse",
       "searchParams": {
-        "query": "batman",
+        "query": "batman mask of the phantasm",
         "attributesToRetrieve": [
           "*"
         ],
@@ -62,7 +62,7 @@
       "path": "/1/indexes/cts_e2e_browse/query",
       "method": "POST",
       "body": {
-        "query": "batman",
+        "query": "batman mask of the phantasm",
         "attributesToRetrieve": [
           "*"
         ],
@@ -74,30 +74,49 @@
     "response": {
       "statusCode": 200,
       "body": {
+        "nbHits": 1,
         "hits": [
           {
             "_snippetResult": {
               "genres": [
                 {
+                  "value": "Animated",
+                  "matchLevel": "none"
+                },
+                {
                   "value": "Superhero",
+                  "matchLevel": "none"
+                },
+                {
+                  "value": "Romance",
                   "matchLevel": "none"
                 }
               ],
               "year": {
-                "value": "1964",
+                "value": "1993",
                 "matchLevel": "none"
               }
             },
             "_highlightResult": {
               "genres": [
                 {
+                  "value": "Animated",
+                  "matchLevel": "none",
+                  "matchedWords": []
+                },
+                {
                   "value": "Superhero",
+                  "matchLevel": "none",
+                  "matchedWords": []
+                },
+                {
+                  "value": "Romance",
                   "matchLevel": "none",
                   "matchedWords": []
                 }
               ],
               "year": {
-                "value": "1964",
+                "value": "1993",
                 "matchLevel": "none",
                 "matchedWords": []
               }

--- a/tests/CTS/requests/search/searchSingleIndex.json
+++ b/tests/CTS/requests/search/searchSingleIndex.json
@@ -43,5 +43,50 @@
         ]
       }
     }
+  },
+  {
+    "testName": "single search retrieve snippets",
+    "parameters": {
+      "indexName": "cts_e2e_browse",
+      "searchParams": {
+        "query": "batman",
+        "attributesToRetrieve": [
+          "*"
+        ],
+        "attributesToSnippet": [
+          "*:20"
+        ]
+      }
+    },
+    "request": {
+      "path": "/1/indexes/cts_e2e_browse/query",
+      "method": "POST",
+      "body": {
+        "query": "batman",
+        "attributesToRetrieve": [
+          "*"
+        ],
+        "attributesToSnippet": [
+          "*:20"
+        ]
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "hits": [
+          {
+            "_snippetResult": {
+              "genres": [
+                {
+                  "value": "Superhero",
+                  "matchLevel": "none"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
   }
 ]

--- a/tests/CTS/requests/search/searchSingleIndex.json
+++ b/tests/CTS/requests/search/searchSingleIndex.json
@@ -83,6 +83,15 @@
                   "matchLevel": "none"
                 }
               ]
+            },
+            "_highlightResult": {
+              "genres": [
+                {
+                  "value": "Superhero",
+                  "matchLevel": "none",
+                  "matchedWords": []
+                }
+              ]
             }
           }
         ]

--- a/tests/CTS/requests/search/searchSingleIndex.json
+++ b/tests/CTS/requests/search/searchSingleIndex.json
@@ -82,7 +82,11 @@
                   "value": "Superhero",
                   "matchLevel": "none"
                 }
-              ]
+              ],
+              "year": {
+                "value": "1964",
+                "matchLevel": "none"
+              }
             },
             "_highlightResult": {
               "genres": [
@@ -91,7 +95,12 @@
                   "matchLevel": "none",
                   "matchedWords": []
                 }
-              ]
+              ],
+              "year": {
+                "value": "1964",
+                "matchLevel": "none",
+                "matchedWords": []
+              }
             }
           }
         ]


### PR DESCRIPTION
## 🧭 What and Why

[DI-1797](https://algolia.atlassian.net/browse/DI-1797)

Snippet results can be an array sometimes ! This tests ensure that we can deserialize it properly.
Also applies to highlight result

[DI-1797]: https://algolia.atlassian.net/browse/DI-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ