### PR TITLE
docs: contribution guide for docs

### DIFF
--- a/website/docs/contributing/add-new-api-client.md
+++ b/website/docs/contributing/add-new-api-client.md
@@ -1,120 +1,191 @@
 ---
-title: Add a new API client
+title: Add new API clients
 ---
 
 :::info
 
-Make sure to first [setup the repository tooling](/docs/contributing/setup-repository) to ease your journey!
+First, [setup the repository tooling](./setup-repository.md) so that you can lint, test, and preview documentation on your computer.
 
 :::
 
-Adding a new API client requires some manual steps in order to have a properly working client:
+To add a new API client in a supported programming language, you need to run these steps:
 
-1. [Writing specs](#1-writing-specs)
-2. [Configuring the generator](#2-configuring-the-generator)
+1. [Write specs](#1-write-specs)
+2. [Configure the generator](#2-configure-the-generator)
 3. [Generate the client](#3-generate-the-client)
-4. [Adding tests](#4-adding-tests-with-the-common-test-suite)
+4. [Add tests](#4-add-tests-with-the-common-test-suite)
 5. [Helpers](#5-helpers)
 
-## 1. Writing specs
+For more information about adding support for a new programming language, see [Support a new language](./add-new-language.md). 
 
-> All of our specs follows the [OpenAPI specification](https://spec.openapis.org/oas/v3.1.0).
+## 1. Write specs
 
-Take a look to how we write specs by checking the [existing ones](https://github.com/algolia/api-clients-automation/blob/main/specs/).
+Algolia's API specs follow the [OpenAPI specification, version 3.1](https://spec.openapis.org/oas/v3.1.0).
 
-> **The `bundled` folder is automatically generated, manual changes shouldn't be done in these files.**
+To add a new spec, it's best to start from an [existing one](https://github.com/algolia/api-clients-automation/blob/main/specs/).
 
-### Guidelines
+> Don't edit files in the `specs/bundled/` directory.
+> These files are auto-generated and your changes will be overwritten.
 
-- **Endpoints**: Each file in [the `paths` folder](https://github.com/algolia/api-clients-automation/tree/main/specs/search/paths) should contain `operationId`s for a single endpoint, multiple methods are allowed.
-- **File name**:
-  - When the `path` file only contain one method (e.g. `GET`), we name the file after the `operationId`
-  - When multiple methods are present (e.g. `PUT` and `DELETE`), we pick a more generic name that is related to the endpoint itself.
-- **Description/Summary**: `operationId`s must have both description and summary.
-- **Complex objects**: Complex objects (nested arrays, nested objects, `oneOf`, `allOf`, etc.) must be referenced (`$ref`) in the `operationId` file and not inlined. This is required to provide a accurate naming and improve readability.
+### How to organize the specs
 
-### `common` spec folder
+Each API spec follows a consistent structure.
 
-[The `common` folder](https://github.com/algolia/api-clients-automation/blob/main/specs/common/) contains properties that are common to many Algolia APIs.
+#### `specs/common/`
 
-### `specs/<apiName>` folder
+The [`common`](https://github.com/algolia/api-clients-automation/blob/main/specs/common/) directory contains schemas and parameters that are common to many Algolia APIs.
 
-> Example with the [search client spec](https://github.com/algolia/api-clients-automation/blob/main/specs/search/)
+#### `specs/<apiName>/`
 
-#### **`specs/<apiName>/spec.yml` file**
+Each API is in its own directory.
 
-The `spec.yml` file is the entry point of the client spec, it contains the `servers`, `paths` and other specific information to contact the API. We recommend to copy an existing [`spec.yml` file](https://github.com/algolia/api-clients-automation/blob/main/specs/search/spec.yml) to get started.
+For an example, see the [Search API](https://github.com/algolia/api-clients-automation/blob/main/specs/search/) directory.
 
-#### **`specs/<apiName>/common` folder**
+#### `specs/<apiName>/spec.yml`
 
-Same as [the global `common` folder](#common-spec-folder) but only related to the current API.
+The `spec.yml` file contains the general description of the API,
+including the `servers` and `paths` properties.
 
-#### **`specs/<apiName>/paths` folder**
+To get started, copy an existing file, for example, from the [Search API](https://github.com/algolia/api-clients-automation/blob/main/specs/search/spec.yml).
 
-Path definition of the paths defined in the [spec file](#specsapinamespecyml-file). See [guidelines](#guidelines).
+For information about documenting the API, see [API descriptions](./docs.md#api-descriptions).
+
+#### `specs/<apiName>/common/`
+
+This directory contains schemas and parameters that are common to endpoints of the current API.
+For schemas that are shared between multiple APIs, see the global [`specs/common`](#specscommon) directory.
+
+#### `specs/<apiName>/paths/`
+
+This directory contains the descriptions of the **endpoints** of the API.
+The paths themselves are defined in the [`spec.yml`](#specsapinamespecyml) file.
+
+### Guidelines for operations
+
+Operations are endpoints combined with an HTTP method (`GET`, `POST`, etc.).
+Each operation must have a unique `operationID` property.
+Operations for the same endpoint may share the same file, for example, the `GET` and `DELETE` request for the same endpoint.
+
+Every operation must have a `summary` and `description` property.
+For information about documenting operations, see [Operation summaries](./docs.md#operation-summaries) and [Operation descriptions](./docs.md#operation-descriptions).
+
+#### Filenames
+
+Follow these conventions:
+
+- If the file only contains one operation, use `<operationId>.yml` as filename.
+- If the file contains multiple operations, use a more generic name, for example [`rule.yml`](https://github.com/algolia/api-clients-automation/blob/main/specs/search/paths/rules/rule.yml) for the `GET`, `PUT`, and `DELETE` request for a rule.
+
+#### Access control lists (ACL)
+
+Each operation should include an `x-acl` property
+to document the ACL required to make the request.
+
+The `x-acl` property is an array of strings.
+For operations that require the admin API key, use `admin`.
+
+#### Complex objects
+
+The following objects must not be inlined, but referenced with `$ref`:
+
+- Nested arrays
+- Nested objects
+- `oneOf`
+- `allOf`
+- `enum`
+
+This is required for accurate naming of the generated code objects.
+It also improves the readability of the specs.
+
+### Guidelines for properties and parameters
+
+- Create separate objects and reference them for [complex objects](#complex-objects).
+- The `format` parameter for strings isn't supported.
+- For **nullable properties**, use the following syntax:
+
+  ```yaml
+  nullableProp:
+    default: null
+    oneOf:
+      - type: string
+        description: Some value
+      - type: 'null'
+        description: The single quotes are required.
+  ```
+
+For information about documenting properties and parameters, see [Properties and parameters](./docs.md#properties-and-parameters).
 
 ### Troubleshooting
 
-#### **Force the name of a `requestBody`**
+#### Explicit names for request bodies
 
 > [Detailed issue](https://github.com/algolia/api-clients-automation/issues/891)
 
-In some cases, you can encounter wrongly named `requestBody` from the specs, which could be due to:
+In some cases, the generated name for the `requestBody` property might be wrong.
+This can happen in these cases:
 
-- The type is too complex/too broad to be generated. (e.g. [An object with `additionalProperties`](https://github.com/algolia/api-clients-automation/tree/main/specs/search/paths/objects/partialUpdate.yml#L24-L33))
-- The type is an alias of its model (e.g. [A list of `model`](https://github.com/algolia/api-clients-automation/tree/main/specs/search/paths/rules/saveRules.yml#L12-L20))
+- The type is too complex or too broad to be correctly generated,
+  for example, [an object with `additionalProperties`](https://github.com/algolia/api-clients-automation/tree/main/specs/search/paths/objects/partialUpdate.yml#L24-L33).
 
-The [`x-codegen-request-body-name`](https://openapi-generator.tech/docs/swagger-codegen-migration/#body-parameter-name) property can be added at the root of the spec, to force the name of the generated `requestBody` property.
+- The type is an alias of its model,
+  for example, [a list of `model`](https://github.com/algolia/api-clients-automation/tree/main/specs/search/paths/rules/saveRules.yml#L12-L20).
 
-You can find an example of this implementation [on this PR](https://github.com/algolia/api-clients-automation/pull/896).
+To provide a name for the request body, add the [`x-codegen-request-body-name`](https://openapi-generator.tech/docs/swagger-codegen-migration/#body-parameter-name) property to the root of the operation's spec file.
 
-#### **Send additional options to the template**
+For an example, see [pull request #896](https://github.com/algolia/api-clients-automation/pull/896).
 
-You might want to send additional information to the generators. To do so, you can add parameters starting with an `x-` at the root level of your spec, which will be available in the `mustache` template under the `vendorExtensions` object.
+#### Send additional options to the templates
 
-[Example in the `search.yml` spec](https://github.com/algolia/api-clients-automation/blob/main/specs/search/paths/search/search.yml#L5-L7) and how it is used [in a mustache file](https://github.com/algolia/api-clients-automation/blob/bf4271246f9282d3c11dd46918e74cb86d9c96dc/templates/java/libraries/okhttp-gson/api.mustache#L196).
+To send additional information to the generators,
+you can add properties starting with `x-` to the root level of your spec.
+These are available in the templates as part of the `vendorExtensions` object.
 
-## 2. Configuring the generator
+For an example, see [`search.yml`](https://github.com/algolia/api-clients-automation/blob/main/specs/search/paths/search/search.yml#L5-L7)
+
+## 2. Configure the generator
 
 > Most of the configuration is "guessed" by the api-clients-automation CLI (`scripts/`).
 
-### Configs
+### Configuration file
 
-#### [`config/clients.config.json`](https://github.com/algolia/api-clients-automation/blob/main/config/clients.config.json)
+The file [`config/clients.config.json`](https://github.com/algolia/api-clients-automation/blob/main/config/clients.config.json) contains information that's common to all clients generated for each language.
 
-Contains information common to every `clients` generated for a language, fields below are required:
+The following fields are required:
 
-| Option               | Description                                                                                                          |
-|----------------------|----------------------------------------------------------------------------------------------------------------------|
-| `folder`             | The path to the parent folder of every clients for this language.                                                    |
-| `gitRepoId`          | The name of the repository of this API client.                                                                       |
-| `packageVersion`     | The version you'd like to publish the first iteration of the generated client. It will be automatically incremented. |
-| `modelFolder`        | The path to the `model` folder that will host the generated code.                                                    |
-| `apiFolder`          | The path to the `api` folder that will host the generated code.                                                      |
-| `tests.extension`    | The extension of a test file, e.g. `.test.java` or `_test.py`                                                        |
-| `tests.outputFolder` | The path to the folder that holds the test for this language, e.g. `tests/`                                          |
-
+| Option               | Description                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `folder`             | Path to the parent folder of every client for this language.                                      |
+| `gitRepoId`          | Name of the repository for this API client.                                                       |
+| `packageVersion`     | Initial version number to publish for the generated client. It will be automatically incremented. |
+| `modelFolder`        | Path to the `model` folder that will host the generated code.                                     |
+| `apiFolder`          | Path to the `api` folder that will host the generated code.                                       |
+| `tests.extension`    | Test file extension, such as `.test.java` or `_test.py`                                           |
+| `tests.outputFolder` | Path to the folder that holds the tests for this language, such as `tests/`                       |
 
 ## 3. Generate the client
 
-You can find all the commands in the [CLI > clients commands page](/docs/contributing/CLI/clients-commands) and [CLI > specs commands page](/docs/contributing/CLI/specs-commands).
+Use the CLI to generate the clients:
 
-## 4. Adding tests with the Common Test Suite
+- [Commands for working with specs](../contributing/CLI/specs-commands.md)
+- [Commands for working with clients](../contributing/CLI/clients-commands.md)
 
-Clients needs to be tested, you can read more in the [Common Test Suite](/docs/contributing/testing/common-test-suite) guide.
+## 4. Add tests with the Common Test Suite
+
+You must add tests for your clients.
+For more information, see [Common Test Suite](../contributing/testing/common-test-suite.md).
 
 ## 5. Helpers
 
-We provide manually written helpers that wrap generated API clients methods in order to ease the user's journey.
+The API clients have hand-written helpers for tasks that would otherwise require custom code.
 
-| Helper name              | Description                                                                                                                                                                               | Wrapped API call            | Stop condition                                          | Example                                                                                                                                                           |
-|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `waitForTask`            | Given a `taskID`, calls the `getTask` method until the status gets `published`                                                                                                            | `getTask()`                 | `response.status == "published"`                        | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L232) |
-| `waitForApiKey`          | Given a `Key`, calls the `getApiKey` method until the stop condition for the given `operation` is validated                                                                               | `getApiKey()`               | Diff between the given `Key` and the `response` payload | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L269) |
-| `browseObjects<T>`       | Given an `indexName` and the same parameters as the `browse` method, aggregates all the `objects` returned by the API calls in a single `browse` response object                          | `browse()`                  | `response.cursor == null`                               | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L342) |
-| `browseRules`            | Given an `indexName` and the same parameters as the `searchRules` method, aggregates all the `rules` returned by the API calls in a single `searchRules` response object                  | `searchRules()`             | `response.nbHits < params.hitsPerPage`                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L379) |
-| `browseSynonyms`         | Given an `indexName` and the same parameters as the `searchSynonyms` method, aggregates all the `synonyms` returned by the API calls in a single `searchSynonyms` response object         | `searchSynonyms()`          | `response.nbHits < params.hitsPerPage`                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L422) |
-| `searchForHits<T>`       | Given the same parameters as the `search` method, returns the API response with the certainty that it will only contain `hits` by casting it to a generic `SearchResponse<T>` object      | `search()`                  | `none`                                                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L462) |
-| `searchForFacets`        | Given the same parameters as the `search` method, returns the API response with the certainty that it will only contain `facets` by casting it to a `SearchForFacetValuesResponse` object | `search()`                  | `none`                                                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L479) |
-| `replaceAllObjects`      | Given an `indexName` and an array of `objects`, replace all objects in this index using a temporary one                                                                                   | `operationIndex(), batch()` | `none`                                                  | [PHP](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-php/lib/Api/SearchClient.php#L2813)                                |
-| `generateSecuredApiKey`  | Given a `indexName` and an array of `restrictions`, generates a secured API Key using the SHA-256 algorithm                                                                               | `none`                      | `none`                                                  | [PHP](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-php/lib/Api/SearchClient.php#L2869)                                |
+| Helper name             | Description                                                                                                                                                                               | Wrapped API call            | Stop condition                                          | Example                                                                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `waitForTask`           | Given a `taskID`, calls the `getTask` method until the status gets `published`                                                                                                            | `getTask()`                 | `response.status == "published"`                        | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L232) |
+| `waitForApiKey`         | Given a `Key`, calls the `getApiKey` method until the stop condition for the given `operation` is validated                                                                               | `getApiKey()`               | Diff between the given `Key` and the `response` payload | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L269) |
+| `browseObjects<T>`      | Given an `indexName` and the same parameters as the `browse` method, aggregates all the `objects` returned by the API calls in a single `browse` response object                          | `browse()`                  | `response.cursor == null`                               | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L342) |
+| `browseRules`           | Given an `indexName` and the same parameters as the `searchRules` method, aggregates all the `rules` returned by the API calls in a single `searchRules` response object                  | `searchRules()`             | `response.nbHits < params.hitsPerPage`                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L379) |
+| `browseSynonyms`        | Given an `indexName` and the same parameters as the `searchSynonyms` method, aggregates all the `synonyms` returned by the API calls in a single `searchSynonyms` response object         | `searchSynonyms()`          | `response.nbHits < params.hitsPerPage`                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L422) |
+| `searchForHits<T>`      | Given the same parameters as the `search` method, returns the API response with the certainty that it will only contain `hits` by casting it to a generic `SearchResponse<T>` object      | `search()`                  | `none`                                                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L462) |
+| `searchForFacets`       | Given the same parameters as the `search` method, returns the API response with the certainty that it will only contain `facets` by casting it to a `SearchForFacetValuesResponse` object | `search()`                  | `none`                                                  | [JavaScript](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts#L479) |
+| `replaceAllObjects`     | Given an `indexName` and an array of `objects`, replace all objects in this index using a temporary one                                                                                   | `operationIndex(), batch()` | `none`                                                  | [PHP](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-php/lib/Api/SearchClient.php#L2813)                                |
+| `generateSecuredApiKey` | Given a `indexName` and an array of `restrictions`, generates a secured API Key using the SHA-256 algorithm                                                                               | `none`                      | `none`                                                  | [PHP](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-php/lib/Api/SearchClient.php#L2869)                                |

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -1,0 +1,161 @@
+---
+title: API documentation
+---
+
+To be a reliable and useful source of truth,
+API documentation must be correct, clear, complete, consistent, and concise.
+
+Use short sentences and write in the present tense.
+
+For more general documentation guidelines,
+see the [Google developer documentation style guide](https://developers.google.com/style).
+
+For information on how to structure spec files to support a new API client,
+see [Add a new API client](./add-new-api-client.md).
+
+## Prefer plain text
+
+The `description` properties of OpenAPI objects support [CommonMark](https://commonmark.org/),
+the specs are used in contexts where Markdown isn't supported.
+
+To make using the specs in these contexts easier, follow these guidelines:
+
+- Don't use HTML.
+- Don't use tables.
+- Don't use headings, except for [API descriptions](#api-descriptions).
+- Prefer using `externalDocs` objects over inline Markdown links.
+- Use inline Markdown links judiciously.
+  Don't link to readily searchable information, such as internet RFCs or Wikipedia.
+
+## API descriptions
+
+Each API spec must include a `description` property in its `info` object.
+In the first sentence, describe what the API does or what it can be used for.
+
+After the introductory sentence, include the following sections.
+For an example, see the [Search API](/specs/search).
+
+- **Client libraries.** For APIs with clients that implement the retry strategy and are covered by the SLA.
+- **Availability.** For APIs that are not available for "regular" Algolia plans.
+- **Base URLs.** List the URLs how users can access the APIs.
+- **Retry strategy.** For APIs with clients that implement the retry strategy.
+- **Authentication.** Explain how to authenticate requests and where to find the credentials.
+- **Request format.** Explain what the expected format for request bodies is.
+- **Parameters.** Explain query and request body parameters, depending on the endpoints of this API.
+- **Response status and errors.** Explain the format of responses and what type of errors are returned.
+- **Version.** Explain the current version of the API.
+
+Use `h1` headings for each section heading to make the section show in the sidebar.
+
+## Operation summaries
+
+Operations are endpoints with a HTTP verb.
+Each operation must have a `summary` property.
+Start with an imperative verb and describe what the operation does in 2 to 3 words.
+
+**Examples:**
+
+- Delete an index
+- List indices
+- Send events
+
+For common operations, use these verbs consistently:
+
+- **Search**. For `/search` endpoints (records, rules, synonyms, etc.).
+- **List**. For operations that return many or all instances of an object.
+- **Retrieve**. For operations that return one instance of an object.
+- **Update**. For operations that update parts of an object without completely replacing it.
+- **Replace**. For operations that replace entire objects.
+
+
+## Operation descriptions
+
+Each operation must have a `description` property.
+Omit the subject and start with a verb in third-person in the present tense.
+Describe what the operation does.
+In many cases, this repeats what is written in the summary,
+but you can expand it.
+
+**Examples:**
+
+- Deletes an index and all its settings ...
+- Lists all indices in the current Algolia application ...
+- Sends a list of events to the Insights API ...
+
+Add paragraphs with more information that users might need when using this endpoint,
+such as limitations, side effects, or any other information that can't be expressed in the schema.
+
+Use the `|` character for multiline descriptions:
+
+```yaml
+description: |
+  A multiline description.
+
+  Multi-paragraph even.
+```
+
+## Properties and parameters
+
+Use a noun phrase to describe what the parameter represents, without articles.
+
+**Examples:**
+
+- `disableTypoToleranceOnAttributes`: Attributes for which you want to turn off typo-tolerance.
+- `maxHitsPerQuery`: Maximum number of API requests allowed per IP address or user token per hour.
+
+### Boolean parameters
+
+Start the description with the word _whether_ and describe what the effect of this parameter is.
+If it's clearer, you can add _if true..._ and _if false..._ to explicitly state the consequences of each value.
+Don't use _whether or not_.
+Use regular font for the literal values _true_ and _false_ (instead of code font).
+
+**Example:**
+
+- `advancedSyntax`: Whether to support phrase matching and excluding words from search queries.
+
+### Dates and timestamps
+
+Don't use the `format` specifier for dates and timestamps.
+
+<details>
+<summary>Why not?</summary>
+
+If you include `format: date` or `format: date-time`,
+the generated code expects formatted date or time objects as input instead of simple strings.
+Strings are straightforward to enter, while date and time objects need to be constructed.
+
+</details>
+
+Instead, include the expected format in the description and provide examples.
+
+To help users with dates and times, be consistent:
+
+- Use **Date and time** for dates in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
+- Use **Timestamp** for timestamps in seconds or milliseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
+
+#### Example: date and time
+
+Use _Date and time ..., in RFC3339 format_.
+Don't link to the RFC, and don't use ISO 8601.
+Don't use _timestamp_ for dates and times.
+
+```
+createdAt:
+  type: string
+  description: Date and time when the object was created, in RFC3339 format.
+  example: 2024-04-06T08:08:08Z
+```
+
+#### Example: timestamp
+
+Use _Timestamp ..., measured in milliseconds since the Unix epoch_.
+Don't use _Unix time_ or _Unix epoch time_.
+
+```
+createdAtTimestamp:
+  type: integer
+  format: int64
+  description: Timestamp when the object was created, measured in milliseconds since the Unix epoch.
+  example: 1656345570000
+```

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -70,7 +70,7 @@ For an example, see the [Search API](/specs/search).
 
 ## Operation summaries
 
-Operations are endpoints with a HTTP verb.
+Operations are endpoints with an HTTP verb.
 Each operation must have a `summary` property.
 Start with an imperative verb and describe what the operation does in 2 to 3 words.
 

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -27,6 +27,25 @@ To make using the specs in these contexts easier, follow these guidelines:
 - Use inline Markdown links judiciously.
   Don't link to readily searchable information, such as internet RFCs or Wikipedia.
 
+## Capitalization
+
+In general, follow the capitalization of the API.
+For example, keys in JSON objects are case-sensitive.
+
+Pay special attention to abbreviations like `taskID` vs `taskId`,
+because the Algolia APIs capitalize them inconsistently.
+
+For case-insensitive properties, follow these conventions.
+
+### Headers
+
+When describing headers, such as the authentication headers `x-algolia-application-id`, prefer lowercase letters.
+
+### Path and query parameters
+
+Use _camelCase_ for parameters, such as `indexName`.
+Use uppercase abbreviations for parameters like `objectID` or `taskID`.
+
 ## API descriptions
 
 Each API spec must include a `description` property in its `info` object.
@@ -67,7 +86,6 @@ For common operations, use these verbs consistently:
 - **Update**. For operations that update parts of an object without completely replacing it.
 - **Replace**. For operations that replace entire objects.
 
-
 ## Operation descriptions
 
 Each operation must have a `description` property.
@@ -94,7 +112,7 @@ description: |
   Multi-paragraph even.
 ```
 
-## Properties and parameters
+## Properties and parameter descriptions
 
 Use a noun phrase to describe what the parameter represents, without articles.
 

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -3,7 +3,9 @@ title: API documentation
 ---
 
 To be a reliable and useful source of truth,
-API documentation must be correct, clear, complete, consistent, and concise.
+API documentation must be correct, clear, complete, and consistent.
+To be as easy to understand as possible,
+API documentation _should_ be concise, while maintaining clarity.
 
 Use short sentences and write in the present tense.
 
@@ -22,7 +24,7 @@ To make using the specs in these contexts easier, follow these guidelines:
 
 - Don't use HTML.
 - Don't use tables.
-- Don't use headings, except for [API descriptions](#api-descriptions).
+- Don't use headings, except in [API descriptions](#api-descriptions).
 - Prefer using `externalDocs` objects over inline Markdown links.
 - Use inline Markdown links judiciously.
   Don't link to readily searchable information, such as internet RFCs or Wikipedia.
@@ -52,6 +54,8 @@ Each API spec must include a `description` property in its `info` object.
 In the first sentence, describe what the API does or what it can be used for.
 
 After the introductory sentence, include the following sections.
+Use `h2` headings.
+
 For an example, see the [Search API](/specs/search).
 
 - **Client libraries.** For APIs with clients that implement the retry strategy and are covered by the SLA.
@@ -63,8 +67,6 @@ For an example, see the [Search API](/specs/search).
 - **Parameters.** Explain query and request body parameters, depending on the endpoints of this API.
 - **Response status and errors.** Explain the format of responses and what type of errors are returned.
 - **Version.** Explain the current version of the API.
-
-Use `h1` headings for each section heading to make the section show in the sidebar.
 
 ## Operation summaries
 

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -129,9 +129,10 @@ Strings are straightforward to enter, while date and time objects need to be con
 
 Instead, include the expected format in the description and provide examples.
 
-To help users with dates and times, be consistent:
+To help users distinguish between dates (strings) and timestamps (integers),
+use the following terms consistently:
 
-- Use **Date and time** for dates in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
+- Use **Date and time** for dates in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
 - Use **Timestamp** for timestamps in seconds or milliseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 #### Example: date and time
@@ -146,6 +147,23 @@ createdAt:
   description: Date and time when the object was created, in RFC3339 format.
   example: 2024-04-06T08:08:08Z
 ```
+
+<details>
+<summary>RFC 3339 vs ISO 8601</summary>
+
+RFC 3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
+Since RFC 3339 is a _profile_ of ISO 8601,
+every RFC 3339 date also complies with ISO 8601,
+but not every ISO 8601 date complies with ISO 8601.
+
+For example, `2024-04-06T00:00:00` conforms to both RFC 3339 and ISO 8601.
+But `20240406T000000` only conforms to ISO 8601, which allows omitting the `-` and `:` separators.
+
+**Exception:** ISO 8601 requires date and time to be separated by `T`,
+whereas RFC 3339 permits a space character for the sake of readability.
+It's best to avoid this ambiguity.
+
+</details>
 
 #### Example: timestamp
 

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -1,5 +1,6 @@
 ---
 title: API documentation
+description: Guidelines for writing API documentation for Algolia's APIs.
 ---
 
 To be a reliable and useful source of truth,
@@ -56,21 +57,85 @@ In the first sentence, describe what the API does or what it can be used for.
 After the introductory sentence, include the following sections.
 Use `h2` headings.
 
-For an example, see the [Search API](/specs/search).
+For consistent documentation of each API,
+use the same wording as the listed example API.
 
-- **Client libraries.** For APIs with clients that implement the retry strategy and are covered by the SLA.
-- **Availability.** For APIs that are not available for "regular" Algolia plans.
-- **Base URLs.** List the URLs how users can access the APIs.
-- **Retry strategy.** For APIs with clients that implement the retry strategy.
-- **Authentication.** Explain how to authenticate requests and where to find the credentials.
-- **Request format.** Explain what the expected format for request bodies is.
-- **Parameters.** Explain query and request body parameters, depending on the endpoints of this API.
-- **Response status and errors.** Explain the format of responses and what type of errors are returned.
-- **Version.** Explain the current version of the API.
+### Client libraries
+
+For APIs with clients that implement the retry strategy,
+the documentation must mention that to be covered by Algolia's SLA,
+users must use the API clients.
+
+**Example:** [Search API](/specs/search#section/Client-libraries)
+
+### Base URLs
+
+All APIs must list the base URLs for making requests.
+If there are multiple base URLs, help users choose by providing guidance and explanations.
+
+**Example:** [Search API](/specs/search#section/Base-URLs)
+
+### Retry strategy
+
+For APIs with clients that implement the retry strategy,
+the documentation must explain the retry strategy.
+
+**Example:** [Search API](/specs/search#section/Base-URLs)
+
+### Availability and authentication
+
+For APIs that require a specific pricing plan (usually a Premium plan),
+or an add-on to the regular Algolia subscription,
+include an _Availability and authentication_ section.
+
+For APIs that are available to every Algolia subscription, see [Authentication](#authentication).
+
+**Example:** [Analytics API](/specs/analytics#section/Availability-and-authentication)
+
+### Authentication
+
+For APIs with requests that require authentication,
+describe the authentication method and where to find the credentials.
+
+For APIs that require a specific Algolia plan, see [Avalavailability-and-authentication](#availability-and-authentication).
+
+**Example:** [Search API](/specs/search#section/Authentication)
+
+### Rate limits
+
+For APIs with rate limits per request,
+describe what the rate limits are and how to check the current rate limits,
+usually with response headers.
+
+**Example:** [Analytics API](/specs/analytics#section/Rate-limits)
+
+### Request format
+
+If the API has `POST`, `PUT`, or `PATCH` requests that require request bodies,
+explain what the expected format is.
+Omit this section if the API only has `GET` or `DELETE` requests.
+
+**Example:** [Search API](/specs/search#section/Request-format)
+
+### Parameters
+
+If the API accepts query or path parameters,
+explain what their expected format is.
+Omit this section if the API doesn't use query or path parameters.
+
+**Example:** [Search API](/specs/search#section/Parameters)
+
+### Response status and errors
+
+Explain the response format, status codes, and error messages.
+
+### Version
+
+State the current version of the API and how to determine it.
 
 ## Operation summaries
 
-Operations are endpoints with an HTTP verb.
+Operations are endpoints combined with an HTTP verb.
 Each operation must have a `summary` property.
 Start with an imperative verb and describe what the operation does in 2 to 3 words.
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable import/no-commonjs */
+const remarkSmartypants = require('remark-smartypants');
 
 const fs = require('fs');
 const path = require('path');
@@ -81,6 +82,7 @@ function getLabel(str) {
               'https://github.com/algolia/api-clients-automation/edit/main/website/',
             showLastUpdateAuthor: true,
             showLastUpdateTime: true,
+            remarkPlugins: [[remarkSmartypants, { dashes: 'oldschool' }]],
           },
           blog: false,
           theme: {

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "clsx": "2.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "redocusaurus": "2.0.2"
+    "redocusaurus": "2.0.2",
+    "remark-smartypants": "^2.1.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -29,6 +29,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "redocusaurus": "2.0.2",
-    "remark-smartypants": "^2.1.0"
+    "remark-smartypants": "2.1.0"
   }
 }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'contributing/add-new-api-client',
+        'contributing/docs',
         'contributing/add-new-language',
         {
           type: 'category',
@@ -45,10 +46,8 @@ const sidebars = {
           type: 'category',
           label: 'CI',
           collapsed: false,
-          items: [
-            'contributing/CI/overview',
-          ]
-        }
+          items: ['contributing/CI/overview'],
+        },
       ],
     },
   ],

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -74,6 +74,10 @@ table tbody tr td h3,
 table tbody tr td h2 {
   margin-top: 16px;
 }
+/* left align table headers */
+table th {
+  text-align: left;
+}
 
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3184,6 +3184,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/nlcst@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "@types/nlcst@npm:1.0.4"
+  dependencies:
+    "@types/unist": "npm:^2"
+  checksum: 7bd08bdf29fc01e335586da6f63a861b721bad0f2d1fcb76ac1f573f6890f5411cf1fbe15fc0d589ffdda17ab94abac60eea1343af92f017298d22048435d24c
+  languageName: node
+  linkType: hard
+
 "@types/node-forge@npm:^1.3.0":
   version: 1.3.11
   resolution: "@types/node-forge@npm:1.3.11"
@@ -3363,7 +3372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/unist@npm:^2.0.0":
+"@types/unist@npm:^2, @types/unist@npm:^2.0.0":
   version: 2.0.10
   resolution: "@types/unist@npm:2.0.10"
   checksum: e2924e18dedf45f68a5c6ccd6015cd62f1643b1b43baac1854efa21ae9e70505db94290434a23da1137d9e31eb58e54ca175982005698ac37300a1c889f6c4aa
@@ -3836,6 +3845,13 @@ __metadata:
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
   checksum: e13c9d247241be82f8b4ec71d035ed7204baa82fae820d4db6948d30d3c4a9f2b3905eb2eec2b937d4aa3565200bd3a1c500480114cff649fa748747d2a50feb
+  languageName: node
+  linkType: hard
+
+"array-iterate@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "array-iterate@npm:2.0.1"
+  checksum: b3db2c865a245dfded8f8dfe280218d2170e2ae8d4f559f6a1f66bdca6523bd406fe2cc99c323c545503f2652ec5ed7b1bbdf3d12eb130bfe980fdde36c33db7
   languageName: node
   linkType: hard
 
@@ -7104,6 +7120,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-buffer@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "is-buffer@npm:2.0.5"
+  checksum: 3261a8b858edcc6c9566ba1694bf829e126faa88911d1c0a747ea658c5d81b14b6955e3a702d59dabadd58fdd440c01f321aa71d6547105fd21d03f94d0597e7
+  languageName: node
+  linkType: hard
+
 "is-ci@npm:^3.0.1":
   version: 3.0.1
   resolution: "is-ci@npm:3.0.1"
@@ -8951,6 +8974,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nlcst-to-string@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "nlcst-to-string@npm:3.1.1"
+  dependencies:
+    "@types/nlcst": "npm:^1.0.0"
+  checksum: c4598918b70ba5bbf96137592dd97149d280458ce68e579e6946729bce909d1d812ee96c2a877c702bd6ae24d47f93b4acfccdeb50fb214ec315cd3979d57cba
+  languageName: node
+  linkType: hard
+
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -9431,6 +9463,17 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
+  languageName: node
+  linkType: hard
+
+"parse-latin@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "parse-latin@npm:5.0.1"
+  dependencies:
+    nlcst-to-string: "npm:^3.0.0"
+    unist-util-modify-children: "npm:^3.0.0"
+    unist-util-visit-children: "npm:^2.0.0"
+  checksum: fee3fe0aea60ed735f62e4d5ddfa1f97b776c5200b9fab2cc04afa7aa38fd165356b9fbe369efc1c74103eca0838f28a910afb36aaace60f3e71d15559acc616
   languageName: node
   linkType: hard
 
@@ -10828,6 +10871,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-smartypants@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "remark-smartypants@npm:2.1.0"
+  dependencies:
+    retext: "npm:^8.1.0"
+    retext-smartypants: "npm:^5.2.0"
+    unist-util-visit: "npm:^5.0.0"
+  checksum: c4c48512a6676312adc54e2fa772b6855b16774a96fa4af120541bba7360a2d7d4e0049cdc767aac9ede967855a2888ed5f3f9910fa1f9d778b877e422bdbc3e
+  languageName: node
+  linkType: hard
+
 "remark-stringify@npm:^11.0.0":
   version: 11.0.0
   resolution: "remark-stringify@npm:11.0.0"
@@ -10943,6 +10997,53 @@ __metadata:
     onetime: "npm:^2.0.0"
     signal-exit: "npm:^3.0.2"
   checksum: 482e13d02d834b6e5e3aa90304a8b5e840775d6f06916cc92a50038adf9f098dcc72405b567da8a37e137ae40ad3e31896fa3136ae62f7a426c2fbf53d036536
+  languageName: node
+  linkType: hard
+
+"retext-latin@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "retext-latin@npm:3.1.0"
+  dependencies:
+    "@types/nlcst": "npm:^1.0.0"
+    parse-latin: "npm:^5.0.0"
+    unherit: "npm:^3.0.0"
+    unified: "npm:^10.0.0"
+  checksum: 1c0eb7430b143b9ac91af44ed6e349df2a691004a4056d77256fc6b2dde2b06688e5b6a3474d43eb606541e39dc84c79e1704a1c768c503671fc6cdc43fd6f95
+  languageName: node
+  linkType: hard
+
+"retext-smartypants@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "retext-smartypants@npm:5.2.0"
+  dependencies:
+    "@types/nlcst": "npm:^1.0.0"
+    nlcst-to-string: "npm:^3.0.0"
+    unified: "npm:^10.0.0"
+    unist-util-visit: "npm:^4.0.0"
+  checksum: d2e2335fddf4ee700fa8416c318330977feaf4667ee08be717b34c0838378db050ea72d65e966e25f8d78156e0dc67c0f204f2b0dc9c758d720a05db46c4837e
+  languageName: node
+  linkType: hard
+
+"retext-stringify@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "retext-stringify@npm:3.1.0"
+  dependencies:
+    "@types/nlcst": "npm:^1.0.0"
+    nlcst-to-string: "npm:^3.0.0"
+    unified: "npm:^10.0.0"
+  checksum: eaafe4fa77d6c25e5caff5cc3dfebaf7cf24cc736f94f099319e58d8f8cc5bb83a59410f1471ece550736bc43c137a6693ecbfc9b1afc166650a33911445639a
+  languageName: node
+  linkType: hard
+
+"retext@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "retext@npm:8.1.0"
+  dependencies:
+    "@types/nlcst": "npm:^1.0.0"
+    retext-latin: "npm:^3.0.0"
+    retext-stringify: "npm:^3.0.0"
+    unified: "npm:^10.0.0"
+  checksum: feea4fa8ae257133adbecaa60f9dc0e8f0496fc90c8587e4925a5e27f91fd4366068cbde71ab2aec12191135ff98d55fa671fda75ff1a5a86deeed4d85cadf49
   languageName: node
   linkType: hard
 
@@ -12090,6 +12191,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unherit@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "unherit@npm:3.0.1"
+  checksum: 36e54f007b8817b5180904c704583e790530950ac57e3eae770ce56bd3c3802018ec3666fcdd38d216c03ab6e3fcc956d12e78b7abaf4355234739a4a56959cf
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.0
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
@@ -12125,6 +12233,21 @@ __metadata:
   version: 2.1.0
   resolution: "unicode-property-aliases-ecmascript@npm:2.1.0"
   checksum: 243524431893649b62cc674d877bd64ef292d6071dd2fd01ab4d5ad26efbc104ffcd064f93f8a06b7e4ec54c172bf03f6417921a0d8c3a9994161fe1f88f815b
+  languageName: node
+  linkType: hard
+
+"unified@npm:^10.0.0":
+  version: 10.1.2
+  resolution: "unified@npm:10.1.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    bail: "npm:^2.0.0"
+    extend: "npm:^3.0.0"
+    is-buffer: "npm:^2.0.0"
+    is-plain-obj: "npm:^4.0.0"
+    trough: "npm:^2.0.0"
+    vfile: "npm:^5.0.0"
+  checksum: 6cffebcefc3290be26d25a58ba714cda943142782baf320fddf374ca3a319bdaabb006f96df4be17b8b367f5e6f6e113b1027c52ef66154846a7a110550f6688
   languageName: node
   linkType: hard
 
@@ -12170,12 +12293,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-is@npm:^5.0.0":
+  version: 5.2.1
+  resolution: "unist-util-is@npm:5.2.1"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+  checksum: c10f6c07aad4f4830ffa8ea82b42a2c8d5cd36c7555e27889e5fee953040af321e4e6f4e52c4edb606604de75d7230a5f4bc7b71b8ac3e874a26ab595c2057e4
+  languageName: node
+  linkType: hard
+
 "unist-util-is@npm:^6.0.0":
   version: 6.0.0
   resolution: "unist-util-is@npm:6.0.0"
   dependencies:
     "@types/unist": "npm:^3.0.0"
   checksum: edd6a93fb2255addf4b9eeb304c1da63c62179aef793169dd64ab955cf2f6814885fe25f95f8105893e3562dead348af535718d7a84333826e0491c04bf42511
+  languageName: node
+  linkType: hard
+
+"unist-util-modify-children@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "unist-util-modify-children@npm:3.1.1"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    array-iterate: "npm:^2.0.0"
+  checksum: c12b4a51726b1e3443db605bbf42037718a06c9e5e3511796ee8d04a458517cf4379af4b5581b607da348027e3689f921b349bc0b6145df948b7481625454aab
   languageName: node
   linkType: hard
 
@@ -12207,12 +12349,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unist-util-stringify-position@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "unist-util-stringify-position@npm:3.0.3"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+  checksum: 07913e4fd77fe57d95f8b2f771354f97a29082229c1ad14ceedce6bbc77b2d784ca8296563335471cdca97915e548204bd6f098ea5b808b822b4b54087662cfb
+  languageName: node
+  linkType: hard
+
 "unist-util-stringify-position@npm:^4.0.0":
   version: 4.0.0
   resolution: "unist-util-stringify-position@npm:4.0.0"
   dependencies:
     "@types/unist": "npm:^3.0.0"
   checksum: d15c88aca7a31902d95d5b5355bbe09583cf6f6ff6e59e134ef76c76d3c30bc1021f2d7ea5b7897c6d0858ed5f3770c1b19de9c78274f50d72f95a0d05f1af71
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-children@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "unist-util-visit-children@npm:2.0.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+  checksum: 02af16ba91b14a57f277e0b73752f4a9420821826ef1b1f0f0c6ba8215bb40ebc5d70e6790d73f828a1903a7cbe953a4c5a39c3220ff279147d59b83ef486e15
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^5.1.1":
+  version: 5.1.3
+  resolution: "unist-util-visit-parents@npm:5.1.3"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-is: "npm:^5.0.0"
+  checksum: 5381fc57a129d478d983b988d86b72a1266d6f91fc608562b00bfa76596128d6e4d1c2b26ced64d96e55eb5d27d620081b4ee9703979bab63e1210789e781372
   languageName: node
   linkType: hard
 
@@ -12223,6 +12393,17 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     unist-util-is: "npm:^6.0.0"
   checksum: 645b3cbc5e923bc692b1eb1a9ca17bffc5aabc25e6090ff3f1489bff8effd1890b28f7a09dc853cb6a7fa0da8581bfebc9b670a68b53c4c086cb9610dfd37701
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^4.0.0":
+  version: 4.1.2
+  resolution: "unist-util-visit@npm:4.1.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-is: "npm:^5.0.0"
+    unist-util-visit-parents: "npm:^5.1.1"
+  checksum: e3b20c6b1f5ae1b7b40bbf9be49103a342d98fad98bdf958110c20d72e5923bd3f12966b6702459bc61ab832facb5af418a79af87cefa7a8a41b892369678b13
   languageName: node
   linkType: hard
 
@@ -12381,6 +12562,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-message@npm:^3.0.0":
+  version: 3.1.4
+  resolution: "vfile-message@npm:3.1.4"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^3.0.0"
+  checksum: 423ca87f4427a403e4688d7ec663a2e6add694eefac47c945746463377428c7553bc613058841f1da83e18b68af886d3dd11cb96d582b5cc3c98e11efb7e55e9
+  languageName: node
+  linkType: hard
+
 "vfile-message@npm:^4.0.0":
   version: 4.0.2
   resolution: "vfile-message@npm:4.0.2"
@@ -12388,6 +12579,18 @@ __metadata:
     "@types/unist": "npm:^3.0.0"
     unist-util-stringify-position: "npm:^4.0.0"
   checksum: 1a5a72bf4945a7103750a3001bd979088ce42f6a01efa8590e68b2425e1afc61ddc5c76f2d3c4a7053b40332b24c09982b68743223e99281158fe727135719fc
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^5.0.0":
+  version: 5.3.7
+  resolution: "vfile@npm:5.3.7"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    is-buffer: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^3.0.0"
+    vfile-message: "npm:^3.0.0"
+  checksum: d8f59b419d4c83b3ed24f500cf02393149b728f8803f88519c18fe0733f62544fa9ab0d8425a8bc7835181d848b9ce29c014168dc45af72f416074bbe475f643
   languageName: node
   linkType: hard
 
@@ -12611,6 +12814,7 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     redocusaurus: "npm:2.0.2"
+    remark-smartypants: "npm:^2.1.0"
   languageName: unknown
   linkType: soft
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -10871,7 +10871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remark-smartypants@npm:^2.1.0":
+"remark-smartypants@npm:2.1.0":
   version: 2.1.0
   resolution: "remark-smartypants@npm:2.1.0"
   dependencies:
@@ -12814,7 +12814,7 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     redocusaurus: "npm:2.0.2"
-    remark-smartypants: "npm:^2.1.0"
+    remark-smartypants: "npm:2.1.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 🧭 What and Why

Improve contribution guidelines for adding new clients and the documentation aspects of it.

### Changes included:

- Edit the "Add new clients" guide to give it a clearer structure and edit for style.
- Add a new "docs" guide to define elements where we want to achieve consistent docs.
- Add the `remark-smartypants` plugin to render straight quotes as "correct" quotes.
- Left-align table headers (looks better IMO)

I'll update the specs to follow these guidelines in a separate PR.