### PR TITLE
fix(clients): remove unused models from lite clients

### DIFF
--- a/scripts/buildSpecs.ts
+++ b/scripts/buildSpecs.ts
@@ -272,6 +272,11 @@ async function buildLiteSpec({
 
   await fsp.writeFile(bundledPath, yaml.dump(parsed));
 
+  // remove unused components for the outputted light spec
+  await run(
+    `yarn openapi bundle ${bundledPath} -o ${bundledPath} --ext yml --remove-unused-components`,
+  );
+
   await transformBundle({
     bundledPath,
     clientName: spec,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2440

### Changes included:

js and dart ships unused models because the lite specs keep them