### PR TITLE
fix(clients): add e2e tests for analytics API

### DIFF
--- a/tests/CTS/requests/analytics/getTopSearches.json
+++ b/tests/CTS/requests/analytics/getTopSearches.json
@@ -40,5 +40,29 @@
         "tags": "tag"
       }
     }
+  },
+  {
+    "testName": "e2e with complex query params",
+    "parameters": {
+      "index": "cts_e2e_space in index"
+    },
+    "request": {
+      "path": "/2/searches",
+      "method": "GET",
+      "queryParameters": {
+        "index": "cts_e2e_space%20in%20index"
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "searches": [
+          {
+            "search": "",
+            "nbHits": 0
+          }
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
## 🧭 What and Why

Simple e2e to make sure the analytics API is called correctly, and that query params encoding is working properly.


Note: the scope of the PR is not very correct but it's just to trigger a release of all languages.