### PR TITLE
chore(scala): publish artifacts once

### DIFF
--- a/clients/algoliasearch-client-scala/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-scala/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        run: sbt +sonatypeBundleRelease
+        run: sbt sonatypeBundleRelease


### PR DESCRIPTION
## 🧭 What and Why

Publishing operation is run multiple times. This is required only once.

### Changes included:

Remove `+` prefix, which is used to run the same command for each target scala version.
We need to run `sonatypeBundleRelease` only once. 
