### PR TITLE
chore(scala): fix scala release ci

### DIFF
--- a/clients/algoliasearch-client-scala/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-scala/.github/workflows/release.yml
@@ -29,12 +29,18 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.SIGNING_PRIVATE_KEY }}
           passphrase: ${{ secrets.SIGNING_PRIVATE_KEY_PASSWORD }}
-          fingerprint: "${{ secrets.SIGNING_PRIVATE_KEY_FINGERPRINT }}"
+          fingerprint: ${{ secrets.SIGNING_PRIVATE_KEY_FINGERPRINT }}
 
-      - name: Release to Sonatype
+      - name: List GPG keys
+        run: gpg -K
+
+      - name: Publish Signed Artifacts
         env:
-          SONATYPE_USERNAME: '${{ secrets.SONATYPE_NEXUS_USERNAME }}'
-          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_NEXUS_PASSWORD }}'
           PGP_PASSPHRASE: ${{ secrets.SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: sbt +publishSigned +sonatypeBundleRelease
-  
+        run: sbt +publishSigned
+
+      - name: Release Bundle to Sonatype
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+        run: sbt +sonatypeBundleRelease

--- a/clients/algoliasearch-client-scala/build.sbt
+++ b/clients/algoliasearch-client-scala/build.sbt
@@ -22,10 +22,6 @@ developers += Developer(
   "contact@algolia.com",
   url("https://github.com/algolia/algoliasearch-client-scala/")
 )
-publishTo := sonatypePublishToBundle.value
-pgpSigningKey := Credentials
-  .forHost(credentials.value, "pgp")
-  .map(_.userName) // related to https://github.com/sbt/sbt-pgp/issues/170
 
 lazy val root = project
   .in(file("."))


### PR DESCRIPTION
## 🧭 What and Why

At Scala client release time, gpg key is not used correctly.

### Changes included:

- Attempt to fix gpg signing 
- Add logging (list installed pgp keys)