### PR TITLE
fix(swift): wait for tasks while sending chunk batches

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchHelpers.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchHelpers.swift
@@ -416,6 +416,7 @@ public extension SearchClient {
         let batchResponses = try await self.chunkedBatch(
             indexName: tmpIndexName,
             objects: objects,
+            waitForTasks: true,
             batchSize: batchSize,
             requestOptions: requestOptions
         )


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

- fix `replaceAllObjects` helper by waiting for tasks in the `chunkedBatch` method

