### PR TITLE
fix(specs): exhaustiveFacetsCount is not deprecated for sffv

### DIFF
--- a/specs/search/common/schemas/SearchForFacetValuesResponse.yml
+++ b/specs/search/common/schemas/SearchForFacetValuesResponse.yml
@@ -29,6 +29,9 @@ searchForFacetValuesResponse:
             description: Number of records with this facet value. [The count may be approximated](https://support.algolia.com/hc/en-us/articles/4406975248145-Why-are-my-facet-and-hit-counts-not-accurate-).
             type: integer
     exhaustiveFacetsCount:
-      $ref: 'SearchResponse.yml#/exhaustiveFacetsCount'
+      properties: boolean
+      description: |
+        Whether the facet count is exhaustive (true) or approximate (false).
+        For more information, see [Why are my facet and hit counts not accurate](https://support.algolia.com/hc/en-us/articles/4406975248145-Why-are-my-facet-and-hit-counts-not-accurate-).
     processingTimeMS:
       $ref: 'SearchResponse.yml#/processingTimeMS'

--- a/specs/search/common/schemas/SearchForFacetValuesResponse.yml
+++ b/specs/search/common/schemas/SearchForFacetValuesResponse.yml
@@ -29,7 +29,7 @@ searchForFacetValuesResponse:
             description: Number of records with this facet value. [The count may be approximated](https://support.algolia.com/hc/en-us/articles/4406975248145-Why-are-my-facet-and-hit-counts-not-accurate-).
             type: integer
     exhaustiveFacetsCount:
-      properties: boolean
+      type: boolean
       description: |
         Whether the facet count is exhaustive (true) or approximate (false).
         For more information, see [Why are my facet and hit counts not accurate](https://support.algolia.com/hc/en-us/articles/4406975248145-Why-are-my-facet-and-hit-counts-not-accurate-).

--- a/specs/search/common/schemas/SearchResponse.yml
+++ b/specs/search/common/schemas/SearchResponse.yml
@@ -78,7 +78,9 @@ baseSearchResponse:
           title: typo
           description: Whether the typo search was exhaustive (`true`) or approximate (`false`). An approximation is done when the typo search query part takes more than 10% of the query budget (ie. 5ms by default) to be processed (this can happen when a lot of typo alternatives exist for the query). This field will not be included when typo-tolerance is entirely disabled.
     exhaustiveFacetsCount:
-      $ref: '#/exhaustiveFacetsCount'
+      type: boolean
+      description: See the `facetsCount` field of the `exhaustive` object in the response.
+      deprecated: true
     exhaustiveNbHits:
       type: boolean
       description: See the `nbHits` field of the `exhaustive` object in the response.
@@ -196,11 +198,6 @@ nbPages:
   type: integer
   description: Number of pages of results.
   example: 1
-
-exhaustiveFacetsCount:
-  type: boolean
-  description: See the `facetsCount` field of the `exhaustive` object in the response.
-  deprecated: true
 
 processingTimeMS:
   type: integer


### PR DESCRIPTION
## 🧭 What and Why

The `exhaustiveFacetsCount` property is considered deprecated in the Search response,
and users should rely on `exhaustive.facetsCount` instead.

The response from Search for facet values doesn't have an `exhaustive` object,
so `exhaustiveFacetsCount` can't be deprecated and we need to use different descriptions in both cases.

🎟 JIRA Ticket:

### Changes included:

- Don't reuse the definition of `exhaustiveFacetsCount`, but inline them for the Search and Search for facet values responses, not marking it deprecated in the Sffv response.