### PR TITLE
chore: prepare release 2024-04-03

### DIFF
--- a/clients/algoliasearch-client-swift/CHANGELOG.md
+++ b/clients/algoliasearch-client-swift/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [9.0.0-alpha.3](https://github.com/algolia/algoliasearch-client-swift/compare/9.0.0-alpha.2...9.0.0-alpha.3)
+
+- [86a5b4ef8](https://github.com/algolia/api-clients-automation/commit/86a5b4ef8) fix(swift): include privacy file in spm ([#2950](https://github.com/algolia/api-clients-automation/pull/2950)) by [@Fluf22](https://github.com/Fluf22/)
+
 ## [9.0.0-alpha.2](https://github.com/algolia/algoliasearch-client-swift/compare/9.0.0-alpha.1...9.0.0-alpha.2)
 
 - [deb4e8cde](https://github.com/algolia/api-clients-automation/commit/deb4e8cde) fix(swift): update CI workflow to a previous working state ([#2947](https://github.com/algolia/api-clients-automation/pull/2947)) by [@Fluf22](https://github.com/Fluf22/)

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -322,7 +322,7 @@
     ],
     "folder": "clients/algoliasearch-client-swift",
     "gitRepoId": "algoliasearch-client-swift",
-    "packageVersion": "9.0.0-alpha.2",
+    "packageVersion": "9.0.0-alpha.3",
     "modelFolder": "Sources",
     "apiFolder": "Sources",
     "dockerImage": "apic_swift",


### PR DESCRIPTION
## Summary

This PR has been created using the `yarn release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~csharp: 7.0.0-alpha.7 (no commit)~
- ~dart: 1.6.3 (no commit)~
- ~go: 4.0.0-beta.10 (no commit)~
- ~java: 4.0.0-beta.28 (no commit)~
- ~javascript: 5.0.0-alpha.112 (no commit)~
- ~kotlin: 3.0.0-beta.23 (no commit)~
- ~php: 4.0.0-alpha.104 (no commit)~
- ~python: 4.0.0b13 (no commit)~
- ~ruby: 3.0.0.alpha.16 (no commit)~
- ~scala: 2.0.0-alpha.15 (no commit)~
- swift: 9.0.0-alpha.2 -> **`prerelease` _(e.g. 9.0.0-alpha.3)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: update release PR URL (#2952)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  
</details>