### PR TITLE
fix(python): remove contact

### DIFF
--- a/clients/algoliasearch-client-csharp/README.md
+++ b/clients/algoliasearch-client-csharp/README.md
@@ -17,7 +17,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-csharp/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/csharp/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-dart/README.md
+++ b/clients/algoliasearch-client-dart/README.md
@@ -22,7 +22,7 @@
   <a href="https://discourse.algolia.com" target="_blank">Community Forum</a>  •
   <a href="https://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-dart/issues" target="_blank">Report a Bug</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## 📚 Description

--- a/clients/algoliasearch-client-dart/packages/algoliasearch/README.md
+++ b/clients/algoliasearch-client-dart/packages/algoliasearch/README.md
@@ -22,7 +22,7 @@
   <a href="https://discourse.algolia.com" target="_blank">Community Forum</a>  •
   <a href="https://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-dart/issues" target="_blank">Report a Bug</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## 📚 Description

--- a/clients/algoliasearch-client-go/README.md
+++ b/clients/algoliasearch-client-go/README.md
@@ -20,7 +20,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-go/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/go/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 # Pre-Release Notice

--- a/clients/algoliasearch-client-java/README.md
+++ b/clients/algoliasearch-client-java/README.md
@@ -17,7 +17,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-java/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/java/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-javascript/README.md
+++ b/clients/algoliasearch-client-javascript/README.md
@@ -1,5 +1,3 @@
-....
-
 <p align="center">
   <a href="https://www.algolia.com">
     <img alt="Algolia for JavaScript" src="https://raw.githubusercontent.com/algolia/algoliasearch-client-common/master/banners/javascript.png" >
@@ -16,9 +14,85 @@
 </p>
 
 <p align="center">
-  <a href="https://api-clients-automation.netlify.app/docs/clients/introduction" target="_blank">Documentation</a>
+  <a href="https://www.algolia.com/doc/api-client/getting-started/install/javascript/" target="_blank">Documentation</a>  •
+  <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/" target="_blank">InstantSearch</a>  •
+  <a href="https://discourse.algolia.com" target="_blank">Community Forum</a>  •
+  <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
+  <a href="https://github.com/algolia/algoliasearch-client-javascript/issues" target="_blank">Report a bug</a>  •
+  <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/" target="_blank">FAQ</a>  •
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
-# Contributing to this repository
+**Migration note from v4.x to v5.x**
 
-The Algolia API clients are automatically generated, you can find everything here https://github.com/algolia/api-clients-automation
+> In July 2024, we released the v5 version of our JavaScript client. If you are using version 4.x of the client, read the [migration guide to version 5.x](https://api-clients-automation.netlify.app/docs/clients/migration-guides/). Version 4.x will **no longer** be under active development.
+
+## ✨ Features
+
+- Thin & **minimal low-level HTTP client** to interact with Algolia's API
+- Works both on the **browser** and **node.js**
+- **UMD and ESM compatible**, you can use it with any module loader
+- Built with TypeScript
+
+## 💡 Getting Started
+
+First, install Algolia JavaScript API Client via your favorite package manager:
+
+```bash
+yarn add algoliasearch@beta
+# or
+npm install algoliasearch@beta
+```
+
+Or Without a package manager:
+
+Add the following JavaScript snippet to the `<head>` of your website:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@beta/dist/algoliasearch.umd.min.js"></script>
+```
+
+Then, create objects on your index:
+
+```js
+import { algoliasearch } from 'algoliasearch';
+
+const client = algoliasearch('YourApplicationID', 'YourAdminAPIKey');
+
+// Add a new record to your Algolia index
+const saveResponse = await client.saveObject({
+  indexName: '<YOUR_INDEX_NAME>',
+  body: { objectID: 'id', test: 'val' },
+});
+
+// use typed response
+console.log(saveResponse);
+
+// Poll the task status to know when it has been indexed
+await client.waitForTask({ indexName: '<YOUR_INDEX_NAME>', taskID: saveResponse.taskID });
+
+// Fetch search results, with typo tolerance
+const searchResponse = await client.search({
+  requests: [
+    {
+      indexName: '<YOUR_INDEX_NAME>',
+      query: '<YOUR_QUERY>',
+      hitsPerPage: 50,
+    },
+  ],
+});
+
+// use typed response
+console.log(searchResponse);
+```
+
+For the full documentation, visit the **[online documentation](https://api-clients-automation.netlify.app/docs/clients/usage)**.
+
+## ❓ Troubleshooting
+
+Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/) where you will find answers for the most common issues and gotchas with the client.
+
+## 📄 License
+
+Algolia JavaScript API Client is an open-sourced software licensed under the [MIT license](LICENSE.md).
+

--- a/clients/algoliasearch-client-kotlin/README.md
+++ b/clients/algoliasearch-client-kotlin/README.md
@@ -17,7 +17,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-kotlin/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/kotlin/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-python/README.md
+++ b/clients/algoliasearch-client-python/README.md
@@ -19,7 +19,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-python/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/python/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-ruby/README.md
+++ b/clients/algoliasearch-client-ruby/README.md
@@ -19,7 +19,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-ruby/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/ruby/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-scala/README.md
+++ b/clients/algoliasearch-client-scala/README.md
@@ -17,7 +17,7 @@
   <a href="https://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-scala/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/scala/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/clients/algoliasearch-client-swift/README.md
+++ b/clients/algoliasearch-client-swift/README.md
@@ -34,7 +34,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-swift/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/swift/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/templates/kotlin/README.mustache
+++ b/templates/kotlin/README.mustache
@@ -17,7 +17,7 @@
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-kotlin/issues" target="_blank">Report a bug</a>  •
   <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/kotlin/" target="_blank">FAQ</a>  •
-  <a href="https://www.algolia.com/support" target="_blank">Support</a>
+  <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
 ## ✨ Features

--- a/templates/python/pyproject.mustache
+++ b/templates/python/pyproject.mustache
@@ -2,7 +2,7 @@
 name = "algoliasearch"
 version = "{{{packageVersion}}}"
 description = "A fully-featured and blazing-fast Python API client to interact with Algolia."
-authors = ["Algolia Team <https://alg.li/support>"]
+authors = ["Algolia Team"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://www.algolia.com"

--- a/tests/output/python/pyproject.toml
+++ b/tests/output/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "tests"
 version = "0.0.1"
 description = "common test suite for the Python API client"
-authors = ["Algolia Team <https://alg.li/support>"]
+authors = ["Algolia Team"]
 license = "MIT"
 homepage = "https://www.algolia.com"
 repository = "https://github.com/algolia/api-clients-automation"


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

seems like the value in between chevrons is parsed and required to be an email, we can remove it and let people use the link only, also update readmes so they all point to the same support page