### PR TITLE
fix(kotlin): return `replaceAllObjects`'s intermediate operations 

### DIFF
--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/extensions/SearchClient.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/extensions/SearchClient.kt
@@ -263,8 +263,8 @@ public suspend fun <T> SearchClient.replaceAllObjects(
   serializer: KSerializer<T>,
   records: List<T>,
   requestOptions: RequestOptions?,
-): Map<String, Long> {
-  if (records.isEmpty()) return emptyMap()
+): List<Long> {
+  if (records.isEmpty()) return emptyList()
 
   val requests = records.map { record ->
     val body = options.json.encodeToJsonElement(serializer, record).jsonObject
@@ -301,11 +301,7 @@ public suspend fun <T> SearchClient.replaceAllObjects(
   waitTask(indexName = destinationIndex, taskID = move.taskID)
 
   // 4. Return the list of operations
-  return mapOf(
-    indexName to copy.taskID,
-    destinationIndex to batch.taskID,
-    destinationIndex to move.taskID,
-  )
+  return listOf(copy.taskID, batch.taskID, move.taskID)
 }
 
 /**


### PR DESCRIPTION
## 🧭 What and Why

Simplify the return type to return the list of operations.

### Changes included:

Return the list of intermediate task IDs.
