### PR TITLE
fix(specs): simplify filter types

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -10,6 +10,7 @@ import org.openapitools.codegen.*;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationsMap;
 
 public class AlgoliaPythonGenerator extends PythonClientCodegen {
@@ -128,5 +129,17 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     operations.setImports(imports);
 
     return operations;
+  }
+
+  @Override
+  public ModelsMap postProcessModels(ModelsMap objs) {
+    // this is to prevent F811 from flake8 because we have some recusrive models
+    String modelName = objs.getModels().get(0).getModel().getClassname();
+    for (Map<String, String> imp : objs.getImports()) {
+      if (imp.get("import").endsWith(modelName)) {
+        imp.remove("import");
+      }
+    }
+    return objs;
   }
 }

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -136,7 +136,7 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     // this is to prevent F811 from flake8 because we have some recusrive models
     String modelName = objs.getModels().get(0).getModel().getClassname();
     for (Map<String, String> imp : objs.getImports()) {
-      if (imp.get("import").endsWith(modelName)) {
+      if (imp.get("import").endsWith("import " + modelName)) {
         imp.remove("import");
       }
     }

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
@@ -306,7 +306,8 @@ public class ParametersWithDataType {
 
       testOutput.putAll(traverseParams(paramName, param, match, parent, suffix, isParentFreeFormObject));
 
-      HashMap<String, Object> oneOfModel = new HashMap<>();
+      Map<String, Object> oneOfModel = new HashMap<>();
+      oneOfModel.put("isArray", false);
       IJsonSchemaValidationProperties current = match;
       String typeName = getTypeName(current);
       boolean isList = false;

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
@@ -307,7 +307,6 @@ public class ParametersWithDataType {
       testOutput.putAll(traverseParams(paramName, param, match, parent, suffix, isParentFreeFormObject));
 
       Map<String, Object> oneOfModel = new HashMap<>();
-      oneOfModel.put("isArray", false);
       IJsonSchemaValidationProperties current = match;
       String typeName = getTypeName(current);
       boolean isList = false;

--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -745,7 +745,9 @@ indexSettingsAsSearchParams:
       x-categories:
         - Filtering
     reRankingApplyFilter:
-      $ref: '#/reRankingApplyFilter'
+      oneOf:
+        - $ref: '#/reRankingApplyFilter'
+        - type: 'null'
 
 maxFacetHits:
   type: integer
@@ -759,11 +761,12 @@ reRankingApplyFilter:
   description: |
     Restrict [Dynamic Re-Ranking](https://www.algolia.com/doc/guides/algolia-ai/re-ranking/) to records that match these filters.
   oneOf:
-    - $ref: './SearchParams.yml#/listOfSearchFilters'
+    - type: array
+      items:
+        $ref: '#/reRankingApplyFilter'
     - type: string
       x-categories:
         - Filtering
-    - type: 'null'
 
 hitsPerPage:
   type: integer

--- a/specs/common/schemas/SearchParams.yml
+++ b/specs/common/schemas/SearchParams.yml
@@ -378,25 +378,6 @@ insidePolygon:
   x-categories:
     - Geo-Search
 
-# There is duplicated logic here because we want to keep a correct description
-# and using `$ref` override everything.
-searchFiltersArrayString:
-  title: search filter array
-  type: array
-  items:
-    type: string
-
-mixedSearchFilters:
-  oneOf:
-    - $ref: '#/searchFiltersArrayString'
-    - type: string
-
-listOfSearchFilters:
-  type: array
-  title: search filters
-  items:
-    $ref: '#/mixedSearchFilters'
-
 filters:
   type: string
   description: |
@@ -441,7 +422,9 @@ facetFilters:
     `facet:\-value`.
   example: [['category:Book', 'category:-Movie'], 'author:John Doe']
   oneOf:
-    - $ref: '#/listOfSearchFilters'
+    - type: array
+      items:
+        $ref: '#/facetFilters'
     - type: string
   x-categories:
     - Filtering
@@ -457,7 +440,9 @@ tagFilters:
     The same combination and escaping rules apply as for `facetFilters`.
   example: [['Book', 'Movie'], 'SciFi']
   oneOf:
-    - $ref: '#/listOfSearchFilters'
+    - type: array
+      items:
+        $ref: '#/tagFilters'
     - type: string
   x-categories:
     - Filtering
@@ -473,7 +458,9 @@ numericFilters:
     The same combination rules apply as for `facetFilters`.
   example: [['inStock = 1', 'deliveryDate < 1441755506'], 'price < 1000']
   oneOf:
-    - $ref: '#/listOfSearchFilters'
+    - type: array
+      items:
+        $ref: '#/numericFilters'
     - type: string
   x-categories:
     - Filtering
@@ -492,7 +479,9 @@ optionalFilters:
 
   example: ['category:Book', 'author:John Doe']
   oneOf:
-    - $ref: '#/listOfSearchFilters'
+    - type: array
+      items:
+        $ref: '#/optionalFilters'
     - type: string
   x-categories:
     - Filtering

--- a/templates/go/tests/requests/requests.mustache
+++ b/templates/go/tests/requests/requests.mustache
@@ -7,6 +7,7 @@ import (
   "os"
   "testing"
   "time"
+  "strings"
 
   "github.com/kinbiko/jsonassert"
   "github.com/stretchr/testify/require"
@@ -129,7 +130,7 @@ func Test{{#lambda.titlecase}}{{clientPrefix}}{{/lambda.titlecase}}_{{#lambda.ti
       require.NoError(t, err)
 
       jaE2E := jsonassert.New(t)
-      jaE2E.Assertf(expectedBodyRaw, string(unionBodyRaw))
+      jaE2E.Assertf(expectedBodyRaw, strings.ReplaceAll(string(unionBodyRaw), "%", "%%"))
       {{/body}}
       {{/response}}
     })

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -66,8 +66,6 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         {{#body}}
         resp = await {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}(self._e2e_app_id, self._e2e_api_key{{#hasRegionalHost}}, "{{{defaultRegion}}}"{{/hasRegionalHost}}).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> tests/requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
         _expected_body = loads("""{{{.}}}""")
-        print(resp)
-        assert False
         assert self._helpers.union(_expected_body, resp) == _expected_body
         {{/body}}
         {{/response}}

--- a/templates/python/tests/requests/requests.mustache
+++ b/templates/python/tests/requests/requests.mustache
@@ -62,9 +62,12 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isE2E}}E2E{
         assert raw_resp.status_code == {{statusCode}}
         {{/statusCode}}
 
+
         {{#body}}
         resp = await {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}(self._e2e_app_id, self._e2e_api_key{{#hasRegionalHost}}, "{{{defaultRegion}}}"{{/hasRegionalHost}}).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> tests/requests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
         _expected_body = loads("""{{{.}}}""")
+        print(resp)
+        assert False
         assert self._helpers.union(_expected_body, resp) == _expected_body
         {{/body}}
         {{/response}}

--- a/templates/ruby/base_object.mustache
+++ b/templates/ruby/base_object.mustache
@@ -23,10 +23,8 @@
       end
       {{#getAdditionalPropertiesIsAnyType}}
 
-      # merge additional_properties into transformed_hash
-      @additional_properties.each_pair do |k, v|
-        transformed_hash[k.to_sym] = v
-      end unless @additional_properties.nil?
+      # add extra attribute to transformed_hash
+      transformed_hash.merge!(attributes.reject { |k, _| attribute_map.key?(k.to_sym) })
       {{/getAdditionalPropertiesIsAnyType}}
       new(transformed_hash)
     end

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -89,13 +89,13 @@
               },
               {
                 "count": 1,
-                "highlighted": "vscode",
-                "value": "vscode"
+                "highlighted": "visual studio",
+                "value": "visual studio"
               },
               {
                 "count": 1,
-                "highlighted": "visual studio",
-                "value": "visual studio"
+                "highlighted": "vscode",
+                "value": "vscode"
               }
             ]
           }

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -395,6 +395,18 @@
               "editor:neovim"
             ]
           ]
+        },
+        {
+          "indexName": "cts_e2e_search_facet",
+          "facetFilters": [
+            "editor:'visual studio'",
+            [
+              "editor:neovim",
+              [
+                "editor:goland"
+              ]
+            ]
+          ]
         }
       ]
     },
@@ -440,6 +452,18 @@
               "editor:'visual studio'",
               [
                 "editor:neovim"
+              ]
+            ]
+          },
+          {
+            "indexName": "cts_e2e_search_facet",
+            "facetFilters": [
+              "editor:'visual studio'",
+              [
+                "editor:neovim",
+                [
+                  "editor:goland"
+                ]
               ]
             ]
           }
@@ -528,6 +552,16 @@
             "hits": [],
             "query": "",
             "params": "facetFilters=%5B%22editor%3A%27visual+studio%27%22%2C%5B%22editor%3Aneovim%22%5D%5D"
+          },
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 0,
+            "nbPages": 0,
+            "page": 0,
+            "hits": [],
+            "query": "",
+            "params": "facetFilters=%5B%22editor%3A%27visual+studio%27%22%2C%5B%22editor%3Aneovim%22%2C%5B%22editor%3Agoland%22%5D%5D%5D"
           }
         ]
       }

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -91,6 +91,11 @@
                 "count": 1,
                 "highlighted": "vscode",
                 "value": "vscode"
+              },
+              {
+                "count": 1,
+                "highlighted": "visual studio",
+                "value": "visual studio"
               }
             ]
           }
@@ -261,7 +266,10 @@
           "facetFilters": [
             "mySearch:filters",
             [
-              "mySearch:filters"
+              "mySearch:filters",
+              [
+                "mySearch:filters"
+              ]
             ]
           ],
           "reRankingApplyFilter": [
@@ -339,6 +347,187 @@
                 "mySearch:filters"
               ]
             ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "testName": "search filters end to end",
+    "parameters": {
+      "requests": [
+        {
+          "indexName": "cts_e2e_search_facet",
+          "filters": "editor:'visual studio' OR editor:neovim"
+        },
+        {
+          "indexName": "cts_e2e_search_facet",
+          "facetFilters": [
+            "editor:'visual studio'",
+            "editor:neovim"
+          ]
+        },
+        {
+          "indexName": "cts_e2e_search_facet",
+          "facetFilters": [
+            [
+              "editor:'visual studio'",
+              "editor:neovim"
+            ]
+          ]
+        },
+        {
+          "indexName": "cts_e2e_search_facet",
+          "facetFilters": [
+            [
+              "editor:'visual studio'",
+              [
+                "editor:neovim"
+              ]
+            ]
+          ]
+        },
+        {
+          "indexName": "cts_e2e_search_facet",
+          "facetFilters": [
+            "editor:'visual studio'",
+            [
+              "editor:neovim"
+            ]
+          ]
+        }
+      ]
+    },
+    "request": {
+      "path": "/1/indexes/*/queries",
+      "method": "POST",
+      "body": {
+        "requests": [
+          {
+            "indexName": "cts_e2e_search_facet",
+            "filters": "editor:'visual studio' OR editor:neovim"
+          },
+          {
+            "indexName": "cts_e2e_search_facet",
+            "facetFilters": [
+              "editor:'visual studio'",
+              "editor:neovim"
+            ]
+          },
+          {
+            "indexName": "cts_e2e_search_facet",
+            "facetFilters": [
+              [
+                "editor:'visual studio'",
+                "editor:neovim"
+              ]
+            ]
+          },
+          {
+            "indexName": "cts_e2e_search_facet",
+            "facetFilters": [
+              [
+                "editor:'visual studio'",
+                [
+                  "editor:neovim"
+                ]
+              ]
+            ]
+          },
+          {
+            "indexName": "cts_e2e_search_facet",
+            "facetFilters": [
+              "editor:'visual studio'",
+              [
+                "editor:neovim"
+              ]
+            ]
+          }
+        ]
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "results": [
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 2,
+            "nbPages": 1,
+            "page": 0,
+            "hits": [
+              {
+                "editor": "visual studio",
+                "_highlightResult": {
+                  "editor": {
+                    "value": "visual studio",
+                    "matchLevel": "none"
+                  }
+                }
+              },
+              {
+                "editor": "neovim",
+                "_highlightResult": {
+                  "editor": {
+                    "value": "neovim",
+                    "matchLevel": "none"
+                  }
+                }
+              }
+            ],
+            "query": "",
+            "params": "filters=editor%3A%27visual+studio%27+OR+editor%3Aneovim"
+          },
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 0,
+            "nbPages": 0,
+            "page": 0,
+            "hits": [],
+            "query": "",
+            "params": "facetFilters=%5B%22editor%3A%27visual+studio%27%22%2C%22editor%3Aneovim%22%5D"
+          },
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 1,
+            "nbPages": 1,
+            "page": 0,
+            "hits": [
+              {
+                "editor": "neovim",
+                "_highlightResult": {
+                  "editor": {
+                    "value": "neovim",
+                    "matchLevel": "none"
+                  }
+                }
+              }
+            ],
+            "query": "",
+            "params": "facetFilters=%5B%5B%22editor%3A%27visual+studio%27%22%2C%22editor%3Aneovim%22%5D%5D"
+          },
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 0,
+            "nbPages": 0,
+            "page": 0,
+            "hits": [],
+            "query": "",
+            "params": "facetFilters=%5B%5B%22editor%3A%27visual+studio%27%22%2C%5B%22editor%3Aneovim%22%5D%5D%5D"
+          },
+          {
+            "hitsPerPage": 20,
+            "index": "cts_e2e_search_facet",
+            "nbHits": 0,
+            "nbPages": 0,
+            "page": 0,
+            "hits": [],
+            "query": "",
+            "params": "facetFilters=%5B%22editor%3A%27visual+studio%27%22%2C%5B%22editor%3Aneovim%22%5D%5D"
           }
         ]
       }

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -309,7 +309,10 @@
             "facetFilters": [
               "mySearch:filters",
               [
-                "mySearch:filters"
+                "mySearch:filters",
+                [
+                  "mySearch:filters"
+                ]
               ]
             ],
             "reRankingApplyFilter": [

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -370,26 +370,6 @@
         {
           "indexName": "cts_e2e_search_facet",
           "facetFilters": [
-            [
-              "editor:'visual studio'",
-              "editor:neovim"
-            ]
-          ]
-        },
-        {
-          "indexName": "cts_e2e_search_facet",
-          "facetFilters": [
-            [
-              "editor:'visual studio'",
-              [
-                "editor:neovim"
-              ]
-            ]
-          ]
-        },
-        {
-          "indexName": "cts_e2e_search_facet",
-          "facetFilters": [
             "editor:'visual studio'",
             [
               "editor:neovim"
@@ -424,26 +404,6 @@
             "facetFilters": [
               "editor:'visual studio'",
               "editor:neovim"
-            ]
-          },
-          {
-            "indexName": "cts_e2e_search_facet",
-            "facetFilters": [
-              [
-                "editor:'visual studio'",
-                "editor:neovim"
-              ]
-            ]
-          },
-          {
-            "indexName": "cts_e2e_search_facet",
-            "facetFilters": [
-              [
-                "editor:'visual studio'",
-                [
-                  "editor:neovim"
-                ]
-              ]
             ]
           },
           {
@@ -512,36 +472,6 @@
             "hits": [],
             "query": "",
             "params": "facetFilters=%5B%22editor%3A%27visual+studio%27%22%2C%22editor%3Aneovim%22%5D"
-          },
-          {
-            "hitsPerPage": 20,
-            "index": "cts_e2e_search_facet",
-            "nbHits": 1,
-            "nbPages": 1,
-            "page": 0,
-            "hits": [
-              {
-                "editor": "neovim",
-                "_highlightResult": {
-                  "editor": {
-                    "value": "neovim",
-                    "matchLevel": "none"
-                  }
-                }
-              }
-            ],
-            "query": "",
-            "params": "facetFilters=%5B%5B%22editor%3A%27visual+studio%27%22%2C%22editor%3Aneovim%22%5D%5D"
-          },
-          {
-            "hitsPerPage": 20,
-            "index": "cts_e2e_search_facet",
-            "nbHits": 0,
-            "nbPages": 0,
-            "page": 0,
-            "hits": [],
-            "query": "",
-            "params": "facetFilters=%5B%5B%22editor%3A%27visual+studio%27%22%2C%5B%22editor%3Aneovim%22%5D%5D%5D"
           },
           {
             "hitsPerPage": 20,


### PR DESCRIPTION
## 🧭 What and Why

Use recursive types to avoid creating in unnecessary oneOf and allow to use the full potential of the filters
