### PR TITLE
fix(specs): dont mention index api keys

### DIFF
--- a/specs/search/paths/manage_indices/operationIndex.yml
+++ b/specs/search/paths/manage_indices/operationIndex.yml
@@ -8,7 +8,7 @@ post:
   description: |
     Copies or moves (renames) an index within the same Algolia application.
 
-    - Existing destination indices are overwritten, except for index-specific API keys and analytics data.
+    - Existing destination indices are overwritten, except for their analytics data.
     - If the destination index doesn't exist yet, it'll be created.
 
     **Copy**


### PR DESCRIPTION
## 🧭 What and Why

Remove mention of "Index-specific API keys:" in the reference for `operationIndex`.
These are deprecated and don't exist on Metis.