### PR TITLE
fix(swift): include privacy file in spm

### DIFF
--- a/clients/algoliasearch-client-swift/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-swift/.github/workflows/release.yml
@@ -30,16 +30,16 @@ jobs:
       - name: Install CocoaPods
         run: gem install cocoapods
 
-      - name: Publish on CocoaPods
-        run: |
-          set -eo pipefail
-          pod trunk push --allow-warnings --verbose AlgoliaSearchClient.podspec
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-
       - name: Publish release on Github
         run: |
           set -eo pipefail
           gh release create ${{ steps.versions.outputs.RELEASE_VERSION }} --title ${{ steps.versions.outputs.RELEASE_VERSION }} -F CHANGELOG.md --target ${{ github.sha }}
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Publish on CocoaPods
+        run: |
+          set -eo pipefail
+          pod trunk push --allow-warnings --verbose AlgoliaSearchClient.podspec
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/templates/swift/Package.mustache
+++ b/templates/swift/Package.mustache
@@ -62,7 +62,10 @@ products.append(
       dependencies: [
         .target(name: "Core"),
       ] + extraTargetDependencies,
-      path: "Sources/\(library)"
+      path: "Sources/\(library)",
+      resources: [
+        .copy("../../PrivacyInfo.xcprivacy")
+      ]
     )
   )
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

- add privacy file in SPM
- invert gh release and cocoapods release so the tag exists
