### PR TITLE
docs: better navbar labels

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,11 +41,19 @@ function getSpecsForNavBar() {
   return getSpecFiles().map((specFile) => {
     /** @type {import('@docusaurus/theme-common').NavbarItem} */
     return {
-      label: specFile.fileName,
+      label: getLabel(specFile.fileName),
       href: specFile.route,
       className: 'header-restapi',
     };
   });
+}
+
+function getLabel(str) {
+  const dict = {
+    abtesting: 'A/B Testing',
+    'query-suggestions': 'Query Suggestions',
+  };
+  return dict[str] || str;
 }
 
 /** @type {import('@docusaurus/types').Config} */


### PR DESCRIPTION
## 🧭 What and Why

A small change to improve the labels for the specs in the navbar, for now 'Query Suggestions', and 'A/B testing'.