### PR TITLE
fix(specs): rankingInfo required properties

### DIFF
--- a/specs/search/common/schemas/Hit.yml
+++ b/specs/search/common/schemas/Hit.yml
@@ -75,13 +75,10 @@ rankingInfo:
       type: boolean
       description: Whether the record is re-ranked.
   required:
-    - promoted
     - nbTypos
     - firstMatchedWord
     - geoDistance
     - nbExactWords
-    - words
-    - filters
     - userScore
 
 matchedGeoLocation:


### PR DESCRIPTION
## 🧭 What and Why

According to the doc examples, `promoted`, `words` and `filters` are not required on the `rankingInfo` response, and it's blocking on the dart client: https://github.com/algolia/algoliasearch-client-dart/issues/6