### PR TITLE
feat(clients): support recommend methods in `algoliasearch`

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -155,6 +155,7 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
       additionalProperties.put("abtestingVersion", Helpers.getPackageJsonVersion("client-abtesting"));
       additionalProperties.put("personalizationVersion", Helpers.getPackageJsonVersion("client-personalization"));
       additionalProperties.put("searchVersion", Helpers.getPackageJsonVersion("client-search"));
+      additionalProperties.put("recommendVersion", Helpers.getPackageJsonVersion("recommend"));
 
       // Files used to generate the `lite` client
       apiName = "lite" + Helpers.API_SUFFIX;

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -42,6 +42,9 @@ export type Spec = {
   servers: Server[];
   tags: Tag[];
   paths: Path[];
+  components: {
+    schemas: Record<string, any>;
+  };
 };
 
 /**
@@ -105,5 +108,9 @@ export type SnippetSamples = Record<Language, Record<string, string>>;
  */
 type Path = Record<
   Method,
-  Record<string, any> & { operationId: string; 'x-codeSamples': CodeSamples[]; summary: string }
+  Record<string, any> & {
+    operationId: string;
+    'x-codeSamples': CodeSamples[];
+    summary: string;
+  }
 >;

--- a/templates/javascript/clients/algoliasearch/builds/browser.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/browser.mustache
@@ -26,6 +26,7 @@
   {{> algoliasearch/builds/initClients}}
 
   return {
+    ...createRecommendClient(commonOptions),
     ...createSearchClient(commonOptions),
     /**
      * Get the value of the `algoliaAgent`, used by our libraries internally and telemetry system.

--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -11,6 +11,7 @@ import { createAbtestingClient, REGIONS as abtestingRegions } from '{{{npmNamesp
 import type { Region as PersonalizationRegion } from '{{{npmNamespace}}}/client-personalization/src/personalizationClient';
 import { createPersonalizationClient, REGIONS as personalizationRegions } from '{{{npmNamespace}}}/client-personalization/src/personalizationClient';
 import { createSearchClient, apiClientVersion as searchClientVersion } from '{{{npmNamespace}}}/client-search/src/searchClient';
+import { createRecommendClient } from '{{{npmNamespace}}}/recommend/src/recommendClient';
 
 import type { serializeQueryParameters  } from '{{{npmNamespace}}}/client-common';
 import type {} from '{{{npmNamespace}}}/client-common';

--- a/templates/javascript/clients/algoliasearch/builds/models.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/models.mustache
@@ -14,11 +14,13 @@ import {
 } from '{{{npmNamespace}}}/client-search/model';
 
 export * from '{{{npmNamespace}}}/client-search/model';
+export * from '{{{npmNamespace}}}/recommend/model';
 export * from '{{{npmNamespace}}}/client-personalization/model';
 export * from '{{{npmNamespace}}}/client-analytics/model';
 export * from '{{{npmNamespace}}}/client-abtesting/model';
 
 export { SearchClient } from '{{{npmNamespace}}}/client-search';
+export { RecommendClient } from '{{{npmNamespace}}}/recommend';
 export { PersonalizationClient } from '{{{npmNamespace}}}/client-personalization';
 export { AnalyticsClient } from '{{{npmNamespace}}}/client-analytics';
 export { AbtestingClient } from '{{{npmNamespace}}}/client-abtesting';

--- a/templates/javascript/clients/algoliasearch/builds/node.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/node.mustache
@@ -20,6 +20,7 @@
   {{> algoliasearch/builds/initClients}}
 
   return {
+    ...createRecommendClient(commonOptions),
     ...createSearchClient(commonOptions),
     /**
      * Get the value of the `algoliaAgent`, used by our libraries internally and telemetry system.

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -111,6 +111,7 @@
     "{{{npmNamespace}}}/client-personalization": "{{personalizationVersion}}",
     "{{{npmNamespace}}}/client-search": "{{searchVersion}}",
     "{{{npmNamespace}}}/client-common": "{{utilsPackageVersion}}",
+    "{{{npmNamespace}}}/recommend": "{{recommendVersion}}",
     "{{{npmNamespace}}}/requester-browser-xhr": "{{utilsPackageVersion}}",
     "{{{npmNamespace}}}/requester-node-http": "{{utilsPackageVersion}}"
   },


### PR DESCRIPTION
## 🧭 What and Why

As we're trying to unify FX libraries, we want to avoid requiring users to import a bunch of different packages.
We've made those changes to v4 : https://github.com/algolia/algoliasearch-client-javascript/pull/1509

🎟 JIRA Ticket: [FX-2774](https://algolia.atlassian.net/browse/FX-2774)

### Changes included:

I'm publishing this as a draft as I'm overall not too sure about the best way to implement this :
- I opted to merge the `search` and `recommend` specs for `algoliasearch/lite`, and it works well however this will have repercussions for the Dart client (cc @aallam)
- For the `algoliasearch` part (not lite), I'm a bit torn as methods are not exported so we can't have the same treeshaking we have with v4, `createRecommend` **has** to be called and the bundle will have redundant code. Running into problems with similar models being exported too.
Also didn't update it for Dart but it might be fine for now.

## 🧪 Test

Didn't bother with tests yet as this is subject to change :D

[FX-2774]: https://algolia.atlassian.net/browse/FX-2774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ