### PR TITLE
feat(go): add `GetSecuredApiKeyRemainingValidity` helper, fix `GenerateSecuredApiKey` encoding

### DIFF
--- a/templates/go/api.mustache
+++ b/templates/go/api.mustache
@@ -13,6 +13,7 @@ import (
   {{#isSearchClient}}
   "slices"
   "time"
+  "sort"
   "github.com/algolia/algoliasearch-client-go/v4/algolia/errs"
   "crypto/hmac"
 	"crypto/sha256"

--- a/templates/go/search_helpers.mustache
+++ b/templates/go/search_helpers.mustache
@@ -294,29 +294,12 @@ func (c *APIClient) WaitForApiKeyWithContext(
   )
 }
 
-// GenerateSecuredApiKey generates a public API key intended to restrict access
-// to certain records. This new key is built upon the existing key named
-// `parentApiKey` and the following options:
-func (c *APIClient) GenerateSecuredApiKey(parentApiKey string, restrictions *SecuredAPIKeyRestrictions) (string, error) {
-	h := hmac.New(sha256.New, []byte(parentApiKey))
-
-	message, err := encodeRestrictions(restrictions)
-  if err != nil {
-    return "", err
-  }
-	_, err = h.Write([]byte(message))
-	if err != nil {
-		return "", fmt.Errorf("failed to compute HMAC: %w", err)
+func encodeRestrictions(restrictions *SecuredAPIKeyRestrictions) (string, error) {
+	if restrictions == nil {
+		return "", nil
 	}
 
-	checksum := hex.EncodeToString(h.Sum(nil))
-	key := base64.StdEncoding.EncodeToString([]byte(checksum + message))
-
-	return key, nil
-}
-
-func encodeRestrictions(restrictions *SecuredAPIKeyRestrictions) (string, error) {
-  toSerialize := map[string]any{}
+	toSerialize := map[string]any{}
 	if restrictions.Filters != nil {
 		toSerialize["filters"] = *restrictions.Filters
 	}
@@ -332,22 +315,75 @@ func encodeRestrictions(restrictions *SecuredAPIKeyRestrictions) (string, error)
 	if restrictions.UserToken != nil {
 		toSerialize["userToken"] = *restrictions.UserToken
 	}
-  if restrictions.SearchParams != nil {
-    // merge with searchParams
-    serializedParams, err := restrictions.SearchParams.MarshalJSON()
-    if err != nil {
-      return "", fmt.Errorf("failed to marshal SearchParams: %w", err)
-    }
-    err = json.Unmarshal(serializedParams, &toSerialize)
-    if err != nil {
-      return "", fmt.Errorf("failed to unmarshal SearchParams: %w", err)
-    }
-  }
+	if restrictions.SearchParams != nil {
+		// merge with searchParams
+		serializedParams, err := restrictions.SearchParams.MarshalJSON()
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal SearchParams: %w", err)
+		}
+		err = json.Unmarshal(serializedParams, &toSerialize)
+		if err != nil {
+			return "", fmt.Errorf("failed to unmarshal SearchParams: %w", err)
+		}
+	}
 
-  queryString := make([]string, 0, len(toSerialize))
-	for k, v := range toSerialize {
-		queryString = append(queryString, k+"="+queryParameterToString(v))
+	// sort the keys to ensure consistent encoding
+	keys := make([]string, 0, len(toSerialize))
+	for k := range toSerialize {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	queryString := make([]string, 0, len(toSerialize))
+	for _, k := range keys {
+		queryString = append(queryString, k+"="+queryParameterToString(toSerialize[k]))
 	}
 
 	return strings.Join(queryString, "&"), nil
+}
+
+// GenerateSecuredApiKey generates a public API key intended to restrict access
+// to certain records. This new key is built upon the existing key named
+// `parentApiKey` and the following options.
+func (c *APIClient) GenerateSecuredApiKey(parentApiKey string, restrictions *SecuredAPIKeyRestrictions) (string, error) {
+	h := hmac.New(sha256.New, []byte(parentApiKey))
+
+	message, err := encodeRestrictions(restrictions)
+	if err != nil {
+		return "", err
+	}
+	_, err = h.Write([]byte(message))
+	if err != nil {
+		return "", fmt.Errorf("failed to compute HMAC: %w", err)
+	}
+
+	checksum := hex.EncodeToString(h.Sum(nil))
+	key := base64.StdEncoding.EncodeToString([]byte(checksum + message))
+
+	return key, nil
+}
+
+// GetSecuredApiKeyRemainingValidity retrieves the remaining validity of the previously generated `securedApiKey`, the `ValidUntil` parameter must have been provided.
+func (c *APIClient) GetSecuredApiKeyRemainingValidity(securedApiKey string) (time.Duration, error) {
+	if len(securedApiKey) == 0 {
+		return 0, fmt.Errorf("given secured API key is empty: %s", securedApiKey)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(securedApiKey)
+	if err != nil {
+		return 0, fmt.Errorf("unable to decode given secured API key: %s", err)
+	}
+
+	submatch := regexp.MustCompile(`validUntil=(\d{1,10})`).FindSubmatch(decoded)
+
+	if len(submatch) != 2 {
+		return 0, fmt.Errorf("unable to find `validUntil` parameter in the given secured API key: %s", string(decoded))
+	}
+
+	ts, err := strconv.Atoi(string(submatch[1]))
+	if err != nil {
+		return 0, fmt.Errorf("invalid format for the received `validUntil` value: %s", string(submatch[1]))
+	}
+
+	return time.Until(time.Unix(int64(ts), 0)), nil
 }

--- a/templates/go/tests/requests/helpers.mustache
+++ b/templates/go/tests/requests/helpers.mustache
@@ -1,0 +1,35 @@
+func TestSearch_GenerateSecuredApiKey(t *testing.T) {
+	client, echo := createSearchClient(t)
+	_ = echo
+
+	t.Run("generates a key without restrictions", func(t *testing.T) {
+		key, err := client.GenerateSecuredApiKey("foo", nil)
+		require.NoError(t, err)
+
+		require.Equal(t, "NjgzNzE2ZDlkN2Y4MmVlZDE3NGM2Y2FlYmUwODZlZTkzMzc2Yzc5ZDdjNjFkZDY3MGVhMDBmN2Y4ZDZlYjBhOA==", key)
+	})
+
+	t.Run("generates a key with restrictions", func(t *testing.T) {
+		key, err := client.GenerateSecuredApiKey("foo", search.NewSecuredAPIKeyRestrictions().SetValidUntil(100).SetRestrictIndices([]string{"bar"}).SetRestrictSources("192,168.1.0/24").SetUserToken("foobarbaz").SetSearchParams(search.NewSearchParamsObject().SetQuery("foo")))
+		require.NoError(t, err)
+
+		require.Equal(t, "NGMxODk0MjViNjM3ODcxNjc4NWU4Y2I5NGIxNDAzMTg4MjU5Mjc4YTEwMzU4Mjk2YjBiMmVjOWViYTIyOTBiY3F1ZXJ5PWZvbyZyZXN0cmljdEluZGljZXM9YmFyJnJlc3RyaWN0U291cmNlcz0xOTIlMkMxNjguMS4wJTJGMjQmdXNlclRva2VuPWZvb2JhcmJheiZ2YWxpZFVudGlsPTEwMA==", key)
+	})
+}
+
+func TestSearch_GetSecuredApiKeyRemainingVaildity(t *testing.T) {
+	client, echo := createSearchClient(t)
+	_ = echo
+
+	t.Run("is able to check the remaining validity of a key", func(t *testing.T) {
+		key, err := client.GenerateSecuredApiKey("foo", search.NewSecuredAPIKeyRestrictions().SetValidUntil(42))
+		require.NoError(t, err)
+
+		require.Equal(t, "NDI5ZjRkMTRiNTBlZmExZWIyN2I3NzczOGUwMzE0NjYwMDU1M2M3NjYyY2IxODZhMDAxMWEwOWJmZjE5MzY0NnZhbGlkVW50aWw9NDI=", key)
+		
+		validity, err := client.GetSecuredApiKeyRemainingValidity(key)
+		require.NoError(t, err)
+
+		require.Greater(t, validity, -time.Now().UnixNano())
+	})
+}

--- a/templates/go/tests/requests/requests.mustache
+++ b/templates/go/tests/requests/requests.mustache
@@ -6,6 +6,7 @@ import (
   "net/url"
   "os"
   "testing"
+  "time"
 
   "github.com/kinbiko/jsonassert"
   "github.com/stretchr/testify/require"
@@ -136,3 +137,7 @@ func Test{{#lambda.titlecase}}{{clientPrefix}}{{/lambda.titlecase}}_{{#lambda.ti
 }
 
 {{/blocksRequests}}
+
+{{#isSearchClient}}
+{{> tests/requests/helpers}}
+{{/isSearchClient}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-1898

### Changes included:

- Add `GetSecuredApiKeyRemainingValidity` helper
- Add tests for `GetSecuredApiKeyRemainingValidity` and `GenerateSecuredApiKey`