### PR TITLE
fix(javascript): allow `batchSize` on `ReplaceAllObjectsOptions`

### DIFF
--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -153,11 +153,6 @@ export type ChunkedBatchOptions = ReplaceAllObjectsOptions & {
    * Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
    */
   waitForTasks?: boolean;
-
-  /**
-   * The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
-   */
-  batchSize?: number;
 }
 
 export type ReplaceAllObjectsOptions = {
@@ -170,6 +165,11 @@ export type ReplaceAllObjectsOptions = {
    * The array of `objects` to store in the given Algolia `indexName`.
    */
   objects: Array<Record<string, any>>;
+
+  /**
+   * The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
+   */
+  batchSize?: number;
 }
 
 export type ReplaceAllObjectsResponse = {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

the automerge merged before I fix, this option should be available on both method not just the chunked one