### PR TITLE
chore: run codegen anytime

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -426,7 +426,6 @@ jobs:
           token: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
       - name: Download all artifacts
-        if: ${{ needs.setup.outputs.RUN_GEN == 'true' || needs.setup.outputs.RUN_GEN_JAVASCRIPT == 'true' }}
         uses: ./scripts/ci/actions/restore-artifacts
         with:
           type: all
@@ -437,7 +436,6 @@ jobs:
           type: minimal
 
       - name: Generate documentation specs with code snippets
-        if: ${{ needs.setup.outputs.RUN_GEN == 'true' || needs.setup.outputs.RUN_GEN_JAVASCRIPT == 'true' }}
         run: yarn cli build specs ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX).toRun }} --docs
 
       - name: Build website


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

codegen is skipped when only touching specs that don't impact clients, see [this](https://github.com/algolia/api-clients-automation/actions/runs/8551115939/job/23429436694) for example, this pr fixes it, see https://github.com/algolia/api-clients-automation/pull/2957