### PR TITLE
feat(specs): add source samples specs

### DIFF
--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -387,3 +387,7 @@ SourceUpdateInput:
 DockerSourceStream:
   type: object
   description: A stream definition (see the Singer specification for details).
+
+SourceSample:
+  type: object
+  description: A source sample is a sample of the data that can be fetched from a source.

--- a/specs/ingestion/common/sourceSamplesParameters.yml
+++ b/specs/ingestion/common/sourceSamplesParameters.yml
@@ -1,0 +1,18 @@
+limit:
+  name: limit
+  description: The maximum number of samples to return.
+  in: query
+  required: false
+  schema:
+    type: integer
+    minimum: 1
+    example: 2
+
+filter:
+  name: filter
+  description: The filter expression to apply to the list of samples. Should be in the format `key = value`.
+  in: query
+  required: false
+  schema:
+    type: string
+    example: event_name = "add_to_cart"

--- a/specs/ingestion/paths/sources/samples.yml
+++ b/specs/ingestion/paths/sources/samples.yml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - sources
+  summary: Get a list of source samples.
+  description: Get a list of source samples for the given sourceID and query parameters.
+  operationId: getSourceSamples
+  x-acl:
+    - addObject
+    - deleteIndex
+    - editSettings
+  parameters:
+    - $ref: '../../common/parameters.yml#/pathSourceID'
+    - $ref: '../../common/sourceSamplesParameters.yml#/filter'
+    - $ref: '../../common/sourceSamplesParameters.yml#/limit'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            title: listSourceSamplesResponse
+            type: object
+            additionalProperties: false
+            properties:
+              samples:
+                type: array
+                items:
+                  $ref: '../../common/schemas/source.yml#/SourceSample'
+            required:
+              - samples
+    '400':
+      $ref: '../../../common/responses/BadRequest.yml'

--- a/specs/ingestion/spec.yml
+++ b/specs/ingestion/spec.yml
@@ -68,6 +68,8 @@ paths:
     $ref: 'paths/sources/sourceID.yml'
   /1/sources/{sourceID}/discover:
     $ref: 'paths/sources/discover.yml'
+  /1/sources/{sourceID}/samples:
+    $ref: 'paths/sources/samples.yml'
 
   # tasks API.
   /1/tasks:


### PR DESCRIPTION
## 🧭 What and Why

Add specs for `/samples` endpoint for GA Connector mapping UI in the dashboard.

🎟 JIRA Ticket:

[EEX-976](https://algolia.atlassian.net/browse/EEX-976)

### Changes included:

- Add `/1/sources/{sourceID}/samples` path
- Add `limit` and `filter` parameters
- Add `SourceSample` type

## 🧪 Test


[EEX-976]: https://algolia.atlassian.net/browse/EEX-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ