### PR TITLE
feat(javascript): allow custom connect timeout

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -151,17 +151,14 @@ export function createTransporter({
         throw new RetryError(stackTraceWithoutCredentials(stackTrace));
       }
 
-      let responseTimeout = requestOptions.timeout;
-      if (responseTimeout === undefined) {
-        responseTimeout = isRead ? timeouts.read : timeouts.write;
-      }
+      let responseTimeout = isRead ? requestOptions.timeouts?.read || timeouts.read : requestOptions.timeouts?.write || timeouts.write;
 
       const payload: EndRequest = {
         data,
         headers,
         method: request.method,
         url: serializeUrl(host, request.path, queryParameters),
-        connectTimeout: getTimeout(timeoutsCount, timeouts.connect),
+        connectTimeout: getTimeout(timeoutsCount, requestOptions.timeouts?.connect || timeouts.connect),
         responseTimeout: getTimeout(timeoutsCount, responseTimeout),
       };
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
@@ -11,7 +11,7 @@ export type RequestOptions = Pick<Request, 'cacheable'> & {
    * the given timeout will be applied. But the transporter layer may
    * increase this timeout if there is need for it.
    */
-  timeout?: number;
+  timeouts?: Partial<Timeouts>;
 
   /**
    * Custom headers for the request. This headers are


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

we don't allow custom connect timeouts with request options on the javascript client, we can make it more flexible