### PR TITLE
docs: separate labels for code samples

### DIFF
--- a/scripts/buildSpecs.ts
+++ b/scripts/buildSpecs.ts
@@ -9,16 +9,16 @@ import type { CodeSamples, Language, SnippetSamples, Spec } from './types.js';
 
 const ALGOLIASEARCH_LITE_OPERATIONS = ['search', 'customPost'];
 
-function mapLanguageToCodeSampleSupporter(language: Language): CodeSamples['lang'] {
+function getCodeSampleLabel(language: Language): CodeSamples['label'] {
   switch (language) {
     case 'csharp':
-      return 'CSharp';
+      return 'C#';
     case 'javascript':
       return 'JavaScript';
     case 'php':
       return 'PHP';
     default:
-      return capitalize(language) as CodeSamples['lang'];
+      return capitalize(language) as CodeSamples['label'];
   }
 }
 
@@ -94,7 +94,7 @@ async function transformBundle({
 
   const bundledSpec = yaml.load(await fsp.readFile(bundledPath, 'utf8')) as Spec;
   const tagsDefinitions = bundledSpec.tags;
-  const snippetSamples = !docs ? {} : await transformSnippetsToCodeSamples(clientName);
+  const snippetSamples = docs ? await transformSnippetsToCodeSamples(clientName) : {};
 
   for (const [pathKey, pathMethods] of Object.entries(bundledSpec.paths)) {
     for (const [method, specMethod] of Object.entries(pathMethods)) {
@@ -121,7 +121,8 @@ async function transformBundle({
         }
 
         specMethod['x-codeSamples'].push({
-          lang: mapLanguageToCodeSampleSupporter(gen.language),
+          lang: gen.language,
+          label: getCodeSampleLabel(gen.language),
           source: snippetSamples[gen.language][specMethod.operationId],
         });
       }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -69,7 +69,32 @@ type Tag = {
 type Method = 'delete' | 'get' | 'options' | 'patch' | 'post' | 'put';
 
 export type CodeSamples = {
-  lang: string;
+  lang:
+    | 'c'
+    | 'c++'
+    | 'coffeescript'
+    | 'csharp'
+    | 'css'
+    | 'dart'
+    | 'dm'
+    | 'elixir'
+    | 'go'
+    | 'groovy'
+    | 'html'
+    | 'java'
+    | 'javascript'
+    | 'kotlin'
+    | 'objective-c'
+    | 'perl'
+    | 'php'
+    | 'powershell'
+    | 'python'
+    | 'ruby'
+    | 'rust'
+    | 'scala'
+    | 'shell'
+    | 'swift'
+    | 'typescript';
   label:
     | 'C'
     | 'C#'

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -69,11 +69,12 @@ type Tag = {
 type Method = 'delete' | 'get' | 'options' | 'patch' | 'post' | 'put';
 
 export type CodeSamples = {
-  lang:
+  lang: string;
+  label:
     | 'C'
+    | 'C#'
     | 'C++'
     | 'CoffeeScript'
-    | 'CSharp'
     | 'CSS'
     | 'Dart'
     | 'DM'
@@ -105,5 +106,9 @@ export type SnippetSamples = Record<Language, Record<string, string>>;
  */
 type Path = Record<
   Method,
-  Record<string, any> & { operationId: string; 'x-codeSamples': CodeSamples[]; summary: string }
+  Record<string, any> & {
+    operationId: string;
+    'x-codeSamples': CodeSamples[];
+    summary: string;
+  }
 >;


### PR DESCRIPTION
## 🧭 What and Why

Add a separate `label` property to the `x-codeSamples` array.
This lets us use `lang` for the syntax highlighting grammar and an arbitrary `label`.
For now, this is only useful to render `C#` instead of `CSharp`.

See: [`x-codeSamples` (Redocly)](https://redocly.com/docs/api-reference-docs/specification-extensions/x-code-samples/).

🎟 JIRA Ticket:

### Changes included:

- Rename `mapLanguagesToCodeSampleSupporter` to `getCodeSampleLabel` and return `C#` when the language is `csharp`. 

## 🧪 Test
