### PR TITLE
chore: run all gen on main

### DIFF
--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -18,7 +18,8 @@ const EMPTY_MATRIX = { client: ['no-run'] };
 
 async function createClientMatrix(baseBranch: string): Promise<void> {
   const matrix: Record<string, ToRunMatrix> = {};
-  const commonDependenciesChanged = await isBaseChanged(baseBranch, COMMON_DEPENDENCIES);
+  const commonDependenciesChanged =
+    baseBranch === 'main' || (await isBaseChanged(baseBranch, COMMON_DEPENDENCIES));
 
   // iterate over every generators to see what changed
   for (const { language, client, output } of Object.values(GENERATORS)) {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

CI failed multiple times on `main` but the last commit merged will only trigger the JavaScript client to run. We should make `main` run every steps of the gen so that we know it's always the most up to date version.