### PR TITLE
chore(CODEOWNERS): add owners for /specs/ingestion/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,5 @@
 # See https://help.github.com/articles/about-code-owners/
 
 * @algolia/api-clients-automation
+
+/specs/ingestion/ @algolia/api-clients-automation @algolia/data-ingestion @algolia/event-experiences


### PR DESCRIPTION
## 🧭 What and Why

Goal: Allow EX to merge our changes without having to wait for a round trip review. Post-merge reviews are always appreciated!

### Changes included:

- Add EX and Data Ingestion teams as owners of /specs/ingestion/
