### PR TITLE
feat(clients): add waitForAppTask helper

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -47,6 +47,33 @@ public partial class SearchClient
     AsyncHelper.RunSync(() => WaitForTaskAsync(indexName, taskId, maxRetries, timeout, requestOptions, ct));
 
   /// <summary>
+  /// Wait for an application-level task to complete with `taskID`.
+  /// </summary>
+  /// <param name="taskId">The `taskID` returned in the method response.</param>
+  /// <param name="maxRetries">The maximum number of retry. 50 by default. (optional)</param>
+  /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
+  /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
+  /// <param name="ct">Cancellation token (optional)</param>
+  public async Task<GetTaskResponse> WaitForAppTaskAsync(long taskId, int maxRetries = DefaultMaxRetries,
+    Func<int, int> timeout = null, RequestOptions requestOptions = null, CancellationToken ct = default)
+  {
+    return await RetryUntil(async () => await GetAppTaskAsync(taskId, requestOptions, ct),
+      resp => resp.Status == Models.Search.TaskStatus.Published, maxRetries, timeout, ct).ConfigureAwait(false);
+  }
+
+  /// <summary>
+  /// Wait for an application-level task to complete with `taskID`. (Synchronous version)
+  /// </summary>
+  /// <param name="taskId">The `taskID` returned in the method response.</param>
+  /// <param name="maxRetries">The maximum number of retry. 50 by default. (optional)</param>
+  /// <param name="timeout">The function to decide how long to wait between retries. Math.Min(retryCount * 200, 5000) by default. (optional)</param>
+  /// <param name="requestOptions">The requestOptions to send along with the query, they will be merged with the transporter requestOptions. (optional)</param>
+  /// <param name="ct">Cancellation token (optional)</param>
+  public GetTaskResponse WaitForAppTask(long taskId, int maxRetries = DefaultMaxRetries,
+    Func<int, int> timeout = null, RequestOptions requestOptions = null, CancellationToken ct = default) =>
+    AsyncHelper.RunSync(() => WaitForAppTaskAsync(taskId, maxRetries, timeout, requestOptions, ct));
+
+  /// <summary>
   /// Helper method that waits for an API key task to be processed.
   /// </summary>
   /// <param name="operation">The `operation` that was done on a `key`.</param>

--- a/clients/algoliasearch-client-dart/packages/client_search/lib/src/extension/wait_task.dart
+++ b/clients/algoliasearch-client-dart/packages/client_search/lib/src/extension/wait_task.dart
@@ -28,7 +28,7 @@ extension WaitTask on SearchClient {
     );
   }
 
-  /// Wait for an application-leve [taskID] to complete before executing the next line of code.
+  /// Wait for an application-level [taskID] to complete before executing the next line of code.
   Future<void> waitAppTask({
     required int taskID,
     WaitParams params = const WaitParams(),

--- a/clients/algoliasearch-client-dart/packages/client_search/lib/src/extension/wait_task.dart
+++ b/clients/algoliasearch-client-dart/packages/client_search/lib/src/extension/wait_task.dart
@@ -28,6 +28,22 @@ extension WaitTask on SearchClient {
     );
   }
 
+  /// Wait for an application-leve [taskID] to complete before executing the next line of code.
+  Future<void> waitAppTask({
+    required int taskID,
+    WaitParams params = const WaitParams(),
+    RequestOptions? requestOptions,
+  }) async {
+    await _waitUntil(
+      params: params,
+      retry: () => getAppTask(
+        taskID: taskID,
+        requestOptions: requestOptions,
+      ),
+      until: (response) => response.status == TaskStatus.published,
+    );
+  }
+
   ///  Wait on an API key creation operation.
   Future<void> waitKeyCreation({
     required String key,

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/extensions/SearchClient.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/extensions/SearchClient.kt
@@ -106,6 +106,34 @@ public suspend fun SearchClient.waitTask(
 }
 
 /**
+ * Wait for an application-level [taskID] to complete before executing the next line of code.
+ *
+ * @param taskID The ID of the task to wait for.
+ * @param timeout If specified, the method will throw a
+ *   [kotlinx.coroutines.TimeoutCancellationException] after the timeout value in milliseconds is
+ *   elapsed.
+ * @param maxRetries maximum number of retry attempts.
+ * @param requestOptions additional request configuration.
+ */
+public suspend fun SearchClient.waitAppTask(
+  taskID: Long,
+  maxRetries: Int = 50,
+  timeout: Duration = Duration.INFINITE,
+  initialDelay: Duration = 200.milliseconds,
+  maxDelay: Duration = 5.seconds,
+  requestOptions: RequestOptions? = null,
+): TaskStatus {
+  return retryUntil(
+    timeout = timeout,
+    maxRetries = maxRetries,
+    initialDelay = initialDelay,
+    maxDelay = maxDelay,
+    retry = { getAppTask(taskID, requestOptions).status },
+    until = { it == TaskStatus.Published },
+  )
+}
+
+/**
  * Wait on an API key update operation.
  *
  * @param key The key that has been updated.

--- a/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/extension/package.scala
+++ b/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/extension/package.scala
@@ -73,6 +73,29 @@ package object extension {
       )
     }
 
+    /** Wait for an application-level taskID to complete before executing the next line of code.
+      *
+      * @param taskID
+      *   The ID of the task to wait for.
+      * @param maxRetries
+      *   maximum number of retry attempts.
+      * @param requestOptions
+      *   additional request configuration.
+      */
+    def waitAppTask(
+        taskID: Long,
+        delay: Long => Long = DEFAULT_DELAY,
+        maxRetries: Int = 50,
+        requestOptions: Option[RequestOptions] = None
+    )(implicit ec: ExecutionContext): Future[TaskStatus] = {
+      retryUntil(
+        retry = () => client.getAppTask(taskID, requestOptions).map(_.status),
+        until = (status: TaskStatus) => status == TaskStatus.Published,
+        maxRetries = maxRetries,
+        delay = delay
+      )
+    }
+
     /** Wait on an API key update operation.
       *
       * @param key

--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -83,7 +83,7 @@ public extension SearchClient {
             },
             timeout: {
                 timeout(retryCount)
-            },
+            }
             error: IterableError(
                 validate: { _ in
                     retryCount >= maxRetries

--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -83,7 +83,7 @@ public extension SearchClient {
             },
             timeout: {
                 timeout(retryCount)
-            }
+            },
             error: IterableError(
                 validate: { _ in
                     retryCount >= maxRetries

--- a/templates/go/search_helpers.mustache
+++ b/templates/go/search_helpers.mustache
@@ -82,6 +82,84 @@ func (c *APIClient) WaitForTaskWithContext(
 }
 
 /*
+WaitForAppTask waits for a task to be published.
+Wraps WaitForAppTask with context.Background().
+It returns the task response if the operation was successful.
+It returns an error if the operation failed.
+
+The maxRetries parameter is the maximum number of retries.
+The initialDelay parameter is the initial delay between each retry.
+The maxDelay parameter is the maximum delay between each retry.
+
+  @param taskID int64 - Task ID.
+  @param maxRetries *int - Maximum number of retries.
+  @param initialDelay *time.Duration - Initial delay between retries.
+  @param maxDelay *time.Duration - Maximum delay between retries.
+  @param opts ...Option - Optional parameters for the request.
+  @return *GetTaskResponse - Task response.
+  @return error - Error if any.
+*/
+func (c *APIClient) WaitForAppTask(
+  taskID int64,
+  maxRetries *int,
+  initialDelay *time.Duration,
+  maxDelay *time.Duration,
+  opts ...Option,
+) (*GetTaskResponse, error) {
+  return c.WaitForAppTaskWithContext(
+    context.Background(),
+    taskID,
+    maxRetries,
+    initialDelay,
+    maxDelay,
+    opts...,
+  )
+}
+
+/*
+WaitForAppTaskWithContext waits for a task to be published.
+It returns the task response if the operation was successful.
+It returns an error if the operation failed.
+
+The maxRetries parameter is the maximum number of retries.
+The initialDelay parameter is the initial delay between each retry.
+The maxDelay parameter is the maximum delay between each retry.
+
+  @param ctx context.Context - The context that will be drilled down to the actual request.
+  @param taskID int64 - Task ID.
+  @param maxRetries *int - Maximum number of retries.
+  @param initialDelay *time.Duration - Initial delay between retries.
+  @param maxDelay *time.Duration - Maximum delay between retries.
+  @param opts ...Option - Optional parameters for the request.
+  @return *GetTaskResponse - Task response.
+  @return error - Error if any.
+*/
+func (c *APIClient) WaitForAppTaskWithContext(
+  ctx context.Context,
+  taskID int64,
+  maxRetries *int,
+  initialDelay *time.Duration,
+  maxDelay *time.Duration,
+  opts ...Option,
+) (*GetTaskResponse, error) {
+  return utils.RetryUntil( //nolint:wrapcheck
+    func() (*GetTaskResponse, error) {
+      return c.GetAppTaskWithContext(ctx, c.NewApiGetAppTaskRequest(taskID), opts...)
+    },
+    func(response *GetTaskResponse, err error) bool {
+      if err != nil || response == nil {
+        return false
+      }
+
+      return response.Status == TASKSTATUS_PUBLISHED
+    },
+    maxRetries,
+    initialDelay,
+    maxDelay,
+  )
+}
+
+/*
 WaitForApiKey waits for an API key to be created, deleted or updated.
 It returns the API key response if the operation was successful.
 It returns an error if the operation failed.

--- a/templates/go/search_helpers.mustache
+++ b/templates/go/search_helpers.mustache
@@ -82,7 +82,7 @@ func (c *APIClient) WaitForTaskWithContext(
 }
 
 /*
-WaitForAppTask waits for a task to be published.
+WaitForAppTask waits for an application-level task to be published.
 Wraps WaitForAppTask with context.Background().
 It returns the task response if the operation was successful.
 It returns an error if the operation failed.
@@ -117,7 +117,7 @@ func (c *APIClient) WaitForAppTask(
 }
 
 /*
-WaitForAppTaskWithContext waits for a task to be published.
+WaitForAppTaskWithContext waits for an application-level task to be published.
 It returns the task response if the operation was successful.
 It returns an error if the operation failed.
 

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -70,7 +70,7 @@ TaskUtils.retryUntil(
 }
 
 /**
-* Helper: Wait for a application-level task to complete with `taskID`.
+* Helper: Wait for an application-level task to complete with `taskID`.
 *
 * @param taskID The `taskID` returned in the method response.
 * @param requestOptions The requestOptions to send along with the query, they will be merged with
@@ -81,7 +81,7 @@ this.waitForAppTask(taskID, TaskUtils.DEFAULT_MAX_RETRIES, TaskUtils.DEFAULT_TIM
 }
 
 /**
-* Helper: Wait for a application-level task to complete with `taskID`.
+* Helper: Wait for an application-level task to complete with `taskID`.
 *
 * @param taskID The `taskID` returned in the method response.
 * @param maxRetries The maximum number of retry. 50 by default. (optional)
@@ -93,7 +93,7 @@ this.waitForAppTask(taskID, maxRetries, timeout, null);
 }
 
 /**
-* Helper: Wait for a application-level task to complete with `taskID`.
+* Helper: Wait for an application-level task to complete with `taskID`.
 *
 * @param taskID The `taskID` returned in the method response.
 */

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -62,7 +62,7 @@ public void waitForTask(String indexName, Long taskID) {
 */
 public void waitForAppTask(Long taskID, int maxRetries, IntUnaryOperator timeout, RequestOptions requestOptions) {
 TaskUtils.retryUntil(
-  () -> this.getTask(taskID, requestOptions),
+  () -> this.getAppTask(taskID, requestOptions),
   (GetTaskResponse task) -> task.getStatus() == TaskStatus.PUBLISHED,
   maxRetries,
   timeout

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -51,6 +51,57 @@ public void waitForTask(String indexName, Long taskID) {
 }
 
 /**
+* Helper: Wait for a application-level task to complete with `taskID`.
+*
+* @param taskID The `taskID` returned in the method response.
+* @param maxRetries The maximum number of retry. 50 by default. (optional)
+* @param timeout The function to decide how long to wait between retries. min(retries * 200,
+*     5000) by default. (optional)
+* @param requestOptions The requestOptions to send along with the query, they will be merged with
+*     the transporter requestOptions. (optional)
+*/
+public void waitForAppTask(Long taskID, int maxRetries, IntUnaryOperator timeout, RequestOptions requestOptions) {
+TaskUtils.retryUntil(
+  () -> this.getTask(taskID, requestOptions),
+  (GetTaskResponse task) -> task.getStatus() == TaskStatus.PUBLISHED,
+  maxRetries,
+  timeout
+);
+}
+
+/**
+* Helper: Wait for a application-level task to complete with `taskID`.
+*
+* @param taskID The `taskID` returned in the method response.
+* @param requestOptions The requestOptions to send along with the query, they will be merged with
+*     the transporter requestOptions. (optional)
+*/
+public void waitForAppTask(Long taskID, RequestOptions requestOptions) {
+this.waitForAppTask(taskID, TaskUtils.DEFAULT_MAX_RETRIES, TaskUtils.DEFAULT_TIMEOUT, requestOptions);
+}
+
+/**
+* Helper: Wait for a application-level task to complete with `taskID`.
+*
+* @param taskID The `taskID` returned in the method response.
+* @param maxRetries The maximum number of retry. 50 by default. (optional)
+* @param timeout The function to decide how long to wait between retries. min(retries * 200,
+*     5000) by default. (optional)
+*/
+public void waitForAppTask(Long taskID, int maxRetries, IntUnaryOperator timeout) {
+this.waitForAppTask(taskID, maxRetries, timeout, null);
+}
+
+/**
+* Helper: Wait for a application-level task to complete with `taskID`.
+*
+* @param taskID The `taskID` returned in the method response.
+*/
+public void waitForAppTask(Long taskID) {
+this.waitForAppTask(taskID, TaskUtils.DEFAULT_MAX_RETRIES, TaskUtils.DEFAULT_TIMEOUT, null);
+}
+
+/**
   * Helper: Wait for an API key to be added, updated or deleted based on a given `operation`.
   *
   * @param operation The `operation` that was done on a `key`.

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -50,7 +50,7 @@ waitForAppTask(
     maxRetries = 50,
     timeout = (retryCount: number): number =>
       Math.min(retryCount * 200, 5000),
-  }: waitForAppTaskOptions,
+  }: WaitForAppTaskOptions,
   requestOptions?: RequestOptions
 ): Promise<GetTaskResponse> {
   let retryCount = 0;

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -35,6 +35,40 @@ waitForTask(
 },
 
 /**
+ * Helper: Wait for an application-level task to complete for a given `taskID`.
+ *
+ * @summary Helper method that waits for a task to be published (completed).
+ * @param waitForAppTaskOptions - The `waitForTaskOptions` object.
+ * @param waitForAppTaskOptions.taskID - The `taskID` returned in the method response.
+ * @param waitForAppTaskOptions.maxRetries - The maximum number of retries. 50 by default.
+ * @param waitForAppTaskOptions.timeout - The function to decide how long to wait between retries.
+ * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
+ */
+waitForAppTask(
+  {
+    taskID,
+    maxRetries = 50,
+    timeout = (retryCount: number): number =>
+      Math.min(retryCount * 200, 5000),
+  }: waitForAppTaskOptions,
+  requestOptions?: RequestOptions
+): Promise<GetTaskResponse> {
+  let retryCount = 0;
+
+  return createIterablePromise({
+    func: () => this.getAppTask({ taskID }, requestOptions),
+    validate: (response) => response.status === 'published',
+    aggregator: () => (retryCount += 1),
+    error: {
+      validate: () => retryCount >= maxRetries,
+      message: () =>
+        `The maximum number of retries exceeded. (${retryCount}/${maxRetries})`,
+    },
+    timeout: () => timeout(retryCount),
+  });
+},
+
+/**
  * Helper: Wait for an API key to be added, updated or deleted based on a given `operation`.
  *
  * @summary Helper method that waits for an API key task to be processed.

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -33,6 +33,7 @@ import type {
     ReplaceAllObjectsOptions,
     WaitForApiKeyOptions,
     WaitForTaskOptions,
+    WaitForAppTaskOptions,
   {{/isSearchClient}}
   {{#operation}}
     {{#vendorExtensions}}

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -63,15 +63,18 @@ type WaitForOptions = Partial<{
   timeout: (retryCount: number) => number;
 }>;
 
-export type WaitForTaskOptions = WaitForOptions & {
-  /**
-   * The `indexName` where the operation was performed.
-   */
-  indexName: string;
+export type waitForAppTaskOptions = WaitForOptions & {
   /**
    * The `taskID` returned by the method response.
    */
   taskID: number;
+};
+
+export type WaitForTaskOptions = WaitForAppTaskOptions & {
+  /**
+   * The `indexName` where the operation was performed.
+   */
+  indexName: string;
 };
 
 export type WaitForApiKeyOptions = WaitForOptions & {

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -63,7 +63,7 @@ type WaitForOptions = Partial<{
   timeout: (retryCount: number) => number;
 }>;
 
-export type waitForAppTaskOptions = WaitForOptions & {
+export type WaitForAppTaskOptions = WaitForOptions & {
   /**
    * The `taskID` returned by the method response.
    */

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -328,6 +328,38 @@ use {{invokerPackage}}\Support\Helpers;
     }
 
     /**
+     * Wait for an application-level task to complete with `taskID`.
+     *
+     * @param int $taskId Task Id
+     * @param array $requestOptions the requestOptions to send along with the query, they will be merged with the transporter requestOptions
+     * @param int|null $maxRetries Maximum number of retries
+     * @param int|null $timeout Timeout
+     *
+     * @throws ExceededRetriesException
+     *
+     * @return void
+     */
+    public function waitForAppTask($taskId, $requestOptions = [], $maxRetries = null, $timeout = null)
+    {
+        if ($timeout === null) {
+            $timeout = $this->config->getWaitTaskTimeBeforeRetry();
+        }
+
+        if ($maxRetries === null) {
+            $maxRetries = $this->config->getDefaultMaxRetries();
+        }
+
+        Helpers::retryUntil(
+            $this,
+            'getAppTask',
+            [$taskId, $requestOptions],
+            function($res) {return 'published' === $res['status'];},
+            $maxRetries,
+            $timeout
+        );
+    }
+
+    /**
      * Wait for an API key to be added, updated or deleted based on a given `operation`.
      *
      * @param string $operation the `operation` that was done on a `key`

--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -26,6 +26,33 @@
             error_message=lambda: f"The maximum number of retries exceeded. (${self._retry_count}/${max_retries})",
         )
 
+    async def wait_for_app_task(
+        self,
+        task_id: int,
+        timeout: RetryTimeout = RetryTimeout(),
+        max_retries: int = 50,
+        request_options: Optional[Union[dict, RequestOptions]] = None,
+    ) -> GetTaskResponse:
+        """
+        Helper: Wait for an application-level task to complete for a given `taskID`.
+        """
+        self._retry_count = 0
+
+        async def _func(_: GetTaskResponse) -> GetTaskResponse:
+            return await self.get_app_task(task_id, request_options)
+
+        def _aggregator(_: GetTaskResponse) -> None:
+            self._retry_count += 1
+
+        return await create_iterable(
+            func=_func,
+            aggregator=_aggregator,
+            validate=lambda _resp: _resp.status == "published",
+            timeout=lambda: timeout(self._retry_count),
+            error_validate=lambda x: self._retry_count >= max_retries,
+            error_message=lambda: f"The maximum number of retries exceeded. (${self._retry_count}/${max_retries})",
+        )
+
     async def wait_for_api_key(
         self,
         operation: str,

--- a/templates/ruby/search_helpers.mustache
+++ b/templates/ruby/search_helpers.mustache
@@ -19,6 +19,26 @@ def wait_for_task(index_name, task_id, max_retries = 50, timeout = -> (retry_cou
   raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
 end
 
+# Helper: Wait for an application-level task to be published (completed) for a given `task_id`.
+#
+# @param task_id [Integer] the `task_id` returned in the method response. (required)
+# @param max_retries [Integer] the maximum number of retries. (optional, default to 50)
+# @param timeout [Proc] the function to decide how long to wait between retries. (optional)
+# @param request_options [Hash] the requestOptions to send along with the query, they will be forwarded to the `get_task` method.
+# @return [Http::Response] the last get_task response
+def wait_for_app_task(task_id, max_retries = 50, timeout = -> (retry_count) { [retry_count * 200, 5000].min }, request_options = {})
+  retries = 0
+  while retries < max_retries
+    res = get_app_task(task_id, request_options)
+    if res.status == 'published'
+      return res
+    end
+    retries += 1
+    sleep(timeout.call(retries) / 1000.0)
+  end
+  raise ApiError, "The maximum number of retries exceeded. (#{max_retries})"
+end
+
 # Helper: Wait for an API key to be added, updated or deleted based on a given `operation`.
 #
 # @param operation [String] the `operation` that was done on a `key`.

--- a/website/docs/clients/guides/manage-dictionary-entries.mdx
+++ b/website/docs/clients/guides/manage-dictionary-entries.mdx
@@ -12,32 +12,32 @@ A `dictionaryName` can be either `stopwords`, `plurals` or `compounds`.
 
 > Useful when you have new data to add to a dictionary and don't want to impact existing entries.
 
-<CodeBlockLanguage snippet={({getSnippet, waitForTaskSnippet}) => (
+<CodeBlockLanguage snippet={({getSnippet, waitForAppTaskSnippet}) => (
 `${getSnippet('import')}
 
 ${getSnippet('init')}
 
 ${getSnippet('batchDictionaryEntries', 'append')}
 
-${waitForTaskSnippet()}
+${waitForAppTaskSnippet()}
 `)}/>
 
 ## Replace dictionary entries
 
 > Useful when you want to clear every entries of a dictionary and add new ones at the same time.
 
-<CodeBlockLanguage snippet={({getSnippet, waitForTaskSnippet}) => (
+<CodeBlockLanguage snippet={({getSnippet, waitForAppTaskSnippet}) => (
 `${getSnippet('batchDictionaryEntries', 'replace')}
 
-${waitForTaskSnippet()}
+${waitForAppTaskSnippet()}
 `)}/>
 
 ## Delete entries in the dictionary
 
 > Useful when deleting one or many entries from a dictionary.
 
-<CodeBlockLanguage snippet={({getSnippet, waitForTaskSnippet}) => (
+<CodeBlockLanguage snippet={({getSnippet, waitForAppTaskSnippet}) => (
 `${getSnippet('batchDictionaryEntries', 'delete')}
 
-${waitForTaskSnippet()}
+${waitForAppTaskSnippet()}
 `)}/>

--- a/website/src/components/CodeBlockLanguage.js
+++ b/website/src/components/CodeBlockLanguage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import TabItem from '@theme/TabItem';
 import { languagesTabValues, TabsLanguage } from './TabsLanguage';
-import { addComment, getSnippet, waitForTaskSnippet, waitForApiKeySnippet } from '../snippets';
+import { addComment, getSnippet, waitForTaskSnippet, waitForApiKeySnippet, waitForAppTaskSnippet } from '../snippets';
 
 export function CodeBlockLanguage(props) {
   return <TabsLanguage>
@@ -15,6 +15,7 @@ export function CodeBlockLanguage(props) {
               getSnippet: (...args) => getSnippet(language, props.client || 'search', ...args),
               addComment: (comment) => addComment(language, comment),
               waitForTaskSnippet: (indexName = '<YOUR_INDEX_NAME>') => waitForTaskSnippet(language, indexName),
+              waitForAppTaskSnippet: () => waitForAppTaskSnippet(language),
               waitForApiKeySnippet: (operation) => waitForApiKeySnippet(language, operation),
               language,
             })}

--- a/website/src/snippets.js
+++ b/website/src/snippets.js
@@ -28,6 +28,26 @@ if err != nil {
   }[language];
 }
 
+
+export function waitForAppTaskSnippet(language) {
+  return {
+    'csharp': `await client.WaitForAppTaskAsync(response.TaskID);`,
+    'dart': `await client.waitAppTask(response.taskID);`,
+    'go': `taskResponse, err := searchClient.WaitForAppTask(response.TaskID, nil, nil, nil)
+if err != nil {
+  panic(err)
+}`,
+    'java': `client.waitForAppTask(response.getTaskID());`,
+    'javascript': `await client.waitForAppTask({ taskID: response.taskID });`,
+    'kotlin': `client.waitAppTask(response.taskID)`,
+    'php': `$client->waitForAppTask($response['taskID']);`,
+    'python': `await client.wait_for_app_task(task_id=response.task_id)`,
+    'ruby': `client.wait_for_app_task(response.task_id)`,
+    'scala': `client.waitAppTask(response.getTaskID())`,
+    'swift': `try await client.waitForAppTask(with: response.taskID)`,
+  }[language];
+}
+
 export function waitForApiKeySnippet(language, operation) {
   return {
     'csharp': {


### PR DESCRIPTION
## 🧭 What and Why

Add the `waitForAppTask` helper in all languages

- [x] csharp
- [x] dart
- [x] go
- [x] java
- [x] javascript
- [x] kotlin
- [x] php
- [x] python
- [x] ruby
- [x] scala
- [x] swift