### PR TITLE
fix(specs): remove periods on summaries

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     '**/target',
     '**/.yarn',
     'website/specs',
-    '**/project.packagespec.json'
+    '**/project.packagespec.json',
   ],
 
   overrides: [
@@ -52,6 +52,7 @@ module.exports = {
           files: ['specs/**/*.yml'],
           rules: {
             'automation-custom/end-with-dot': 'error',
+            'automation-custom/no-final-dot': 'error',
             'automation-custom/single-quote-ref': 'error',
           },
           overrides: [
@@ -149,7 +150,7 @@ module.exports = {
 
       parserOptions: {
         tsconfigRootDir: __dirname,
-        project: './clients/algoliasearch-client-javascript/tsconfig.json'
+        project: './clients/algoliasearch-client-javascript/tsconfig.json',
       },
 
       rules: {
@@ -183,6 +184,6 @@ module.exports = {
       rules: {
         'automation-custom/no-new-line': 'error',
       },
-    }
+    },
   ],
 };

--- a/eslint/src/index.ts
+++ b/eslint/src/index.ts
@@ -1,4 +1,5 @@
 import { endWithDot } from './rules/endWithDot';
+import { noFinalDot } from './rules/noFinalDot';
 import { noNewLine } from './rules/noNewLine';
 import { createOutOfLineRule } from './rules/outOfLineRule';
 import { singleQuoteRef } from './rules/singleQuoteRef';
@@ -6,6 +7,7 @@ import { validACL } from './rules/validACL';
 
 const rules = {
   'end-with-dot': endWithDot,
+  'no-final-dot': noFinalDot,
   'out-of-line-enum': createOutOfLineRule({ property: 'enum' }),
   'out-of-line-one-of': createOutOfLineRule({ property: 'oneOf' }),
   'out-of-line-all-of': createOutOfLineRule({ property: 'allOf' }),

--- a/eslint/src/rules/endWithDot.ts
+++ b/eslint/src/rules/endWithDot.ts
@@ -5,10 +5,10 @@ import { isBlockScalar, isPairWithKey, isScalar } from '../utils';
 export const endWithDot: Rule.RuleModule = {
   meta: {
     docs: {
-      description: '`description`, `summary` must end with a dot',
+      description: '`description` must end with a period',
     },
     messages: {
-      endWithDot: 'content does not end with a dot',
+      endWithDot: 'description does not end with a period',
     },
     fixable: 'code',
   },
@@ -20,8 +20,7 @@ export const endWithDot: Rule.RuleModule = {
     return {
       YAMLPair(node): void {
         if (
-          !isPairWithKey(node, 'description') &&
-          !isPairWithKey(node, 'summary')
+          !isPairWithKey(node, 'description')
         ) {
           return;
         }

--- a/eslint/src/rules/noFinalDot.ts
+++ b/eslint/src/rules/noFinalDot.ts
@@ -1,0 +1,52 @@
+import type { Rule } from 'eslint';
+
+import { isBlockScalar, isPairWithKey, isScalar } from '../utils';
+
+export const noFinalDot: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: '`summary` must not end with a period',
+    },
+    messages: {
+      noFinalDot: 'summary ends with a period',
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    if (!context.sourceCode.parserServices.isYAML) {
+      return {};
+    }
+
+    return {
+      YAMLPair(node): void {
+        if (!isPairWithKey(node, 'summary')) {
+          return;
+        }
+
+        if (!isScalar(node.value)) {
+          return;
+        }
+
+        const value = node.value;
+        if (
+          typeof value.value !== 'string' ||
+          !value.value.trim().endsWith('.')
+        ) {
+          // The rule is respected if:
+          // the summary is not a string
+          // or it doesn't end with a dot.
+          return;
+        }
+
+        context.report({
+          node: node as any,
+          messageId: 'noFinalDot',
+          fix(fixer) {
+            const end = node.range[1];
+            return fixer.removeRange([end - 1, end]);
+          },
+        });
+      },
+    };
+  },
+};

--- a/eslint/src/rules/noFinalDot.ts
+++ b/eslint/src/rules/noFinalDot.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint';
 
-import { isBlockScalar, isPairWithKey, isScalar } from '../utils';
+import { isPairWithKey, isScalar } from '../utils';
 
 export const noFinalDot: Rule.RuleModule = {
   meta: {

--- a/eslint/tests/noFinalDot.test.ts
+++ b/eslint/tests/noFinalDot.test.ts
@@ -1,0 +1,27 @@
+import { RuleTester } from 'eslint';
+
+import { noFinalDot } from '../src/rules/noFinalDot';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('yaml-eslint-parser'),
+});
+
+ruleTester.run('no-final-dot', noFinalDot, {
+  valid: [`summary: Valid summary`],
+  invalid: [
+    {
+      code: `summary: Has final dot.`,
+      errors: [{ messageId: 'noFinalDot' }],
+      output: `summary: Has final dot`,
+    },
+    {
+      code: `summary: With dot and newline.
+
+      `,
+      errors: [{ messageId: 'noFinalDot' }],
+      output: `summary: With dot and newline
+
+      `,
+    },
+  ],
+});

--- a/specs/abtesting/paths/abtest.yml
+++ b/specs/abtesting/paths/abtest.yml
@@ -4,7 +4,7 @@ get:
   operationId: getABTest
   x-acl:
     - analytics
-  summary: Retrieve A/B test details.
+  summary: Retrieve A/B test details
   description: Retrieves the details for an A/B test by its ID.
   parameters:
     - $ref: '../common/parameters.yml#/ID'
@@ -37,7 +37,7 @@ delete:
   operationId: deleteABTest
   x-acl:
     - editSettings
-  summary: Delete an A/B test.
+  summary: Delete an A/B test
   description: Deletes an A/B test by its ID.
   parameters:
     - $ref: '../common/parameters.yml#/ID'

--- a/specs/abtesting/paths/abtests.yml
+++ b/specs/abtesting/paths/abtests.yml
@@ -4,7 +4,7 @@ post:
   operationId: addABTests
   x-acl:
     - editSettings
-  summary: Create an A/B test.
+  summary: Create an A/B test
   description: Creates a new A/B test.
   requestBody:
     required: true
@@ -59,7 +59,7 @@ get:
   operationId: listABTests
   x-acl:
     - analytics
-  summary: List all A/B tests.
+  summary: List all A/B tests
   description: Lists all A/B tests you configured for this application.
   parameters:
     - $ref: '../../common/parameters.yml#/Offset'

--- a/specs/abtesting/paths/stopABTest.yml
+++ b/specs/abtesting/paths/stopABTest.yml
@@ -4,7 +4,7 @@ post:
   operationId: stopABTest
   x-acl:
     - editSettings
-  summary: Stop an A/B test.
+  summary: Stop an A/B test
   description: |
     Stops an A/B test by its ID.
 

--- a/specs/analytics/paths/click/getAddToCartRate.yml
+++ b/specs/analytics/paths/click/getAddToCartRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getAddToCartRate
   x-acl:
     - analytics
-  summary: Retrieve add-to-cart rate.
+  summary: Retrieve add-to-cart rate
   description: |
     Retrieves the add-to-cart rate for all of your searches with at least one add-to-cart event, including a daily breakdown.
 

--- a/specs/analytics/paths/click/getAverageClickPosition.yml
+++ b/specs/analytics/paths/click/getAverageClickPosition.yml
@@ -4,7 +4,7 @@ get:
   operationId: getAverageClickPosition
   x-acl:
     - analytics
-  summary: Retrieve average click position.
+  summary: Retrieve average click position
   description: |
     Retrieves the average click position of your search results, including a daily breakdown.
 

--- a/specs/analytics/paths/click/getClickPositions.yml
+++ b/specs/analytics/paths/click/getClickPositions.yml
@@ -4,7 +4,7 @@ get:
   operationId: getClickPositions
   x-acl:
     - analytics
-  summary: Retrieve click positions.
+  summary: Retrieve click positions
   description: |
     Retrieves the positions in the search results and their associated number of clicks.
 

--- a/specs/analytics/paths/click/getClickThroughRate.yml
+++ b/specs/analytics/paths/click/getClickThroughRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getClickThroughRate
   x-acl:
     - analytics
-  summary: Retrieve click-through rate.
+  summary: Retrieve click-through rate
   description: |
     Retrieves the click-through rate for all of your searches with at least one click event, including a daily breakdown
 

--- a/specs/analytics/paths/click/getConversionRate.yml
+++ b/specs/analytics/paths/click/getConversionRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getConversionRate
   x-acl:
     - analytics
-  summary: Retrieve conversion rate.
+  summary: Retrieve conversion rate
   description: |
     Retrieves the conversion rate for all of your searches with at least one conversion event, including a daily breakdown.
 

--- a/specs/analytics/paths/click/getPurchaseRate.yml
+++ b/specs/analytics/paths/click/getPurchaseRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getPurchaseRate
   x-acl:
     - analytics
-  summary: Retrieve purchase rate.
+  summary: Retrieve purchase rate
   description: |
     Retrieves the purchase rate for all of your searches with at least one purchase event, including a daily breakdown.
 

--- a/specs/analytics/paths/revenue/getRevenue.yml
+++ b/specs/analytics/paths/revenue/getRevenue.yml
@@ -4,7 +4,7 @@ get:
   operationId: getRevenue
   x-acl:
     - analytics
-  summary: Retrieve revenue data.
+  summary: Retrieve revenue data
   description: |
     Retrieves revenue-related metrics, such as the total revenue or the average order value.
 

--- a/specs/analytics/paths/search/getNoClickRate.yml
+++ b/specs/analytics/paths/search/getNoClickRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getNoClickRate
   x-acl:
     - analytics
-  summary: Retrieve no click rate.
+  summary: Retrieve no click rate
   description: |
     Retrieves the fraction of searches that didn't lead to any click within a time range, including a daily breakdown.
 

--- a/specs/analytics/paths/search/getNoResultsRate.yml
+++ b/specs/analytics/paths/search/getNoResultsRate.yml
@@ -4,7 +4,7 @@ get:
   operationId: getNoResultsRate
   x-acl:
     - analytics
-  summary: Retrieve no results rate.
+  summary: Retrieve no results rate
   description: |
     Retrieves the fraction of searches that didn't return any results within a time range, including a daily breakdown.
 

--- a/specs/analytics/paths/search/getSearchesCount.yml
+++ b/specs/analytics/paths/search/getSearchesCount.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSearchesCount
   x-acl:
     - analytics
-  summary: Retrieve number of searches.
+  summary: Retrieve number of searches
   description: |
     Retrieves the number of searches within a time range, including a daily breakdown.
 

--- a/specs/analytics/paths/search/getSearchesNoClicks.yml
+++ b/specs/analytics/paths/search/getSearchesNoClicks.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSearchesNoClicks
   x-acl:
     - analytics
-  summary: Retrieve top searches without clicks.
+  summary: Retrieve top searches without clicks
   description: Retrieves the most popular searches that didn't lead to any clicks, from the 1,000 most frequent searches.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'

--- a/specs/analytics/paths/search/getSearchesNoResults.yml
+++ b/specs/analytics/paths/search/getSearchesNoResults.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSearchesNoResults
   x-acl:
     - analytics
-  summary: Retrieve top searches without results.
+  summary: Retrieve top searches without results
   description: Retrieves the most popular searches that didn't return any results.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'

--- a/specs/analytics/paths/search/getTopCountries.yml
+++ b/specs/analytics/paths/search/getTopCountries.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopCountries
   x-acl:
     - analytics
-  summary: Retrieve top countries.
+  summary: Retrieve top countries
   description: Retrieves the countries with the most searches to your index.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'

--- a/specs/analytics/paths/search/getTopFilterAttributes.yml
+++ b/specs/analytics/paths/search/getTopFilterAttributes.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopFilterAttributes
   x-acl:
     - analytics
-  summary: Retrieve top filters.
+  summary: Retrieve top filters
   description: |
     Retrieves the most frequently used filter attributes.
 

--- a/specs/analytics/paths/search/getTopFilterForAttribute.yml
+++ b/specs/analytics/paths/search/getTopFilterForAttribute.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopFilterForAttribute
   x-acl:
     - analytics
-  summary: Retrieve top filter values.
+  summary: Retrieve top filter values
   description: |
     Retrieves the most frequent filter (facet) values for a filter attribute.
 

--- a/specs/analytics/paths/search/getTopFiltersNoResults.yml
+++ b/specs/analytics/paths/search/getTopFiltersNoResults.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopFiltersNoResults
   x-acl:
     - analytics
-  summary: Retrieve top filters for a search without results.
+  summary: Retrieve top filters for a search without results
   description: |
     Retrieves the most frequently used filters for a search that didn't return any results.
 

--- a/specs/analytics/paths/search/getTopHits.yml
+++ b/specs/analytics/paths/search/getTopHits.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopHits
   x-acl:
     - analytics
-  summary: Retrieve top search results.
+  summary: Retrieve top search results
   description: Retrieves the object IDs of the most frequent search results.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'

--- a/specs/analytics/paths/search/getTopSearches.yml
+++ b/specs/analytics/paths/search/getTopSearches.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopSearches
   x-acl:
     - analytics
-  summary: Retrieve top searches.
+  summary: Retrieve top searches
   description: Returns the most popular search terms.
   parameters:
     - $ref: '../../../common/parameters.yml#/Index'

--- a/specs/analytics/paths/search/getUsersCount.yml
+++ b/specs/analytics/paths/search/getUsersCount.yml
@@ -4,7 +4,7 @@ get:
   operationId: getUsersCount
   x-acl:
     - analytics
-  summary: Retrieve number of users.
+  summary: Retrieve number of users
   description: |
     Retrieves the number of unique users within a time range, including a daily breakdown.
 

--- a/specs/analytics/paths/status/getStatus.yml
+++ b/specs/analytics/paths/status/getStatus.yml
@@ -4,7 +4,7 @@ get:
   operationId: getStatus
   x-acl:
     - analytics
-  summary: Retrieve update status.
+  summary: Retrieve update status
   description: |
     Retrieves the time when the Analytics data for the specified index was last updated.
 

--- a/specs/common/schemas/CustomRequest.yml
+++ b/specs/common/schemas/CustomRequest.yml
@@ -1,5 +1,5 @@
 customRequest:
-  summary: Send requests to the Algolia REST API.
+  summary: Send requests to the Algolia REST API
   description: This method allow you to send requests to the Algolia REST API.
   parameters:
     - $ref: '#/PathInPath'

--- a/specs/crawler/paths/crawler.yml
+++ b/specs/crawler/paths/crawler.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getCrawler
-  summary: Retrieve crawler details.
+  summary: Retrieve crawler details
   description: |
     Retrieves details about the specified crawler, optionally with its configuration.
   tags:
@@ -27,7 +27,7 @@ get:
       $ref: '../common/schemas/responses.yml#/NoRightsOnCrawler'
 patch:
   operationId: patchCrawler
-  summary: Update crawler.
+  summary: Update crawler
   description: |
     Updates the crawler, either its name or its configuration.
 

--- a/specs/crawler/paths/crawlerConfig.yml
+++ b/specs/crawler/paths/crawlerConfig.yml
@@ -1,6 +1,6 @@
 patch:
   operationId: patchConfig
-  summary: Update crawler configuration.
+  summary: Update crawler configuration
   description: |
     Updates the configuration of the specified crawler.
     Every time you update the configuration, a new version is created.

--- a/specs/crawler/paths/crawlerConfigVersion.yml
+++ b/specs/crawler/paths/crawlerConfigVersion.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getConfigVersion
-  summary: Retrieve a configuration version.
+  summary: Retrieve a configuration version
   description: |
     Retrieves the specified version of the crawler configuration.
 

--- a/specs/crawler/paths/crawlerConfigVersions.yml
+++ b/specs/crawler/paths/crawlerConfigVersions.yml
@@ -1,6 +1,6 @@
 get:
   operationId: listConfigVersions
-  summary: List configuration versions.
+  summary: List configuration versions
   description: |
     Lists previous versions of the specified crawler's configuration, including who authored the change.
     Every time you [update the configuration](#tag/config/operation/patchConfig) of a crawler,

--- a/specs/crawler/paths/crawlerCrawl.yml
+++ b/specs/crawler/paths/crawlerCrawl.yml
@@ -1,6 +1,6 @@
 post:
   operationId: crawlUrls
-  summary: Crawl URLs.
+  summary: Crawl URLs
   description: |
     Crawls the specified URLs, extracts records from them, and adds them to the index.
     If a crawl is currently running (the crawler's `reindexing` property is true),

--- a/specs/crawler/paths/crawlerPause.yml
+++ b/specs/crawler/paths/crawlerPause.yml
@@ -1,6 +1,6 @@
 post:
   operationId: pauseCrawler
-  summary: Pause a crawler.
+  summary: Pause a crawler
   description: Pauses the specified crawler.
   tags:
     - actions

--- a/specs/crawler/paths/crawlerReindex.yml
+++ b/specs/crawler/paths/crawlerReindex.yml
@@ -1,6 +1,6 @@
 post:
   operationId: startReindex
-  summary: Start a crawl.
+  summary: Start a crawl
   description: Starts or resumes a crawl.
   tags:
     - actions

--- a/specs/crawler/paths/crawlerRun.yml
+++ b/specs/crawler/paths/crawlerRun.yml
@@ -1,6 +1,6 @@
 post:
   operationId: runCrawler
-  summary: Unpause a crawler.
+  summary: Unpause a crawler
   description: |
     Unpauses the specified crawler.
     Previously ongoing crawls will be resumed.

--- a/specs/crawler/paths/crawlerStats.yml
+++ b/specs/crawler/paths/crawlerStats.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getStats
-  summary: Retrieve crawler stats.
+  summary: Retrieve crawler stats
   description: Retrieves information about the number of crawled, skipped, and failed URLs.
   tags:
     - crawlers

--- a/specs/crawler/paths/crawlerTask.yml
+++ b/specs/crawler/paths/crawlerTask.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getTaskStatus
-  summary: Retrieve task status.
+  summary: Retrieve task status
   description: Retrieves the status of the specified tasks, whether they're pending or completed.
   tags:
     - tasks

--- a/specs/crawler/paths/crawlerTaskCancel.yml
+++ b/specs/crawler/paths/crawlerTaskCancel.yml
@@ -1,6 +1,6 @@
 post:
   operationId: cancelBlockingAction
-  summary: Cancel a blocking task.
+  summary: Cancel a blocking task
   description: |
     Cancels a blocking task.
 

--- a/specs/crawler/paths/crawlerTest.yml
+++ b/specs/crawler/paths/crawlerTest.yml
@@ -1,6 +1,6 @@
 post:
   operationId: testUrl
-  summary: Test crawling a URL.
+  summary: Test crawling a URL
   description: |
     Tests a URL with the crawler's configuration and shows the extracted records.
 

--- a/specs/crawler/paths/crawlers.yml
+++ b/specs/crawler/paths/crawlers.yml
@@ -1,6 +1,6 @@
 get:
   operationId: listCrawlers
-  summary: List crawlers.
+  summary: List crawlers
   description: Lists all your crawlers.
   tags:
     - crawlers
@@ -26,7 +26,7 @@ get:
       description: The call does not have results for this combinaison of query params.
 post:
   operationId: createCrawler
-  summary: Create a crawler.
+  summary: Create a crawler
   description: Creates a new crawler with the provided configuration.
   tags:
     - crawlers

--- a/specs/crawler/paths/docsearch.yml
+++ b/specs/crawler/paths/docsearch.yml
@@ -1,6 +1,6 @@
 post:
   operationId: createDocSearchApp
-  summary: Create a new Algolia app with the DocSearch plan.
+  summary: Create a new Algolia app with the DocSearch plan
   description: Create a new Algolia app with the DocSearch plan.
   requestBody:
     content:

--- a/specs/crawler/paths/domains.yml
+++ b/specs/crawler/paths/domains.yml
@@ -1,6 +1,6 @@
 get:
   operationId: listDomains
-  summary: List registered domains.
+  summary: List registered domains
   description: |
     Lists registered domains.
 

--- a/specs/ingestion/paths/authentications/authenticationID.yml
+++ b/specs/ingestion/paths/authentications/authenticationID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - authentications
-  summary: Retrieve an authentication resource.
+  summary: Retrieve an authentication resource
   description: Retrieves an authentication resource by its ID.
   operationId: getAuthentication
   x-acl:
@@ -23,7 +23,7 @@ get:
 patch:
   tags:
     - authentications
-  summary: Update an authentication resource.
+  summary: Update an authentication resource
   description: Updates an authentication resource.
   operationId: updateAuthentication
   x-acl:
@@ -51,7 +51,7 @@ patch:
 delete:
   tags:
     - authentications
-  summary: Delete an authentication resource.
+  summary: Delete an authentication resource
   description: Deletes an authentication resource. You can't delete authentication resources that are used by a source or a destination.
   operationId: deleteAuthentication
   x-acl:

--- a/specs/ingestion/paths/authentications/authentications.yml
+++ b/specs/ingestion/paths/authentications/authentications.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - authentications
-  summary: List authentication resources.
+  summary: List authentication resources
   description: Retrieves a list of all authentication resources.
   operationId: getAuthentications
   x-acl:
@@ -40,7 +40,7 @@ get:
 post:
   tags:
     - authentications
-  summary: Create an authentication resource.
+  summary: Create an authentication resource
   description: Creates a new authentication resource.
   operationId: createAuthentication
   x-acl:

--- a/specs/ingestion/paths/authentications/searchAuthentications.yml
+++ b/specs/ingestion/paths/authentications/searchAuthentications.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - authentications
-  summary: Search for authentication resources.
+  summary: Search for authentication resources
   description: Searches for authentication resources.
   operationId: searchAuthentications
   x-acl:

--- a/specs/ingestion/paths/destinations/destinationID.yml
+++ b/specs/ingestion/paths/destinations/destinationID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - destinations
-  summary: Retrieve a destination.
+  summary: Retrieve a destination
   description: Retrieves a destination by its ID.
   operationId: getDestination
   x-acl:
@@ -23,7 +23,7 @@ get:
 patch:
   tags:
     - destinations
-  summary: Update a destination.
+  summary: Update a destination
   description: Updates the destination by its ID.
   operationId: updateDestination
   x-acl:
@@ -51,7 +51,7 @@ patch:
 delete:
   tags:
     - destinations
-  summary: Delete a destination.
+  summary: Delete a destination
   description: Deletes a destination by its ID. You can't delete destinations that are referenced in tasks.
   operationId: deleteDestination
   x-acl:

--- a/specs/ingestion/paths/destinations/destinations.yml
+++ b/specs/ingestion/paths/destinations/destinations.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - destinations
-  summary: List destinations.
+  summary: List destinations
   description: Retrieves a list of destinations.
   operationId: getDestinations
   x-acl:
@@ -40,7 +40,7 @@ get:
 post:
   tags:
     - destinations
-  summary: Create a destination.
+  summary: Create a destination
   description: Creates a new destination.
   operationId: createDestination
   x-acl:

--- a/specs/ingestion/paths/destinations/searchDestinations.yml
+++ b/specs/ingestion/paths/destinations/searchDestinations.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - destinations
-  summary: Search for destinations.
+  summary: Search for destinations
   description: Searches for destinations.
   operationId: searchDestinations
   x-acl:

--- a/specs/ingestion/paths/runs/events/eventID.yml
+++ b/specs/ingestion/paths/runs/events/eventID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - observability
-  summary: Retrieve a task run event.
+  summary: Retrieve a task run event
   description: Retrieves a single task run event by its ID.
   operationId: getEvent
   x-acl:

--- a/specs/ingestion/paths/runs/events/events.yml
+++ b/specs/ingestion/paths/runs/events/events.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - observability
-  summary: List task run events.
+  summary: List task run events
   description: Retrieves a list of events for a task run, identified by it's ID.
   operationId: getEvents
   x-acl:

--- a/specs/ingestion/paths/runs/runID.yml
+++ b/specs/ingestion/paths/runs/runID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - observability
-  summary: Retrieve a task run.
+  summary: Retrieve a task run
   description: Retrieve a single task run by its ID.
   operationId: getRun
   x-acl:

--- a/specs/ingestion/paths/runs/runs.yml
+++ b/specs/ingestion/paths/runs/runs.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - observability
-  summary: List task runs.
+  summary: List task runs
   description: Retrieve a list of task runs.
   operationId: getRuns
   x-acl:

--- a/specs/ingestion/paths/sources/discover.yml
+++ b/specs/ingestion/paths/sources/discover.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - sources
-  summary: Retrieve a stream listing.
+  summary: Retrieve a stream listing
   description: |
     Retrieves a stream listing for a source.
 
@@ -35,7 +35,7 @@ get:
 post:
   tags:
     - sources
-  summary: Trigger a stream-listing request.
+  summary: Trigger a stream-listing request
   description: |
     Triggers a stream-listing request for a source.
     Triggering stream-listing requests only works with sources with `type: docker` and `imageType: singer`.

--- a/specs/ingestion/paths/sources/searchSources.yml
+++ b/specs/ingestion/paths/sources/searchSources.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - sources
-  summary: Search for sources.
+  summary: Search for sources
   description: Searches for sources.
   operationId: searchSources
   x-acl:

--- a/specs/ingestion/paths/sources/sourceID.yml
+++ b/specs/ingestion/paths/sources/sourceID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - sources
-  summary: Retrieve a source.
+  summary: Retrieve a source
   description: Retrieve a source by its ID.
   operationId: getSource
   x-acl:
@@ -23,7 +23,7 @@ get:
 patch:
   tags:
     - sources
-  summary: Update a source.
+  summary: Update a source
   description: Updates a source by its ID.
   operationId: updateSource
   x-acl:
@@ -51,7 +51,7 @@ patch:
 delete:
   tags:
     - sources
-  summary: Delete a source.
+  summary: Delete a source
   description: Deletes a source by its ID. You can't delete sources that are referenced in tasks.
   operationId: deleteSource
   x-acl:

--- a/specs/ingestion/paths/sources/sources.yml
+++ b/specs/ingestion/paths/sources/sources.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - sources
-  summary: List sources.
+  summary: List sources
   description: Retrieves a list of sources.
   operationId: getSources
   x-acl:
@@ -40,7 +40,7 @@ get:
 post:
   tags:
     - sources
-  summary: Create a source.
+  summary: Create a source
   description: Creates a new source.
   operationId: createSource
   x-acl:

--- a/specs/ingestion/paths/tasks/disableTask.yml
+++ b/specs/ingestion/paths/tasks/disableTask.yml
@@ -1,7 +1,7 @@
 put:
   tags:
     - tasks
-  summary: Disable a task.
+  summary: Disable a task
   description: Disables a task.
   operationId: disableTask
   x-acl:

--- a/specs/ingestion/paths/tasks/enableTask.yml
+++ b/specs/ingestion/paths/tasks/enableTask.yml
@@ -1,7 +1,7 @@
 put:
   tags:
     - tasks
-  summary: Enable a task.
+  summary: Enable a task
   description: Enables a task.
   operationId: enableTask
   x-acl:

--- a/specs/ingestion/paths/tasks/runTask.yml
+++ b/specs/ingestion/paths/tasks/runTask.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - tasks
-  summary: Run a task.
+  summary: Run a task
   description: Runs a task. You can check the status of task runs with the observability endpoints.
   operationId: runTask
   x-acl:

--- a/specs/ingestion/paths/tasks/searchTasks.yml
+++ b/specs/ingestion/paths/tasks/searchTasks.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - tasks
-  summary: Search for tasks.
+  summary: Search for tasks
   description: Searches for tasks.
   operationId: searchTasks
   x-acl:

--- a/specs/ingestion/paths/tasks/taskID.yml
+++ b/specs/ingestion/paths/tasks/taskID.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - tasks
-  summary: Retrieve a task.
+  summary: Retrieve a task
   description: Retrieves a task by its ID.
   operationId: getTask
   x-acl:
@@ -23,7 +23,7 @@ get:
 patch:
   tags:
     - tasks
-  summary: Update a task.
+  summary: Update a task
   description: Updates a task by its ID.
   operationId: updateTask
   parameters:
@@ -47,7 +47,7 @@ patch:
 delete:
   tags:
     - tasks
-  summary: Delete a task.
+  summary: Delete a task
   description: Deletes a task by its ID.
   operationId: deleteTask
   parameters:

--- a/specs/ingestion/paths/tasks/tasks.yml
+++ b/specs/ingestion/paths/tasks/tasks.yml
@@ -1,7 +1,7 @@
 get:
   tags:
     - tasks
-  summary: List tasks.
+  summary: List tasks
   description: Retrieves a list of tasks.
   operationId: getTasks
   x-acl:
@@ -44,7 +44,7 @@ get:
 post:
   tags:
     - tasks
-  summary: Create a task.
+  summary: Create a task
   description: Creates a new task.
   operationId: createTask
   requestBody:

--- a/specs/insights/paths/deleteUserToken.yml
+++ b/specs/insights/paths/deleteUserToken.yml
@@ -2,7 +2,7 @@ delete:
   tags:
     - usertokens
   operationId: deleteUserToken
-  summary: Delete user token.
+  summary: Delete user token
   description: |
     Deletes all events related to the specified user token from events metrics and analytics.
     To delete a personalization user profile, see [Delete a user profile](/specs/personalization#tag/profiles/operation/deleteUserProfile).

--- a/specs/insights/paths/pushEvents.yml
+++ b/specs/insights/paths/pushEvents.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - events
   operationId: pushEvents
-  summary: Send events.
+  summary: Send events
   description: |
     Sends a list of events to the Insights API.
 
@@ -31,7 +31,7 @@ post:
                 $ref: '../common/schemas/EventsItems.yml'
         examples:
           ClickObjectIDsAfterSearch:
-            summary: Click event after search requests.
+            summary: Click event after search requests
             value:
               events:
                 - eventName: Products Clicked
@@ -43,7 +43,7 @@ post:
                   positions: [1]
                   queryID: 7dfe2ada7bca48bdd0629649df0bee07
           ConversionObjectIDsAfterSearch:
-            summary: Conversion event after search or browse requests.
+            summary: Conversion event after search or browse requests
             value:
               events:
                 - eventName: Articles Liked
@@ -54,7 +54,7 @@ post:
                   objectIDs: ['article-1']
                   queryID: 7dfe2ada7bca48bdd0629649df0bee07
           AddedToCartAfterSearch:
-            summary: Add-to-cart event after search or browse requests.
+            summary: Add-to-cart event after search or browse requests
             value:
               events:
                 - eventName: Products Added To Cart
@@ -70,7 +70,7 @@ post:
                   currency: USD
                   queryID: 7dfe2ada7bca48bdd0629649df0bee07
           PurchasedAfterSearch:
-            summary: Purchase event after search or browse requests.
+            summary: Purchase event after search or browse requests
             value:
               events:
                 - eventName: Products Purchased
@@ -92,7 +92,7 @@ post:
                   value: 69.97
                   currency: USD
           ClickObjectIDs:
-            summary: Click event.
+            summary: Click event
             value:
               events:
                 - eventName: Products Clicked
@@ -102,7 +102,7 @@ post:
                   authenticatedUserToken: user-1
                   objectIDs: ['object-1']
           ConversionObjectIDs:
-            summary: Conversion event.
+            summary: Conversion event
             value:
               events:
                 - eventName: Products Added To Cart
@@ -112,7 +112,7 @@ post:
                   authenticatedUserToken: user-1
                   objectIDs: ['object-1']
           AddedToCart:
-            summary: Add-to-cart event.
+            summary: Add-to-cart event
             value:
               events:
                 - eventName: Products Added To Cart
@@ -127,7 +127,7 @@ post:
                       quantity: 1
                   currency: EUR
           Purchased:
-            summary: Purchase event.
+            summary: Purchase event
             value:
               events:
                 - eventName: Products Purchased
@@ -145,7 +145,7 @@ post:
                   currency: USD
                   value: 69.97
           ClickFilter:
-            summary: Click event with filters.
+            summary: Click event with filters
             value:
               events:
                 - eventName: Category Clicked
@@ -155,7 +155,7 @@ post:
                   authenticatedUserToken: user-1
                   filters: ['category:books']
           ConversionFilter:
-            summary: Conversion event with filters.
+            summary: Conversion event with filters
             value:
               events:
                 - eventName: Category Converted
@@ -165,7 +165,7 @@ post:
                   authenticatedUserToken: user-1
                   filters: ['category:books']
           ViewObjectIDs:
-            summary: View event.
+            summary: View event
             value:
               events:
                 - eventName: Products Viewed
@@ -175,7 +175,7 @@ post:
                   authenticatedUserToken: user-1
                   objectIDs: ['object-1']
           ViewFilters:
-            summary: View event with filters.
+            summary: View event with filters
             value:
               events:
                 - eventName: Category Viewed
@@ -194,7 +194,7 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             Success:
-              summary: Events successfully sent to the Insights API.
+              summary: Events successfully sent to the Insights API
               description: >-
                 Success indicates that the Insights API received the events correctly,
                 and that event properties are formatted correctly.
@@ -213,7 +213,7 @@ post:
             title: HTML
           examples:
             BadRequest:
-              summary: Bad request.
+              summary: Bad request
               description: This error doesn't return a JSON object, but HTML.
               value: 'Error: Bad Request. Your client has issued a malformed or illegal request.'
     '401':
@@ -224,7 +224,7 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             Unauthorized:
-              summary: Invalid credentials.
+              summary: Invalid credentials
               description: You need to provide your application ID using the `X-Algolia-Application-ID` header and your (search) API key with the `X-Algolia-API-Key` header.
               value:
                 status: 401
@@ -237,7 +237,7 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             NotFound:
-              summary: Unsupported operation.
+              summary: Unsupported operation
               description: Check that you're using the correct URL.
               value:
                 status: 404
@@ -250,7 +250,7 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             MethodNotAllowed:
-              summary: Method not allowed.
+              summary: Method not allowed
               description: Check, that you send events with the `POST` method.
               value:
                 status: 405
@@ -263,7 +263,7 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             PayloadTooLarge:
-              summary: Request body larger than 2&nbspMB.
+              summary: Request body larger than 2&nbspMB
               value:
                 status: 413
                 message: Request Entity Too Large
@@ -275,12 +275,12 @@ post:
             $ref: '../common/schemas/EventsResponse.yml'
           examples:
             InvalidPayload:
-              summary: Incorrect event object.
+              summary: Incorrect event object
               value:
                 status: 422
                 message: Invalid payload
             NoEvents:
-              summary: No events.
+              summary: No events
               description: >-
                 This can happen if you're sending an empty `events` array,
                 or if you try to send a single event object instead of the `events` array.
@@ -288,76 +288,76 @@ post:
                 status: 422
                 message: No events to process
             NoEventsField:
-              summary: Missing events attribute.
+              summary: Missing events attribute
               description: This can happen if you try to send an array of events directly instead of using the `events` attribute.
               value:
                 status: 422
                 message: 'Invalid type for field : expected insights.PublicEventsBatch, got array'
             EventNameRequired:
-              summary: Missing eventName attribute.
+              summary: Missing eventName attribute
               value:
                 status: 422
                 message: EventName is required
             WrongEventName:
-              summary: Event name too long or wrong characters.
+              summary: Event name too long or wrong characters
               value:
                 status: 422
                 message: EventName must contain only visible ASCII characters, and be between 1 and 64 characters long
             EventTypeRequired:
-              summary: Missing eventType attribute.
+              summary: Missing eventType attribute
               value:
                 status: 422
                 message: EventType is required
             WrongEventType:
-              summary: Wrong event type.
+              summary: Wrong event type
               value:
                 status: 422
                 message: EventType must be one of "click", "conversion" or "view"
             IndexRequired:
-              summary: Missing index attribute.
+              summary: Missing index attribute
               value:
                 status: 422
                 message: The index field is required
             UserTokenRequired:
-              summary: Missing userToken attribute.
+              summary: Missing userToken attribute
               value:
                 status: 422
                 message: The userToken field is required
             WrongUserToken:
-              summary: Malformed user token.
+              summary: Malformed user token
               value:
                 status: 422
                 message: UserToken must contain only alphanumeric, equal, plus, slash, hyphen, or underscore characters, and be between 1 and 128 characters long
             NoObjectIDsOrFilters:
-              summary: Missing objectIDs or filters attribute.
+              summary: Missing objectIDs or filters attribute
               description: Each event must include either the `objectIDs` or `filters` attribute.
               value:
                 status: 422
                 message: Event should specify either some ObjectIDs or some Filters
             BothDefined:
-              summary: Both objectIDs and filters attributes defined.
+              summary: Both objectIDs and filters attributes defined
               value:
                 status: 422
                 message: Event should specify ObjectIDs or Filters, but not both
             PositionsOnWrongEventType:
-              summary: Wrong combination of positions and eventType attributes.
+              summary: Wrong combination of positions and eventType attributes
               value:
                 status: 422
                 message: Only event of type click should specify the positions attribute
             PositionsWithoutQueryID:
-              summary: Positions attribute without queryID.
+              summary: Positions attribute without queryID
               description: Click events with the `positions` attribute require the `queryID` attribute.
               value:
                 status: 422
                 message: Event of type click with positions should specify a queryID
             WrongPositionsValue:
-              summary: Wrong value in positions array.
+              summary: Wrong value in positions array
               description: Any value in the `positions` array must be greater than 0.
               value:
                 status: 422
                 message: Event of type click may only have strictly positive positions
             WrongPositionsItems:
-              summary: Wrong number of items in positions array.
+              summary: Wrong number of items in positions array
               description: >-
                 For click events with the `queryID` and `objectIDs` attributes,
                 you must include the `positions` attribute with the same number of items as the `objectIDs` attribute.
@@ -365,23 +365,23 @@ post:
                 status: 422
                 message: Event of type click should have the same number of ObjectIDs and Positions
             WrongQueryID:
-              summary: Malformed query ID.
+              summary: Malformed query ID
               value:
                 status: 422
                 message: Query ID must be a search query ID (32 characters hexadecimal string)
             InvalidDataType:
-              summary: Wrong data type.
+              summary: Wrong data type
               description: This can happen if one or more attribute is a number instead of a string.
               value:
                 status: 422
                 message: 'Invalid type for field events: expected string, got number'
             InvalidTimestamp:
-              summary: Timestamp too old.
+              summary: Timestamp too old
               value:
                 status: 422
                 message: The timestamp must be at most 4 days in the past
             TooManyEvents:
-              summary: Too many events.
+              summary: Too many events
               description: You can include up to 1,000 events in a single API request.
               value:
                 status: 422

--- a/specs/monitoring/common/responses/UnauthorizedResponse.yml
+++ b/specs/monitoring/common/responses/UnauthorizedResponse.yml
@@ -5,6 +5,6 @@ content:
       type: string
     examples:
       Unauthorized:
-        summary: Invalid credentials.
+        summary: Invalid credentials
         description: Use the Monitoring API key.
         value: Invalid credentials

--- a/specs/monitoring/paths/getClusterIncidents.yml
+++ b/specs/monitoring/paths/getClusterIncidents.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve cluster incidents.
+  summary: Retrieve cluster incidents
   description: Retrieves known incidents for the selected clusters.
   operationId: getClusterIncidents
   tags:

--- a/specs/monitoring/paths/getClusterStatus.yml
+++ b/specs/monitoring/paths/getClusterStatus.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve cluster status.
+  summary: Retrieve cluster status
   description: Retrieves the status of selected clusters.
   operationId: getClusterStatus
   tags:

--- a/specs/monitoring/paths/getIncidents.yml
+++ b/specs/monitoring/paths/getIncidents.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve all incidents.
+  summary: Retrieve all incidents
   description: Retrieves known incidents for all clusters.
   operationId: getIncidents
   security: []

--- a/specs/monitoring/paths/getIndexingTime.yml
+++ b/specs/monitoring/paths/getIndexingTime.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve indexing times.
+  summary: Retrieve indexing times
   description: Retrieves average times for indexing operations for selected clusters.
   operationId: getIndexingTime
   security: []

--- a/specs/monitoring/paths/getLatency.yml
+++ b/specs/monitoring/paths/getLatency.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve search latency times.
+  summary: Retrieve search latency times
   description: Retrieves the average latency for search requests for selected clusters.
   operationId: getLatency
   security: []

--- a/specs/monitoring/paths/getMetrics.yml
+++ b/specs/monitoring/paths/getMetrics.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve metrics.
+  summary: Retrieve metrics
   description: |
     Retrieves metrics related to your Algolia infrastructure, aggregated over a selected time window.
 

--- a/specs/monitoring/paths/getReachability.yml
+++ b/specs/monitoring/paths/getReachability.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Test the reachability of clusters.
+  summary: Test the reachability of clusters
   description: Test whether clusters are reachable or not.
   operationId: getReachability
   security: []

--- a/specs/monitoring/paths/getServers.yml
+++ b/specs/monitoring/paths/getServers.yml
@@ -1,5 +1,5 @@
 get:
-  summary: Retrieve servers.
+  summary: Retrieve servers
   operationId: getServers
   security:
     - appId: []

--- a/specs/monitoring/paths/getStatus.yml
+++ b/specs/monitoring/paths/getStatus.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getStatus
-  summary: Retrieve status of all clusters.
+  summary: Retrieve status of all clusters
   security: []
   tags:
     - status

--- a/specs/personalization/paths/deleteUserProfile.yml
+++ b/specs/personalization/paths/deleteUserProfile.yml
@@ -4,7 +4,7 @@ delete:
   operationId: deleteUserProfile
   x-acl:
     - recommendation
-  summary: Delete a user profile.
+  summary: Delete a user profile
   description: |
     Deletes a user profile.
 

--- a/specs/personalization/paths/getUserTokenProfile.yml
+++ b/specs/personalization/paths/getUserTokenProfile.yml
@@ -4,7 +4,7 @@ get:
   operationId: getUserTokenProfile
   x-acl:
     - recommendation
-  summary: Retrieve a user profile.
+  summary: Retrieve a user profile
   description: Retrieves a user profile and their affinities for different facets.
   parameters:
     - $ref: '../common/parameters.yml#/UserToken'

--- a/specs/personalization/paths/personalizationStrategy.yml
+++ b/specs/personalization/paths/personalizationStrategy.yml
@@ -4,7 +4,7 @@ get:
   operationId: getPersonalizationStrategy
   x-acl:
     - recommendation
-  summary: Retrieve the personalization strategy.
+  summary: Retrieve the personalization strategy
   description: Retrieves the current personalization strategy.
   responses:
     '200':
@@ -28,7 +28,7 @@ post:
   operationId: setPersonalizationStrategy
   x-acl:
     - recommendation
-  summary: Define the personalization strategy.
+  summary: Define the personalization strategy
   description: Creates a new personalization strategy.
   requestBody:
     required: true

--- a/specs/query-suggestions/common/responses/BadRequest.yml
+++ b/specs/query-suggestions/common/responses/BadRequest.yml
@@ -5,30 +5,30 @@ content:
       $ref: './BaseResponse.yml'
     examples:
       IndexNameRequired:
-        summary: Index name required.
+        summary: Index name required
         value:
           status: 400
           message: IndexName cannot be empty.
       SourceIndicesRequired:
-        summary: Source indices required.
+        summary: Source indices required
         value:
           status: 400
           message: Invalid body "sourceIndices needs to contain at least one index".
 
       SourceIndexNameRequired:
-        summary: Source index name required.
+        summary: Source index name required
         value:
           status: 400
           message: Invalid body "every source index must have an `indexName`".
 
       MinHitsPositive:
-        summary: MinHits must be positive.
+        summary: MinHits must be positive
         value:
           status: 400
           message: Invalid body "every source index `minHits` must be positive".
 
       MinLettersPositive:
-        summary: MinLetters must be positive.
+        summary: MinLetters must be positive
         value:
           status: 400
           message: Invalid body "every source index `minLetters` must be positive".

--- a/specs/query-suggestions/common/responses/NotFound.yml
+++ b/specs/query-suggestions/common/responses/NotFound.yml
@@ -5,7 +5,7 @@ content:
       $ref: './BaseResponse.yml'
     examples:
       NotFound:
-        summary: Index not found.
+        summary: Index not found
         value:
           status: 404
           message: Not Found

--- a/specs/query-suggestions/common/responses/Unauthorized.yml
+++ b/specs/query-suggestions/common/responses/Unauthorized.yml
@@ -5,7 +5,7 @@ content:
       $ref: './BaseResponse.yml'
     examples:
       Unauthorized:
-        summary: Wrong region.
+        summary: Wrong region
         description: |
           Make sure to make your request to the server corresponding to your region.
 
@@ -15,13 +15,13 @@ content:
           message: The log processing region does not match.
 
       InvalidCredentials:
-        summary: Invalid credentials.
+        summary: Invalid credentials
         description: Your application ID or API key is wrong.
         value:
           status: 401
           message: Invalid credentials
       MissingACL:
-        summary: Key is missing ACL.
+        summary: Key is missing ACL
         description: Your API key is missing the required ACL for this operation.
         value:
           status: 401

--- a/specs/query-suggestions/common/responses/UnprocessableEntity.yml
+++ b/specs/query-suggestions/common/responses/UnprocessableEntity.yml
@@ -5,7 +5,7 @@ content:
       $ref: './BaseResponse.yml'
     examples:
       UnprocessableEntity:
-        summary: Configuration already exists.
+        summary: Configuration already exists
         value:
           status: 422
           message: 'Configuration already exists for index: test-qs'

--- a/specs/query-suggestions/paths/getConfigurationStatus.yml
+++ b/specs/query-suggestions/paths/getConfigurationStatus.yml
@@ -4,7 +4,7 @@ get:
   operationId: getConfigStatus
   x-acl:
     - settings
-  summary: Retrieve configuration status.
+  summary: Retrieve configuration status
   description: Reports the status of a Query Suggestions index.
   parameters:
     - $ref: '../common/parameters.yml#/IndexName'

--- a/specs/query-suggestions/paths/getLogFile.yml
+++ b/specs/query-suggestions/paths/getLogFile.yml
@@ -4,7 +4,7 @@ get:
   operationId: getLogFile
   x-acl:
     - settings
-  summary: Retrieve logs.
+  summary: Retrieve logs
   description: Retrieves the logs for a single Query Suggestions index.
   parameters:
     - $ref: '../common/parameters.yml#/IndexName'

--- a/specs/query-suggestions/paths/qsConfig.yml
+++ b/specs/query-suggestions/paths/qsConfig.yml
@@ -4,7 +4,7 @@ get:
   operationId: getConfig
   x-acl:
     - settings
-  summary: Retrieve a configuration.
+  summary: Retrieve a configuration
   description: Retrieves a single Query Suggestions configuration by its index name.
   parameters:
     - $ref: '../common/parameters.yml#/IndexName'
@@ -28,7 +28,7 @@ put:
   operationId: updateConfig
   x-acl:
     - editSettings
-  summary: Update a configuration.
+  summary: Update a configuration
   description: Updates a QuerySuggestions configuration.
   parameters:
     - $ref: '../common/parameters.yml#/IndexName'
@@ -47,7 +47,7 @@ put:
             $ref: '../common/responses/BaseResponse.yml'
           examples:
             Created:
-              summary: Configuration created.
+              summary: Configuration created
               value:
                 'status': 200
                 'message': 'Configuration was updated, and a new indexing job has been scheduled.'
@@ -63,7 +63,7 @@ delete:
   operationId: deleteConfig
   x-acl:
     - editSettings
-  summary: Delete a configuration.
+  summary: Delete a configuration
   description: |
     Deletes a Query Suggestions configuration.
 
@@ -80,7 +80,7 @@ delete:
             $ref: '../common/responses/BaseResponse.yml'
           examples:
             Created:
-              summary: Configuration created.
+              summary: Configuration created
               value:
                 'status': 200
                 'message': 'Configuration was deleted with success.'

--- a/specs/query-suggestions/paths/qsConfigs.yml
+++ b/specs/query-suggestions/paths/qsConfigs.yml
@@ -4,7 +4,7 @@ get:
   operationId: getAllConfigs
   x-acl:
     - settings
-  summary: List configurations.
+  summary: List configurations
   description: Retrieves all Query Suggestions configurations of your Algolia application.
   responses:
     '200':
@@ -24,7 +24,7 @@ post:
   operationId: createConfig
   x-acl:
     - editSettings
-  summary: Create a configuration.
+  summary: Create a configuration
   description: |
     Creates a new Query Suggestions configuration.
 
@@ -44,7 +44,7 @@ post:
             $ref: '../common/responses/BaseResponse.yml'
           examples:
             Created:
-              summary: Configuration created.
+              summary: Configuration created
               value:
                 status: 200
                 message: Configuration was created, and a new indexing job has been scheduled.

--- a/specs/recommend/paths/getRecommendStatus.yml
+++ b/specs/recommend/paths/getRecommendStatus.yml
@@ -4,7 +4,7 @@ get:
   operationId: getRecommendStatus
   x-acl:
     - editSettings
-  summary: Check task status.
+  summary: Check task status
   description: |
     Checks the status of a given task.
 

--- a/specs/recommend/paths/getRecommendations.yml
+++ b/specs/recommend/paths/getRecommendations.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - search
-  summary: Retrieve recommendations.
+  summary: Retrieve recommendations
   description: |
     Retrieves recommendations from selected AI models.
   requestBody:

--- a/specs/recommend/paths/recommendRule.yml
+++ b/specs/recommend/paths/recommendRule.yml
@@ -4,7 +4,7 @@ get:
   operationId: getRecommendRule
   x-acl:
     - settings
-  summary: Retrieve a rule.
+  summary: Retrieve a rule
   description: Retrieves a Recommend rule that you previously created in the Algolia dashboard.
   parameters:
     - $ref: '../../common/parameters.yml#/IndexName'
@@ -32,7 +32,7 @@ delete:
   operationId: deleteRecommendRule
   x-acl:
     - editSettings
-  summary: Delete a rule.
+  summary: Delete a rule
   description: Deletes a Recommend rule from a recommendation scenario.
   parameters:
     - $ref: '../../common/parameters.yml#/IndexName'

--- a/specs/recommend/paths/searchRecommendRules.yml
+++ b/specs/recommend/paths/searchRecommendRules.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - settings
-  summary: Search for rules.
+  summary: Search for rules
   description: |
     Searches for Recommend rules.
 

--- a/specs/search/helpers/generateSecuredApiKey.yml
+++ b/specs/search/helpers/generateSecuredApiKey.yml
@@ -4,7 +4,7 @@ method:
     tags:
       - Api Keys
     operationId: generateSecuredApiKey
-    summary: Create secured API keys.
+    summary: Create secured API keys
     description: |
       Generates a secured API key without any requests to Algolia's servers.
 

--- a/specs/search/helpers/waitForApiKey.yml
+++ b/specs/search/helpers/waitForApiKey.yml
@@ -4,7 +4,7 @@ method:
     tags:
       - Api Keys
     operationId: waitForApiKey
-    summary: Wait for an API key operation.
+    summary: Wait for an API key operation
     description: Waits for an API key to be added, updated, or deleted.
     parameters:
       - in: query

--- a/specs/search/paths/advanced/getLogs.yml
+++ b/specs/search/paths/advanced/getLogs.yml
@@ -10,7 +10,7 @@ get:
     - Logs are held for the last seven days.
     - Up to 1,000 API requests per server are logged.
     - This request counts towards your [operations quota](https://support.algolia.com/hc/en-us/articles/4406981829777-How-does-Algolia-count-records-and-operations-) but doesn't appear in the logs itself.
-  summary: Retrieve log entries.
+  summary: Retrieve log entries
   parameters:
     - name: offset
       in: query

--- a/specs/search/paths/advanced/getTask.yml
+++ b/specs/search/paths/advanced/getTask.yml
@@ -12,7 +12,7 @@ get:
     a task is created on a queue and completed depending on the load on the server.
 
     The indexing tasks' responses include a task ID that you can use to check the status.
-  summary: Check task status.
+  summary: Check task status
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - name: taskID

--- a/specs/search/paths/dictionaries/batchDictionaryEntries.yml
+++ b/specs/search/paths/dictionaries/batchDictionaryEntries.yml
@@ -5,7 +5,7 @@ post:
   x-acl:
     - editSettings
   description: Adds or deletes multiple entries from your plurals, segmentation, or stop word dictionaries.
-  summary: Add or delete dictionary entries.
+  summary: Add or delete dictionary entries
   parameters:
     - $ref: 'common/parameters.yml#/DictionaryName'
   requestBody:

--- a/specs/search/paths/dictionaries/dictionarySettings.yml
+++ b/specs/search/paths/dictionaries/dictionarySettings.yml
@@ -4,7 +4,7 @@ get:
   operationId: getDictionarySettings
   x-acl:
     - settings
-  summary: Retrieve dictionary settings.
+  summary: Retrieve dictionary settings
   description: Retrieves the languages for which standard dictionary entries are turned off.
   responses:
     '200':
@@ -36,7 +36,7 @@ put:
   x-acl:
     - editSettings
   description: Turns standard stop word dictionary entries on or off for a given language.
-  summary: Update dictionary settings.
+  summary: Update dictionary settings
   requestBody:
     required: true
     content:

--- a/specs/search/paths/dictionaries/getDictionaryLanguages.yml
+++ b/specs/search/paths/dictionaries/getDictionaryLanguages.yml
@@ -6,7 +6,7 @@ get:
     - settings
   description: |
     Lists supported languages with their supported dictionary types and number of custom entries.
-  summary: List available languages.
+  summary: List available languages
   externalDocs:
     url: https://www.algolia.com/doc/guides/managing-results/optimize-search-results/handling-natural-languages-nlp/in-depth/supported-languages/
     description: Supported languages.

--- a/specs/search/paths/dictionaries/searchDictionaryEntries.yml
+++ b/specs/search/paths/dictionaries/searchDictionaryEntries.yml
@@ -7,7 +7,7 @@ post:
   x-acl:
     - settings
   description: Searches for standard and custom dictionary entries.
-  summary: Search dictionary entries.
+  summary: Search dictionary entries
   parameters:
     - $ref: 'common/parameters.yml#/DictionaryName'
   requestBody:

--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -2,7 +2,7 @@ get:
   tags:
     - Api Keys
   operationId: getApiKey
-  summary: Retrieve API key permissions.
+  summary: Retrieve API key permissions
   description: |
     Gets the permissions and restrictions of an API key.
 
@@ -32,7 +32,7 @@ put:
   operationId: updateApiKey
   x-acl:
     - admin
-  summary: Update an API key.
+  summary: Update an API key
   description: |
     Replaces the permissions of an existing API key.
 
@@ -77,7 +77,7 @@ delete:
   operationId: deleteApiKey
   x-acl:
     - admin
-  summary: Delete an API key.
+  summary: Delete an API key
   description: Deletes the API key.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'

--- a/specs/search/paths/keys/keys.yml
+++ b/specs/search/paths/keys/keys.yml
@@ -4,7 +4,7 @@ get:
   operationId: listApiKeys
   x-acl:
     - admin
-  summary: List API keys.
+  summary: List API keys
   description: Lists all API keys associated with your Algolia application, including their permissions and restrictions.
   responses:
     '200':
@@ -38,7 +38,7 @@ post:
   operationId: addApiKey
   x-acl:
     - admin
-  summary: Create an API key.
+  summary: Create an API key
   description: Creates a new API key with specific permissions and restrictions.
   requestBody:
     required: true

--- a/specs/search/paths/keys/restoreApiKey.yml
+++ b/specs/search/paths/keys/restoreApiKey.yml
@@ -4,7 +4,7 @@ post:
   operationId: restoreApiKey
   x-acl:
     - admin
-  summary: Restore an API key.
+  summary: Restore an API key
   description: |
     Restores a deleted API key.
 

--- a/specs/search/paths/manage_indices/listIndices.yml
+++ b/specs/search/paths/manage_indices/listIndices.yml
@@ -4,7 +4,7 @@ get:
   operationId: listIndices
   x-acl:
     - listIndexes
-  summary: List indices.
+  summary: List indices
   description: |
     Lists all indices in the current Algolia application.
 

--- a/specs/search/paths/manage_indices/operationIndex.yml
+++ b/specs/search/paths/manage_indices/operationIndex.yml
@@ -4,7 +4,7 @@ post:
   operationId: operationIndex
   x-acl:
     - addObject
-  summary: Copy or move an index.
+  summary: Copy or move an index
   description: |
     Copies or moves (renames) an index within the same Algolia application.
 

--- a/specs/search/paths/multiclusters/batchAssignUserIds.yml
+++ b/specs/search/paths/multiclusters/batchAssignUserIds.yml
@@ -4,7 +4,7 @@ post:
   operationId: batchAssignUserIds
   x-acl:
     - admin
-  summary: Assign multiple userIDs.
+  summary: Assign multiple userIDs
   description: |
     Assigns multiple user IDs to a cluster.
 

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -4,7 +4,7 @@ get:
   operationId: getTopUserIds
   x-acl:
     - admin
-  summary: Get top user IDs.
+  summary: Get top user IDs
   description: |
     Get the IDs of the 10 users with the highest number of records per cluster.
 

--- a/specs/search/paths/multiclusters/hasPendingMappings.yml
+++ b/specs/search/paths/multiclusters/hasPendingMappings.yml
@@ -4,7 +4,7 @@ get:
   operationId: hasPendingMappings
   x-acl:
     - admin
-  summary: Get migration and user mapping status.
+  summary: Get migration and user mapping status
   description: |
     To determine when the time-consuming process of creating a large batch of users or migrating users from one cluster to another is complete, this operation retrieves the status of the process.
   parameters:

--- a/specs/search/paths/multiclusters/listClusters.yml
+++ b/specs/search/paths/multiclusters/listClusters.yml
@@ -4,7 +4,7 @@ get:
   operationId: listClusters
   x-acl:
     - admin
-  summary: List clusters.
+  summary: List clusters
   description: Lists the available clusters in a multi-cluster setup.
   responses:
     '200':

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - admin
-  summary: Search for user IDs.
+  summary: Search for user IDs
   description: |
     Since it can take a few seconds to get the data from the different clusters,
     the response isn't real-time.

--- a/specs/search/paths/multiclusters/userId.yml
+++ b/specs/search/paths/multiclusters/userId.yml
@@ -4,7 +4,7 @@ get:
   operationId: getUserId
   x-acl:
     - admin
-  summary: Retrieve user ID.
+  summary: Retrieve user ID
   description: |
     Returns the user ID data stored in the mapping.
 
@@ -34,7 +34,7 @@ delete:
   operationId: removeUserId
   x-acl:
     - admin
-  summary: Delete user ID.
+  summary: Delete user ID
   description: Deletes a user ID and its associated data from the clusters.
   parameters:
     - $ref: '../../common/parameters.yml#/UserIDInPath'

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -4,7 +4,7 @@ post:
   operationId: assignUserId
   x-acl:
     - admin
-  summary: Assign or move a user ID.
+  summary: Assign or move a user ID
   description: |
     Assigns or moves a user ID to a cluster.
 
@@ -43,7 +43,7 @@ get:
   operationId: listUserIds
   x-acl:
     - admin
-  summary: List user IDs.
+  summary: List user IDs
   description: |
     Lists the userIDs assigned to a multi-cluster application.
 

--- a/specs/search/paths/objects/batch.yml
+++ b/specs/search/paths/objects/batch.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - Records
   operationId: batch
-  summary: Batch indexing operations on one index.
+  summary: Batch indexing operations on one index
   description: |
     Adds, updates, or deletes records in one index with a single API request.
 
@@ -46,7 +46,7 @@ post:
             - requests
         examples:
           batch:
-            summary: Batch indexing request.
+            summary: Batch indexing request
             value:
               requests:
                 - action: addObject

--- a/specs/search/paths/objects/clearObjects.yml
+++ b/specs/search/paths/objects/clearObjects.yml
@@ -4,7 +4,7 @@ post:
   operationId: clearObjects
   x-acl:
     - deleteIndex
-  summary: Delete all records from an index.
+  summary: Delete all records from an index
   description: Deletes only the records from an index while keeping settings, synonyms, and rules.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'

--- a/specs/search/paths/objects/deleteBy.yml
+++ b/specs/search/paths/objects/deleteBy.yml
@@ -4,7 +4,7 @@ post:
   operationId: deleteBy
   x-acl:
     - deleteIndex
-  summary: Delete records matching a query.
+  summary: Delete records matching a query
   description: |
     This operation doesn't accept empty queries or filters.
 

--- a/specs/search/paths/objects/getObjects.yml
+++ b/specs/search/paths/objects/getObjects.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - search
-  summary: Retrieve records.
+  summary: Retrieve records
   description: |
     Retrieves one or more records, potentially from different indices.
 

--- a/specs/search/paths/objects/multipleBatch.yml
+++ b/specs/search/paths/objects/multipleBatch.yml
@@ -7,7 +7,7 @@ post:
 
     - Actions are applied in the order they are specified.
     - Actions are equivalent to the individual API requests of the same name.
-  summary: Batch indexing operations on multiple indices.
+  summary: Batch indexing operations on multiple indices
   requestBody:
     required: true
     content:
@@ -40,7 +40,7 @@ post:
             - requests
         examples:
           batch:
-            summary: Batch indexing request to two indices.
+            summary: Batch indexing request to two indices
             value:
               requests:
                 - action: addObject

--- a/specs/search/paths/objects/object.yml
+++ b/specs/search/paths/objects/object.yml
@@ -4,7 +4,7 @@ get:
   operationId: getObject
   x-acl:
     - search
-  summary: Retrieve a record.
+  summary: Retrieve a record
   description: |
     Retrieves one record by its object ID.
 
@@ -53,7 +53,7 @@ put:
   operationId: addOrUpdateObject
   x-acl:
     - addObject
-  summary: Add or replace a record.
+  summary: Add or replace a record
   description: |
     If a record with the specified object ID exists, the existing record is replaced.
     Otherwise, a new record is added to the index.
@@ -88,7 +88,7 @@ delete:
   operationId: deleteObject
   x-acl:
     - deleteObject
-  summary: Delete a record.
+  summary: Delete a record
   description: |
     Deletes a record by its object ID.
 

--- a/specs/search/paths/objects/objects.yml
+++ b/specs/search/paths/objects/objects.yml
@@ -14,7 +14,7 @@ post:
 
     To update _some_ attributes of a record, use the [`partial` operation](#tag/Records/operation/partial).
     To add, update, or replace multiple records, use the [`batch` operation](#tag/Records/operation/batch).
-  summary: Add or replace a record.
+  summary: Add or replace a record
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   requestBody:
@@ -58,7 +58,7 @@ delete:
   operationId: deleteIndex
   x-acl:
     - deleteIndex
-  summary: Delete an index.
+  summary: Delete an index
   description: |
     Deletes an index and all its settings.
 

--- a/specs/search/paths/objects/partialUpdate.yml
+++ b/specs/search/paths/objects/partialUpdate.yml
@@ -4,7 +4,7 @@ post:
   operationId: partialUpdateObject
   x-acl:
     - addObject
-  summary: Add or update attributes.
+  summary: Add or update attributes
   x-codegen-request-body-name: attributesToUpdate
   description: |
     Adds new attributes to a record, or update existing ones.

--- a/specs/search/paths/rules/clearRules.yml
+++ b/specs/search/paths/rules/clearRules.yml
@@ -4,7 +4,7 @@ post:
   operationId: clearRules
   x-acl:
     - editSettings
-  summary: Delete all rules.
+  summary: Delete all rules
   description: Deletes all rules from the index.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'

--- a/specs/search/paths/rules/rule.yml
+++ b/specs/search/paths/rules/rule.yml
@@ -4,7 +4,7 @@ get:
   operationId: getRule
   x-acl:
     - settings
-  summary: Retrieve a rule.
+  summary: Retrieve a rule
   description: |
     Retrieves a rule by its ID.
     To find the object ID of rules, use the [`search` operation](#tag/Rules/operation/searchRules).
@@ -34,7 +34,7 @@ put:
   operationId: saveRule
   x-acl:
     - editSettings
-  summary: Create or replace a rule.
+  summary: Create or replace a rule
   description: |
     If a rule with the specified object ID doesn't exist, it's created.
     Otherwise, the existing rule is replaced.
@@ -72,7 +72,7 @@ delete:
   operationId: deleteRule
   x-acl:
     - editSettings
-  summary: Delete a rule.
+  summary: Delete a rule
   description: |
     Deletes a rule by its ID.
     To find the object ID for rules,

--- a/specs/search/paths/rules/saveRules.yml
+++ b/specs/search/paths/rules/saveRules.yml
@@ -4,7 +4,7 @@ post:
   operationId: saveRules
   x-acl:
     - editSettings
-  summary: Create or update rules.
+  summary: Create or update rules
   description: |
     Create or update multiple rules.
 

--- a/specs/search/paths/rules/searchRules.yml
+++ b/specs/search/paths/rules/searchRules.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - settings
-  summary: Search for rules.
+  summary: Search for rules
   description: Searches for rules in your index.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'

--- a/specs/search/paths/search/browse.yml
+++ b/specs/search/paths/search/browse.yml
@@ -4,7 +4,7 @@ post:
   operationId: browse
   x-acl:
     - browse
-  summary: Browse for records.
+  summary: Browse for records
   description: |
     Retrieves records from an index, up to 1,000 per request.
 

--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -7,7 +7,7 @@ post:
   x-legacy-signature: true
   x-acl:
     - search
-  summary: Search multiple indices.
+  summary: Search multiple indices
   description: |
     Sends multiple search request to one or more indices.
 

--- a/specs/search/paths/search/searchForFacetValues.yml
+++ b/specs/search/paths/search/searchForFacetValues.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - search
-  summary: Search for facet values.
+  summary: Search for facet values
   description: |
     Searches for values of a specified facet attribute.
 

--- a/specs/search/paths/search/searchSingleIndex.yml
+++ b/specs/search/paths/search/searchSingleIndex.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - search
-  summary: Search an index.
+  summary: Search an index
   description: |
     Searches a single index and return matching search results (_hits_).
 

--- a/specs/search/paths/settings/settings.yml
+++ b/specs/search/paths/settings/settings.yml
@@ -5,7 +5,7 @@ get:
   x-acl:
     - search
   description: Retrieves an object with non-null index settings.
-  summary: Retrieve index settings.
+  summary: Retrieve index settings
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   responses:
@@ -37,7 +37,7 @@ put:
     Specify `null` to reset a setting to its default value.
 
     For best performance, update the index settings before you add new records to your index.
-  summary: Update index settings.
+  summary: Update index settings
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ForwardToReplicas'

--- a/specs/search/paths/synonyms/clearSynonyms.yml
+++ b/specs/search/paths/synonyms/clearSynonyms.yml
@@ -4,7 +4,7 @@ post:
   operationId: clearSynonyms
   x-acl:
     - editSettings
-  summary: Delete all synonyms.
+  summary: Delete all synonyms
   description: Deletes all synonyms from the index.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'

--- a/specs/search/paths/synonyms/saveSynonyms.yml
+++ b/specs/search/paths/synonyms/saveSynonyms.yml
@@ -4,7 +4,7 @@ post:
   operationId: saveSynonyms
   x-acl:
     - editSettings
-  summary: Create or replace synonyms.
+  summary: Create or replace synonyms
   description: |
     If a synonym with the `objectID` doesn't exist, Algolia adds a new one.
     Otherwise, existing synonyms are replaced.

--- a/specs/search/paths/synonyms/searchSynonyms.yml
+++ b/specs/search/paths/synonyms/searchSynonyms.yml
@@ -6,7 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - settings
-  summary: Search for synonyms.
+  summary: Search for synonyms
   description: Searches for synonyms in your index.
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'

--- a/specs/search/paths/synonyms/synonym.yml
+++ b/specs/search/paths/synonyms/synonym.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSynonym
   x-acl:
     - settings
-  summary: Retrieve a synonym.
+  summary: Retrieve a synonym
   description: |
     Retrieves a syonym by its ID.
     To find the object IDs for your synonyms,
@@ -34,7 +34,7 @@ put:
   operationId: saveSynonym
   x-acl:
     - editSettings
-  summary: Create or replace a synonym.
+  summary: Create or replace a synonym
   description: |
     If a synonym with the specified object ID doesn't exist, Algolia adds a new one.
     Otherwise, the existing synonym is replaced.
@@ -84,7 +84,7 @@ delete:
   operationId: deleteSynonym
   x-acl:
     - editSettings
-  summary: Delete a synonym.
+  summary: Delete a synonym
   description: |
     Deletes a synonym by its ID.
     To find the object IDs of your synonyms, use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).

--- a/specs/search/paths/vault/appendSource.yml
+++ b/specs/search/paths/vault/appendSource.yml
@@ -5,7 +5,7 @@ post:
   x-acl:
     - admin
   description: Adds a source to the list of allowed sources.
-  summary: Add a source.
+  summary: Add a source
   requestBody:
     required: true
     description: Source to add.

--- a/specs/search/paths/vault/deleteSource.yml
+++ b/specs/search/paths/vault/deleteSource.yml
@@ -5,7 +5,7 @@ delete:
   x-acl:
     - admin
   description: Deletes a source from the list of allowed sources.
-  summary: Delete a source.
+  summary: Delete a source
   parameters:
     - name: source
       in: path

--- a/specs/search/paths/vault/vaultSources.yml
+++ b/specs/search/paths/vault/vaultSources.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSources
   x-acl:
     - admin
-  summary: List allowed sources.
+  summary: List allowed sources
   description: Retrieves all allowed IP addresses with access to your application.
   responses:
     '200':
@@ -28,7 +28,7 @@ put:
   operationId: replaceSources
   x-acl:
     - admin
-  summary: Replace allowed sources.
+  summary: Replace allowed sources
   description: Replaces the list of allowed sources.
   requestBody:
     required: true

--- a/specs/usage/paths/statistic.yml
+++ b/specs/usage/paths/statistic.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getUsage
-  summary: Retrieve usage information.
+  summary: Retrieve usage information
   description: |
     Retrieves usage statistics evaluated over a specified period.
   parameters:

--- a/specs/usage/paths/statisticIndex.yml
+++ b/specs/usage/paths/statisticIndex.yml
@@ -1,6 +1,6 @@
 get:
   operationId: getIndexUsage
-  summary: Retrieve usage information for one index.
+  summary: Retrieve usage information for one index
   description: |
     Retrieves the selected usage statistics for one index.
   parameters:


### PR DESCRIPTION
## 🧭 What and Why

Add a new ESLint rule to remove trailing `.` on `summary` fields.
This will make the docs look a tiny bit better, since the `summary` entries are used as headers.

### Changes included:

- Add new rule `no-final-dot`
- Modify existing rule `end-with-dot`
- Remove final `.` from summaries

## 🧪 Test

I added a unit test for the rule.