### PR TITLE
fix(cts): use the oldest authentication to avoid failure on creation

### DIFF
--- a/tests/CTS/requests/ingestion/getAuthentications.json
+++ b/tests/CTS/requests/ingestion/getAuthentications.json
@@ -20,7 +20,7 @@
         "none"
       ],
       "sort": "createdAt",
-      "order": "desc"
+      "order": "asc"
     },
     "request": {
       "path": "/1/authentications",
@@ -31,7 +31,7 @@
         "type": "basic%2Calgolia",
         "platform": "none",
         "sort": "createdAt",
-        "order": "desc"
+        "order": "asc"
       }
     },
     "response": {
@@ -43,12 +43,12 @@
         },
         "authentications": [
           {
-            "authenticationID": "b57a7ea5-8592-493b-b75b-6c66d77aee7f",
+            "authenticationID": "474f050f-a771-464c-a016-323538029f5f",
             "type": "algolia",
-            "name": "Auto-generated Authentication for T8JK9S7I7X - 1704732447751",
+            "name": "algolia-auth-1677060483885",
             "input": {},
-            "createdAt": "2024-01-08T16:47:31Z",
-            "updatedAt": "2024-01-08T16:47:31Z"
+            "createdAt": "2023-02-22T10:08:04Z",
+            "updatedAt": "2023-10-25T08:41:56Z"
           },
           {},
           {},


### PR DESCRIPTION
## 🧭 What and Why

There was a new auth created on `T8JK9S7I7X` that made the CTS fail, we can list by ascending order to prevent this issue.