### PR TITLE
fix(cts): remove flaky monitoring tests

### DIFF
--- a/tests/CTS/requests/monitoring/getInventory.json
+++ b/tests/CTS/requests/monitoring/getInventory.json
@@ -5,37 +5,6 @@
     "request": {
       "path": "/1/inventory/servers",
       "method": "GET"
-    },
-    "response": {
-      "statusCode": 200,
-      "body": {
-        "inventory": [
-          {
-            "name": "c30-use-3",
-            "region": "use",
-            "is_replica": false,
-            "cluster": "c30-use",
-            "status": "PRODUCTION",
-            "type": "cluster"
-          },
-          {
-            "name": "c30-use-2",
-            "region": "use",
-            "is_replica": false,
-            "cluster": "c30-use",
-            "status": "PRODUCTION",
-            "type": "cluster"
-          },
-          {
-            "name": "c30-use-1",
-            "region": "use",
-            "is_replica": false,
-            "cluster": "c30-use",
-            "status": "PRODUCTION",
-            "type": "cluster"
-          }
-        ]
-      }
     }
   }
 ]

--- a/tests/CTS/requests/monitoring/getStatus.json
+++ b/tests/CTS/requests/monitoring/getStatus.json
@@ -5,14 +5,6 @@
     "request": {
       "path": "/1/status",
       "method": "GET"
-    },
-    "response": {
-      "statusCode": 200,
-      "body": {
-        "status": {
-          "c30-use": "operational"
-        }
-      }
     }
   }
 ]


### PR DESCRIPTION
## 🧭 What and Why

The monitoring API seems to be very slow for us, and return a lot of Connection timeout which makes the CTS flaky, the easiest solution is to remove the test.