### PR TITLE
fix(javascript): use correct vendor values

### DIFF
--- a/templates/javascript/clients/client/model/types/dataType.mustache
+++ b/templates/javascript/clients/client/model/types/dataType.mustache
@@ -3,17 +3,17 @@
   {{classname}}{{{nameInCamelCase}}}{{#isArray}}[]{{/isArray}}
 {{/isEnum}}
 {{^isEnum}}
-  {{#x-propagated-generic}}
+  {{#vendorExtensions.x-propagated-generic}}
     {{> client/model/types/dataTypeGeneric}}
-  {{/x-propagated-generic}}
-  {{^x-propagated-generic}}
-    {{#x-has-child-generic}}
+  {{/vendorExtensions.x-propagated-generic}}
+  {{^vendorExtensions.x-propagated-generic}}
+    {{#vendorExtensions.x-has-child-generic}}
       {{> client/model/types/dataTypeGeneric}}
-    {{/x-has-child-generic}}
-    {{^x-has-child-generic}}
+    {{/vendorExtensions.x-has-child-generic}}
+    {{^vendorExtensions.x-has-child-generic}}
       {{{dataType}}}
-    {{/x-has-child-generic}}
-  {{/x-propagated-generic}}
+    {{/vendorExtensions.x-has-child-generic}}
+  {{/vendorExtensions.x-propagated-generic}}
   {{#isNullable}}
     | null
   {{/isNullable}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

discovered while testing on the crawler, the js template doesn't use the correct vendor extensions values (see https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/model/searchHits.ts), meaning generics are broken