### PR TITLE
fix(clients): browse synonyms page not in response

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/ClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/ClientExtensions.cs
@@ -236,7 +236,7 @@ public static class ClientExtensions
     RequestOptions requestOptions = null)
   {
     const int hitsPerPage = 1000;
-    var int page = synonymsParams.Page ?? 0;
+    var page = synonymsParams.Page ?? 0;
     synonymsParams.HitsPerPage = hitsPerPage;
     var all = await CreateIterable<Tuple<SearchSynonymsResponse, int>>(async (prevResp) =>
     {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/ClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/ClientExtensions.cs
@@ -236,12 +236,13 @@ public static class ClientExtensions
     RequestOptions requestOptions = null)
   {
     const int hitsPerPage = 1000;
+    var int page = synonymsParams.Page ?? 0;
     synonymsParams.HitsPerPage = hitsPerPage;
     var all = await CreateIterable<Tuple<SearchSynonymsResponse, int>>(async (prevResp) =>
     {
-      synonymsParams.Page = prevResp?.Item2 ?? 0;
       var searchSynonymsResponse = await client.SearchSynonymsAsync(indexName, synonymsParams, requestOptions);
-      return new Tuple<SearchSynonymsResponse, int>(searchSynonymsResponse, (prevResp?.Item2 ?? 0) + 1);
+      page = page + 1;
+      return new Tuple<SearchSynonymsResponse, int>(searchSynonymsResponse, page);
     }, resp => resp?.Item1 is { NbHits: < hitsPerPage }).ConfigureAwait(false);
 
     return all.SelectMany(u => u.Item1.Hits);

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -2,9 +2,6 @@ from asyncio import run
 from os import environ
 
 from algoliasearch.search.client import SearchClient
-from algoliasearch.search.models.search_method_params import SearchMethodParams
-from algoliasearch.search.models.search_for_hits import SearchForHits
-from algoliasearch.search.models.search_query import SearchQuery
 from algoliasearch.search import __version__
 from dotenv import load_dotenv
 
@@ -18,16 +15,9 @@ async def main():
     print("client initialized", client)
 
     try:
-        response = await client.search(
-            search_method_params=SearchMethodParams(
-                requests=[
-                    SearchQuery(SearchForHits(index_name="cts_e2e_search_facet")),
-                ],
-            ),
-        )
+        resp = await client.browse_synonyms(index_name="test-flag", aggregator=lambda _resp: print(_resp))
 
-        print("client response")
-        print(response.to_json())
+        print(resp)
     finally:
         await client.close()
 

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -214,7 +214,7 @@ browseSynonyms(
   };
 
   return createIterablePromise<SearchSynonymsResponse>({
-    func: (previousResponse) => {
+    func: (_) => {
       const resp = this.searchSynonyms(
         {
           indexName,
@@ -226,6 +226,7 @@ browseSynonyms(
         requestOptions
       );
       params.page += 1;
+      return resp;
     },
     validate: (response) => response.nbHits < params.hitsPerPage,
     ...browseSynonymsOptions,

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -215,18 +215,17 @@ browseSynonyms(
 
   return createIterablePromise<SearchSynonymsResponse>({
     func: (previousResponse) => {
-      return this.searchSynonyms(
+      const resp = this.searchSynonyms(
         {
           indexName,
           searchSynonymsParams: {
             ...params,
-            page: previousResponse
-              ? previousResponse.page + 1
-              : params.page,
+            page: params.page,
           },
         },
         requestOptions
       );
+      params.page += 1;
     },
     validate: (response) => response.nbHits < params.hitsPerPage,
     ...browseSynonymsOptions,

--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -135,24 +135,25 @@
     async def browse_synonyms(
         self,
         index_name: str,
-        aggregator: Optional[Callable[[SearchSynonymsResponse], None]],
+        aggregator: Callable[[SearchSynonymsResponse], None],
         search_synonyms_params: Optional[SearchSynonymsParams] = SearchSynonymsParams(),
         request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> SearchSynonymsResponse:
         """
         Helper: Iterate on the `search_synonyms` method of the client to allow aggregating synonyms of an index.
         """
-        search_synonyms_params.page = 0
+        if search_synonyms_params.page is None:
+            search_synonyms_params.page = 0
         search_synonyms_params.hits_per_page = 1000
 
         async def _func(_prev: SearchRulesResponse) -> SearchRulesResponse:
-            if _prev is not None:
-                search_synonyms_params.page = _prev.page + 1
-            return await self.search_synonyms(
+            resp = await self.search_synonyms(
                 index_name=index_name,
                 search_synonyms_params=search_synonyms_params,
                 request_options=request_options,
             )
+            search_synonyms_params.page += 1
+            return resp
         return await create_iterable(
             func=_func,
             validate=lambda _resp: _resp.nb_hits < search_synonyms_params.hits_per_page,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

Catched by fluffman the page parameter doesn't exist in the synonyms response