### PR TITLE
fix(php): revert restriction for psr/http-message dependency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -345,8 +345,12 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: yarn cli generate ${{ matrix.client.language }} ${{ matrix.client.toRun }}
 
+      - name: Update composer.lock
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language == 'php' && startsWith(env.head_ref, 'chore/renovateBaseBranch') }}
+        run: cd ${{ matrix.client.path }} && composer update
+
       - name: Build clients
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && matrix.client.language != 'php' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: ${{ matrix.client.buildCommand }}
 
       - name: Run Java 'algoliasearch' public API validation

--- a/clients/algoliasearch-client-php/composer.lock
+++ b/clients/algoliasearch-client-php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7932c987f86b81f42e13a14ba077535",
+    "content-hash": "8655a3535dbee9564b28f425c5ce61cb",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -1628,16 +1628,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.0.2",
+            "version": "11.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e"
+                "reference": "de24e7e7c67fbf437f7b6cd7bc919f2dc6fd89d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
-                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de24e7e7c67fbf437f7b6cd7bc919f2dc6fd89d4",
+                "reference": "de24e7e7c67fbf437f7b6cd7bc919f2dc6fd89d4",
                 "shasum": ""
             },
             "require": {
@@ -1708,7 +1708,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.3"
             },
             "funding": [
                 {
@@ -1724,7 +1724,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-04T09:09:14+00:00"
+            "time": "2024-02-10T06:31:16+00:00"
         },
         {
             "name": "psr/cache",

--- a/templates/php/composer.mustache
+++ b/templates/php/composer.mustache
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/psr7": "^2.0",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: DI-1822

### Changes included:

Following the feedback from the Magento team, we want to rollback the `psr/http-message` dependency by including the 1.1 version to allow them to use the generated PHP client in Magento. 
