### PR TITLE
refactor(csharp): move client search extensions to instance method

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -5,61 +5,50 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
 using Algolia.Search.Http;
-using Algolia.Search.Models.Common;
 using Algolia.Search.Models.Search;
+using Algolia.Search.Utils;
 using Action = Algolia.Search.Models.Search.Action;
 
-namespace Algolia.Search.Utils;
+namespace Algolia.Search.Clients;
 
-/// <summary>
-/// A tool class to help with common tasks
-/// </summary>
-public static class ClientExtensions
+public partial class SearchClient
 {
   private const int DefaultMaxRetries = 50;
 
   /// <summary>
   /// Wait for a task to complete with `indexName` and `taskID`.
   /// </summary>
-  /// <param name="client">Algolia Search Client instance</param>
   /// <param name="indexName">The `indexName` where the operation was performed.</param>
   /// <param name="taskId">The `taskID` returned in the method response.</param>
   /// <param name="maxRetries">The maximum number of retry. 50 by default. (optional)</param>
   /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
   /// <param name="ct">Cancellation token (optional)</param>
-  public static async Task<GetTaskResponse> WaitForTaskAsync(this SearchClient client, string indexName, long taskId,
-    int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null, RequestOptions requestOptions = null,
-    CancellationToken ct = default)
+  public async Task<GetTaskResponse> WaitForTaskAsync(string indexName, long taskId, int maxRetries = DefaultMaxRetries,
+    Func<int, int> timeout = null, RequestOptions requestOptions = null, CancellationToken ct = default)
   {
-    return await RetryUntil(
-      async () => await client.GetTaskAsync(indexName, taskId, requestOptions, ct),
+    return await RetryUntil(async () => await GetTaskAsync(indexName, taskId, requestOptions, ct),
       resp => resp.Status == Models.Search.TaskStatus.Published, maxRetries, timeout, ct).ConfigureAwait(false);
   }
 
   /// <summary>
   /// Wait for a task to complete with `indexName` and `taskID`. (Synchronous version)
   /// </summary>
-  /// <param name="client">Algolia Search Client instance</param>
   /// <param name="indexName">The `indexName` where the operation was performed.</param>
   /// <param name="taskId">The `taskID` returned in the method response.</param>
   /// <param name="maxRetries">The maximum number of retry. 50 by default. (optional)</param>
   /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
   /// <param name="ct">Cancellation token (optional)</param>
-  public static GetTaskResponse WaitForTask(this SearchClient client, string indexName, long taskId,
-    int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null, RequestOptions requestOptions = null,
-    CancellationToken ct = default) =>
-    AsyncHelper.RunSync(() =>
-      client.WaitForTaskAsync(indexName, taskId, maxRetries, timeout, requestOptions, ct));
+  public GetTaskResponse WaitForTask(string indexName, long taskId, int maxRetries = DefaultMaxRetries,
+    Func<int, int> timeout = null, RequestOptions requestOptions = null, CancellationToken ct = default) =>
+    AsyncHelper.RunSync(() => WaitForTaskAsync(indexName, taskId, maxRetries, timeout, requestOptions, ct));
 
   /// <summary>
   /// Helper method that waits for an API key task to be processed.
   /// </summary>
-  /// <param name="client">Algolia Search Client instance</param>
   /// <param name="operation">The `operation` that was done on a `key`.</param>
   /// <param name="key">The key that has been added, deleted or updated.</param>
   /// <param name="apiKey">Necessary to know if an `update` operation has been processed, compare fields of the response with it. (optional - mandatory if operation is UPDATE)</param>
@@ -67,11 +56,9 @@ public static class ClientExtensions
   /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
   /// <param name="ct">Cancellation token (optional)</param>
-  public static async Task<GetApiKeyResponse> WaitForApiKeyAsync(this SearchClient client,
-    ApiKeyOperation operation, string key,
+  public async Task<GetApiKeyResponse> WaitForApiKeyAsync(ApiKeyOperation operation, string key,
     ApiKey apiKey = default, int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null,
-    RequestOptions requestOptions = null,
-    CancellationToken ct = default)
+    RequestOptions requestOptions = null, CancellationToken ct = default)
   {
     if (operation == ApiKeyOperation.Update)
     {
@@ -80,7 +67,7 @@ public static class ClientExtensions
         throw new AlgoliaException("`ApiKey` is required when waiting for an `update` operation.");
       }
 
-      return await RetryUntil(() => client.GetApiKeyAsync(key, requestOptions, ct),
+      return await RetryUntil(() => GetApiKeyAsync(key, requestOptions, ct),
         resp =>
         {
           var apiKeyResponse = new ApiKey
@@ -105,7 +92,7 @@ public static class ClientExtensions
       {
         try
         {
-          addedKey = await client.GetApiKeyAsync(key, requestOptions, ct).ConfigureAwait(false);
+          addedKey = await GetApiKeyAsync(key, requestOptions, ct).ConfigureAwait(false);
           // magic number to signify we found the key
           return -2;
         }
@@ -133,7 +120,6 @@ public static class ClientExtensions
   /// <summary>
   /// Helper method that waits for an API key task to be processed. (Synchronous version)
   /// </summary>
-  /// <param name="client">Algolia Search Client instance</param>
   /// <param name="operation">The `operation` that was done on a `key`.</param>
   /// <param name="key">The key that has been added, deleted or updated.</param>
   /// <param name="apiKey">Necessary to know if an `update` operation has been processed, compare fields of the response with it. (optional - mandatory if operation is UPDATE)</param>
@@ -141,32 +127,27 @@ public static class ClientExtensions
   /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
   /// <param name="ct">Cancellation token (optional)</param>
-  public static GetApiKeyResponse WaitForApiKey(this SearchClient client,
-    ApiKeyOperation operation, string key,
-    ApiKey apiKey = default, int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null,
-    RequestOptions requestOptions = null,
+  public GetApiKeyResponse WaitForApiKey(ApiKeyOperation operation, string key, ApiKey apiKey = default,
+    int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null, RequestOptions requestOptions = null,
     CancellationToken ct = default) =>
-    AsyncHelper.RunSync(
-      () => client.WaitForApiKeyAsync(operation, key, apiKey, maxRetries, timeout, requestOptions, ct));
+    AsyncHelper.RunSync(() => WaitForApiKeyAsync(operation, key, apiKey, maxRetries, timeout, requestOptions, ct));
 
 
   /// <summary>
   /// Iterate on the `browse` method of the client to allow aggregating objects of an index.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="browseParams">The `browse` parameters.</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `browse` method and merged with the transporter requestOptions.</param>
   /// <typeparam name="T">The model of the record</typeparam>
-  public static async Task<IEnumerable<T>> BrowseObjectsAsync<T>(this SearchClient client, string indexName,
-    BrowseParamsObject browseParams,
+  public async Task<IEnumerable<T>> BrowseObjectsAsync<T>(string indexName, BrowseParamsObject browseParams,
     RequestOptions requestOptions = null)
   {
     browseParams.HitsPerPage = 1000;
     var all = await CreateIterable<BrowseResponse<T>>(async prevResp =>
     {
       browseParams.Cursor = prevResp?.Cursor;
-      return await client.BrowseAsync<T>(indexName, new BrowseParams(browseParams), requestOptions);
+      return await BrowseAsync<T>(indexName, new BrowseParams(browseParams), requestOptions);
     }, resp => resp is { Cursor: null }).ConfigureAwait(false);
 
     return all.SelectMany(u => u.Hits);
@@ -176,26 +157,22 @@ public static class ClientExtensions
   /// <summary>
   /// Iterate on the `browse` method of the client to allow aggregating objects of an index. (Synchronous version)
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="browseParams">The `browse` parameters.</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `browse` method and merged with the transporter requestOptions.</param>
   /// <typeparam name="T">The model of the record</typeparam>
-  public static IEnumerable<T> BrowseObjects<T>(this SearchClient client, string indexName,
-    BrowseParamsObject browseParams,
+  public IEnumerable<T> BrowseObjects<T>(string indexName, BrowseParamsObject browseParams,
     RequestOptions requestOptions = null) =>
-    AsyncHelper.RunSync(() => client.BrowseObjectsAsync<T>(indexName, browseParams, requestOptions));
+    AsyncHelper.RunSync(() => BrowseObjectsAsync<T>(indexName, browseParams, requestOptions));
 
 
   /// <summary>
   /// Iterate on the `SearchRules` method of the client to allow aggregating rules of an index.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="searchRulesParams">The `SearchRules` parameters</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `searchRules` method and merged with the transporter requestOptions.</param>
-  public static async Task<IEnumerable<Rule>> BrowseRulesAsync(this SearchClient client, string indexName,
-    SearchRulesParams searchRulesParams,
+  public async Task<IEnumerable<Rule>> BrowseRulesAsync(string indexName, SearchRulesParams searchRulesParams,
     RequestOptions requestOptions = null)
   {
     const int hitsPerPage = 1000;
@@ -204,7 +181,7 @@ public static class ClientExtensions
     var all = await CreateIterable<Tuple<SearchRulesResponse, int>>(async (prevResp) =>
     {
       var page = prevResp?.Item2 ?? 0;
-      var searchSynonymsResponse = await client.SearchRulesAsync(indexName, searchRulesParams, requestOptions);
+      var searchSynonymsResponse = await SearchRulesAsync(indexName, searchRulesParams, requestOptions);
       return new Tuple<SearchRulesResponse, int>(searchSynonymsResponse, page + 1);
     }, resp => resp?.Item1 is { NbHits: < hitsPerPage }).ConfigureAwait(false);
 
@@ -214,25 +191,21 @@ public static class ClientExtensions
   /// <summary>
   /// Iterate on the `SearchRules` method of the client to allow aggregating rules of an index. (Synchronous version)
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="searchRulesParams">The `SearchRules` parameters</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `searchRules` method and merged with the transporter requestOptions.</param>
-  public static IEnumerable<Rule> BrowseRules(this SearchClient client, string indexName,
-    SearchRulesParams searchRulesParams,
+  public IEnumerable<Rule> BrowseRules(string indexName, SearchRulesParams searchRulesParams,
     RequestOptions requestOptions = null) =>
-    AsyncHelper.RunSync(() => client.BrowseRulesAsync(indexName, searchRulesParams, requestOptions));
+    AsyncHelper.RunSync(() => BrowseRulesAsync(indexName, searchRulesParams, requestOptions));
 
 
   /// <summary>
   /// Iterate on the `SearchSynonyms` method of the client to allow aggregating rules of an index.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="synonymsParams">The `SearchSynonyms` parameters.</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `searchSynonyms` method and merged with the transporter requestOptions.</param>
-  public static async Task<IEnumerable<SynonymHit>> BrowseSynonymsAsync(this SearchClient client, string indexName,
-    SearchSynonymsParams synonymsParams,
+  public async Task<IEnumerable<SynonymHit>> BrowseSynonymsAsync(string indexName, SearchSynonymsParams synonymsParams,
     RequestOptions requestOptions = null)
   {
     const int hitsPerPage = 1000;
@@ -240,7 +213,7 @@ public static class ClientExtensions
     synonymsParams.HitsPerPage = hitsPerPage;
     var all = await CreateIterable<Tuple<SearchSynonymsResponse, int>>(async (prevResp) =>
     {
-      var searchSynonymsResponse = await client.SearchSynonymsAsync(indexName, synonymsParams, requestOptions);
+      var searchSynonymsResponse = await SearchSynonymsAsync(indexName, synonymsParams, requestOptions);
       page = page + 1;
       return new Tuple<SearchSynonymsResponse, int>(searchSynonymsResponse, page);
     }, resp => resp?.Item1 is { NbHits: < hitsPerPage }).ConfigureAwait(false);
@@ -251,24 +224,20 @@ public static class ClientExtensions
   /// <summary>
   /// Iterate on the `SearchSynonyms` method of the client to allow aggregating rules of an index. (Synchronous version)
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="synonymsParams">The `SearchSynonyms` parameters.</param>
   /// <param name="requestOptions">The requestOptions to send along with the query, they will be forwarded to the `searchSynonyms` method and merged with the transporter requestOptions.</param>
-  public static IEnumerable<SynonymHit> BrowseSynonyms(this SearchClient client, string indexName,
-    SearchSynonymsParams synonymsParams,
+  public IEnumerable<SynonymHit> BrowseSynonyms(string indexName, SearchSynonymsParams synonymsParams,
     RequestOptions requestOptions = null) =>
-    AsyncHelper.RunSync(() => client.BrowseSynonymsAsync(indexName, synonymsParams, requestOptions));
+    AsyncHelper.RunSync(() => BrowseSynonymsAsync(indexName, synonymsParams, requestOptions));
 
   /// <summary>
   /// Generate a virtual API Key without any call to the server.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="parentApiKey">Parent API Key</param>
   /// <param name="restriction">Restriction to add the key</param>
   /// <returns></returns>
-  public static string GenerateSecuredApiKey(this SearchClient client, string parentApiKey,
-    SecuredAPIKeyRestrictions restriction)
+  public string GenerateSecuredApiKey(string parentApiKey, SecuredAPIKeyRestrictions restriction)
   {
     var queryParams = restriction.ToQueryString();
     var hash = HmacShaHelper.GetHash(parentApiKey, queryParams);
@@ -279,12 +248,11 @@ public static class ClientExtensions
   /// <summary>
   ///  Get the remaining validity of a key generated by `GenerateSecuredApiKeys`.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="securedAPIKey">The secured API Key</param>
   /// <returns></returns>
   /// <exception cref="ArgumentNullException"></exception>
   /// <exception cref="AlgoliaException"></exception>
-  public static TimeSpan GetSecuredApiKeyRemainingValidity(this SearchClient client, string securedAPIKey)
+  public TimeSpan GetSecuredApiKeyRemainingValidity(string securedAPIKey)
   {
     if (string.IsNullOrWhiteSpace(securedAPIKey))
     {
@@ -317,7 +285,6 @@ public static class ClientExtensions
   /// <summary>
   /// Executes a synchronous search for the provided search requests, with certainty that we will only request Algolia records (hits). Results will be received in the same order as the queries.
   /// </summary>
-  /// <param name="client">Search client</param>
   /// <param name="requests">A list of search requests to be executed.</param>
   /// <param name="searchStrategy">The search strategy to be employed during the search. (optional)</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
@@ -326,20 +293,18 @@ public static class ClientExtensions
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
   /// <returns>Task of List{SearchResponse{T}}</returns>
-  public static async Task<List<SearchResponse<T>>> SearchForHitsAsync<T>(this SearchClient client,
-    IEnumerable<SearchForHits> requests, SearchStrategy? searchStrategy = null, RequestOptions options = null,
-    CancellationToken cancellationToken = default)
+  public async Task<List<SearchResponse<T>>> SearchForHitsAsync<T>(IEnumerable<SearchForHits> requests,
+    SearchStrategy? searchStrategy = null, RequestOptions options = null, CancellationToken cancellationToken = default)
   {
     var queries = requests.Select(t => new SearchQuery(t)).ToList();
     var searchMethod = new SearchMethodParams(queries) { Strategy = searchStrategy };
-    var searchResponses = await client.SearchAsync<T>(searchMethod, options, cancellationToken);
+    var searchResponses = await SearchAsync<T>(searchMethod, options, cancellationToken);
     return searchResponses.Results.Where(x => x.IsSearchResponse()).Select(x => x.AsSearchResponse()).ToList();
   }
 
   /// <summary>
   /// Executes a synchronous search for the provided search requests, with certainty that we will only request Algolia records (hits). Results will be received in the same order as the queries. (Synchronous version)
   /// </summary>
-  /// <param name="client">Search client</param>
   /// <param name="requests">A list of search requests to be executed.</param>
   /// <param name="searchStrategy">The search strategy to be employed during the search. (optional)</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
@@ -348,17 +313,16 @@ public static class ClientExtensions
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
   /// <returns>Task of List{SearchResponse{T}}</returns>
-  public static List<SearchResponse<T>> SearchForHits<T>(this SearchClient client,
-    IEnumerable<SearchForHits> requests, SearchStrategy? searchStrategy = null, RequestOptions options = null,
+  public List<SearchResponse<T>> SearchForHits<T>(IEnumerable<SearchForHits> requests,
+    SearchStrategy? searchStrategy = null, RequestOptions options = null,
     CancellationToken cancellationToken = default) =>
     AsyncHelper.RunSync(() =>
-      client.SearchForHitsAsync<T>(requests, searchStrategy, options, cancellationToken));
+      SearchForHitsAsync<T>(requests, searchStrategy, options, cancellationToken));
 
 
   /// <summary>
   /// Executes a synchronous search for the provided search requests, with certainty that we will only request Algolia facets. Results will be received in the same order as the queries.
   /// </summary>
-  /// <param name="client">Search client</param>
   /// <param name="requests">A list of search requests to be executed.</param>
   /// <param name="searchStrategy">The search strategy to be employed during the search. (optional)</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
@@ -367,13 +331,12 @@ public static class ClientExtensions
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
   /// <returns>Task of List{SearchResponse{T}}</returns>
-  public static async Task<List<SearchForFacetValuesResponse>> SearchForFacetsAsync(this SearchClient client,
-    IEnumerable<SearchForFacets> requests, SearchStrategy? searchStrategy, RequestOptions options = null,
-    CancellationToken cancellationToken = default)
+  public async Task<List<SearchForFacetValuesResponse>> SearchForFacetsAsync(IEnumerable<SearchForFacets> requests,
+    SearchStrategy? searchStrategy, RequestOptions options = null, CancellationToken cancellationToken = default)
   {
     var queries = requests.Select(t => new SearchQuery(t)).ToList();
     var searchMethod = new SearchMethodParams(queries) { Strategy = searchStrategy };
-    var searchResponses = await client.SearchAsync<object>(searchMethod, options, cancellationToken);
+    var searchResponses = await SearchAsync<object>(searchMethod, options, cancellationToken);
     return searchResponses.Results.Where(x => x.IsSearchForFacetValuesResponse())
       .Select(x => x.AsSearchForFacetValuesResponse()).ToList();
   }
@@ -381,7 +344,6 @@ public static class ClientExtensions
   /// <summary>
   /// Executes a synchronous search for the provided search requests, with certainty that we will only request Algolia facets. Results will be received in the same order as the queries.
   /// </summary>
-  /// <param name="client">Search client</param>
   /// <param name="requests">A list of search requests to be executed.</param>
   /// <param name="searchStrategy">The search strategy to be employed during the search. (optional)</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
@@ -390,10 +352,9 @@ public static class ClientExtensions
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
   /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
   /// <returns>Task of List{SearchResponse{T}}</returns>
-  public static List<SearchForFacetValuesResponse> SearchForFacets(this SearchClient client,
-    IEnumerable<SearchForFacets> requests, SearchStrategy? searchStrategy, RequestOptions options = null,
-    CancellationToken cancellationToken = default) =>
-    AsyncHelper.RunSync(() => client.SearchForFacetsAsync(requests, searchStrategy, options, cancellationToken));
+  public List<SearchForFacetValuesResponse> SearchForFacets(IEnumerable<SearchForFacets> requests,
+    SearchStrategy? searchStrategy, RequestOptions options = null, CancellationToken cancellationToken = default) =>
+    AsyncHelper.RunSync(() => SearchForFacetsAsync(requests, searchStrategy, options, cancellationToken));
 
   private static async Task<T> RetryUntil<T>(Func<Task<T>> func, Func<T, bool> validate,
     int maxRetries = DefaultMaxRetries, Func<int, int> timeout = null, CancellationToken ct = default)
@@ -423,32 +384,27 @@ public static class ClientExtensions
   /// Replace all objects in an index without any downtime. Internally, this method copies the existing index settings, synonyms and query rules and indexes all passed objects.
   /// Finally, the temporary one replaces the existing index. (Synchronous version)
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="objects">The list of `objects` to store in the given Algolia `indexName`.</param>
   /// <param name="batchSize">The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-  public static ReplaceAllObjectsResponse ReplaceAllObjects<T>(this SearchClient client, string indexName,
-    IEnumerable<T> objects, int batchSize = 1000, RequestOptions options = null,
-    CancellationToken cancellationToken = default) where T : class
-    => AsyncHelper.RunSync(() =>
-      client.ReplaceAllObjectsAsync(indexName, objects, batchSize, options, cancellationToken));
+  public ReplaceAllObjectsResponse ReplaceAllObjects<T>(string indexName, IEnumerable<T> objects, int batchSize = 1000,
+    RequestOptions options = null, CancellationToken cancellationToken = default) where T : class =>
+    AsyncHelper.RunSync(() => ReplaceAllObjectsAsync(indexName, objects, batchSize, options, cancellationToken));
 
   /// <summary>
   ///  Push a new set of objects and remove all previous ones. Settings, synonyms and query rules are untouched.
   /// Replace all objects in an index without any downtime. Internally, this method copies the existing index settings, synonyms and query rules and indexes all passed objects.
   /// Finally, the temporary one replaces the existing index.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="objects">The list of `objects` to store in the given Algolia `indexName`.</param>
   /// <param name="batchSize">The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-  public static async Task<ReplaceAllObjectsResponse> ReplaceAllObjectsAsync<T>(this SearchClient client,
-    string indexName, IEnumerable<T> objects, int batchSize = 1000, RequestOptions options = null,
-    CancellationToken cancellationToken = default) where T : class
+  public async Task<ReplaceAllObjectsResponse> ReplaceAllObjectsAsync<T>(string indexName, IEnumerable<T> objects,
+    int batchSize = 1000, RequestOptions options = null, CancellationToken cancellationToken = default) where T : class
   {
     if (objects == null)
     {
@@ -459,24 +415,24 @@ public static class ClientExtensions
     var tmpIndexName = $"{indexName}_tmp_{rnd.Next(100)}";
 
     // Copy settings, synonyms and query rules into the temporary index
-    var copyResponse = await client.OperationIndexAsync(indexName,
+    var copyResponse = await OperationIndexAsync(indexName,
         new OperationIndexParams(OperationType.Copy, tmpIndexName)
-        { Scope = [ScopeType.Rules, ScopeType.Settings, ScopeType.Synonyms] }, options, cancellationToken)
+          { Scope = [ScopeType.Rules, ScopeType.Settings, ScopeType.Synonyms] }, options, cancellationToken)
       .ConfigureAwait(false);
 
-    await client.WaitForTaskAsync(indexName, copyResponse.TaskID, requestOptions: options, ct: cancellationToken)
+    await WaitForTaskAsync(indexName, copyResponse.TaskID, requestOptions: options, ct: cancellationToken)
       .ConfigureAwait(false);
 
     // Add objects to the temporary index
-    var batchResponse = await client.ChunkedBatchAsync(tmpIndexName, objects, Action.AddObject, batchSize,
+    var batchResponse = await ChunkedBatchAsync(tmpIndexName, objects, Action.AddObject, batchSize,
       options, cancellationToken).ConfigureAwait(false);
 
     // Move the temporary index to the main one
-    var moveResponse = await client.OperationIndexAsync(tmpIndexName,
+    var moveResponse = await OperationIndexAsync(tmpIndexName,
         new OperationIndexParams(OperationType.Move, indexName), options, cancellationToken)
       .ConfigureAwait(false);
 
-    await client.WaitForTaskAsync(tmpIndexName, moveResponse.TaskID, requestOptions: options, ct: cancellationToken)
+    await WaitForTaskAsync(tmpIndexName, moveResponse.TaskID, requestOptions: options, ct: cancellationToken)
       .ConfigureAwait(false);
 
     return new ReplaceAllObjectsResponse
@@ -490,7 +446,6 @@ public static class ClientExtensions
   /// <summary>
   /// Helper: Chunks the given `objects` list in subset of 1000 elements max in order to make it fit in `batch` requests. (Synchronous version)
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="objects">The list of `objects` to store in the given Algolia `indexName`.</param>
   /// <param name="action">The `batch` `action` to perform on the given array of `objects`, defaults to `addObject`.</param>
@@ -498,16 +453,14 @@ public static class ClientExtensions
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
   /// <typeparam name="T"></typeparam>
-  public static List<BatchResponse> ChunkedBatch<T>(this SearchClient client, string indexName,
-    IEnumerable<T> objects, Action action = Action.AddObject, int batchSize = 1000, RequestOptions options = null,
-    CancellationToken cancellationToken = default) where T : class =>
-    AsyncHelper.RunSync(() =>
-      client.ChunkedBatchAsync(indexName, objects, action, batchSize, options, cancellationToken));
+  public List<BatchResponse> ChunkedBatch<T>(string indexName, IEnumerable<T> objects, Action action = Action.AddObject,
+    int batchSize = 1000, RequestOptions options = null, CancellationToken cancellationToken = default)
+    where T : class =>
+    AsyncHelper.RunSync(() => ChunkedBatchAsync(indexName, objects, action, batchSize, options, cancellationToken));
 
   /// <summary>
   /// Helper: Chunks the given `objects` list in subset of 1000 elements max in order to make it fit in `batch` requests.
   /// </summary>
-  /// <param name="client"></param>
   /// <param name="indexName">The index in which to perform the request.</param>
   /// <param name="objects">The list of `objects` to store in the given Algolia `indexName`.</param>
   /// <param name="action">The `batch` `action` to perform on the given array of `objects`, defaults to `addObject`.</param>
@@ -515,8 +468,8 @@ public static class ClientExtensions
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
   /// <typeparam name="T"></typeparam>
-  public static async Task<List<BatchResponse>> ChunkedBatchAsync<T>(this SearchClient client, string indexName,
-    IEnumerable<T> objects, Action action = Action.AddObject, int batchSize = 1000, RequestOptions options = null,
+  public async Task<List<BatchResponse>> ChunkedBatchAsync<T>(string indexName, IEnumerable<T> objects,
+    Action action = Action.AddObject, int batchSize = 1000, RequestOptions options = null,
     CancellationToken cancellationToken = default) where T : class
   {
     var batchCount = (int)Math.Ceiling((double)objects.Count() / batchSize);
@@ -525,7 +478,7 @@ public static class ClientExtensions
     for (var i = 0; i < batchCount; i++)
     {
       var chunk = objects.Skip(i * batchSize).Take(batchSize);
-      var batchResponse = await client.BatchAsync(indexName,
+      var batchResponse = await BatchAsync(indexName,
         new BatchWriteParams(chunk.Select(x => new BatchRequest(action, x)).ToList()),
         options, cancellationToken).ConfigureAwait(false);
 
@@ -534,7 +487,7 @@ public static class ClientExtensions
 
     foreach (var batch in responses)
     {
-      await client.WaitForTaskAsync(indexName, batch.TaskID, requestOptions: options, ct: cancellationToken)
+      await WaitForTaskAsync(indexName, batch.TaskID, requestOptions: options, ct: cancellationToken)
         .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## 🧭 What and Why

Move `SearchClient` extensions into instance functions.
