### PR TITLE
fix(go): typo in method name

### DIFF
--- a/templates/go/search_helpers.mustache
+++ b/templates/go/search_helpers.mustache
@@ -147,7 +147,7 @@ If the operation is "delete" or "add", the apiKey parameter is not used.
   @return *GetApiKeyResponse - API key response.
   @return error - Error if any.
 */
-func (c *APIClient) WaitForApiKeyWitOptions(
+func (c *APIClient) WaitForApiKeyWithOptions(
   operation ApiKeyOperation,
   key string,
   apiKey *ApiKey,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

missing h in method name