### PR TITLE
feat(scripts): allow subset release and major

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "github-actions:lint": "eslint --ext=yml .github/",
     "postinstall": "husky && yarn workspace eslint-plugin-automation-custom build && yarn workspace scripts build:cli",
     "playground:browser": "yarn workspace javascript-browser-playground start",
-    "release": "yarn workspace scripts createReleasePR",
     "scripts:build": "yarn workspace scripts build",
     "scripts:lint": "yarn workspace scripts lint",
     "scripts:test": "yarn workspace scripts test",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,7 +8,6 @@
     "build:cli": "tsc && tsc-alias",
     "cleanGeneratedBranch": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/cleanGeneratedBranch.js",
     "createMatrix": "NODE_NO_WARNINGS=1 node dist/scripts/ci/githubActions/createMatrix.js",
-    "createReleasePR": "NODE_NO_WARNINGS=1 RELEASE=true node dist/scripts/release/createReleasePR.js",
     "lint": "eslint --ext=ts,js,mjs,cjs .",
     "lint:deadcode": "knip",
     "pre-commit": "node ./ci/husky/pre-commit.mjs",

--- a/scripts/release/__tests__/createReleasePR.test.ts
+++ b/scripts/release/__tests__/createReleasePR.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 
 import releaseConfig from '../../../config/release.config.json' assert { type: 'json' };
 import type { PassedCommit } from '../types.js';
+import { LANGUAGES } from "../../common.js";
 
 const gitAuthor = releaseConfig.gitAuthor;
 
@@ -450,10 +451,85 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.releaseType).toEqual('major');
       expect(versions.javascript.next).toEqual('1.0.0');
+    });
+
+    it('allows forcing major releases', async () => {
+      const versions = await decideReleaseStrategy({
+        versions: {
+          javascript: {
+            current: '0.0.1',
+          },
+          java: {
+            current: '0.0.1',
+          },
+          php: {
+            current: '0.0.1',
+          },
+        },
+        commits: [],
+        languages: LANGUAGES,
+        major: true
+      });
+
+      expect(versions.javascript.releaseType).toEqual('major');
+      expect(versions.javascript.next).toEqual('1.0.0');
+
+      expect(versions.php.releaseType).toEqual('major');
+      expect(versions.php.next).toEqual('1.0.0');
+
+      expect(versions.java.releaseType).toEqual('major');
+      expect(versions.java.next).toEqual('1.0.0');
+    });
+
+    it('allows releasing subset of clients', async () => {
+      const versions = await decideReleaseStrategy({
+        versions: {
+          javascript: {
+            current: '0.0.1',
+          },
+          java: {
+            current: '0.0.1',
+          },
+          php: {
+            current: '0.0.1',
+          },
+        },
+        commits: [
+          (await parseCommit(
+            buildTestCommit({
+              type: 'feat',
+              scope: 'javascript',
+              message: 'update the API',
+            })
+          )) as PassedCommit,
+          (await parseCommit(
+            buildTestCommit({
+              type: 'feat',
+              scope: 'java',
+              message: 'update the API',
+            })
+          )) as PassedCommit,
+          (await parseCommit(
+            buildTestCommit({
+              type: 'feat',
+              scope: 'php',
+              message: 'update the API',
+            })
+          )) as PassedCommit,
+        ],
+        languages: ['php'],
+      });
+
+      expect(versions.javascript.skipRelease).toEqual(true);
+      expect(versions.java.skipRelease).toEqual(true);
+      expect(versions.php.skipRelease).toEqual(false);
+      expect(versions.php.releaseType).toEqual('minor');
+      expect(versions.php.next).toEqual('0.1.0');
     });
 
     it('bumps minor version for feat', async () => {
@@ -478,6 +554,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.php.releaseType).toEqual('minor');
@@ -506,6 +583,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.java.releaseType).toEqual('patch');
@@ -534,6 +612,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toEqual(true);
@@ -565,6 +644,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toBeUndefined();
@@ -600,6 +680,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toBeUndefined();
@@ -642,6 +723,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toBeUndefined();
@@ -677,6 +759,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
       expect(versions.javascript.skipRelease).toEqual(true);
       expect(versions.java.skipRelease).toBeUndefined();
@@ -705,6 +788,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toBeUndefined();
@@ -740,6 +824,7 @@ describe('createReleasePR', () => {
             })
           )) as PassedCommit,
         ],
+        languages: LANGUAGES,
       });
 
       expect(versions.javascript.noCommit).toBeUndefined();

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -208,18 +208,37 @@ export function getNextVersion(current: string, releaseType: semver.ReleaseType 
 export async function decideReleaseStrategy({
   versions,
   commits,
+  languages,
+  major,
 }: {
   versions: VersionsBeforeBump;
   commits: PassedCommit[];
+  languages: Language[];
+  major?: boolean;
 }): Promise<Versions> {
   const versionsToPublish: Versions = {};
 
   for (const [lang, version] of Object.entries(versions)) {
+    const currentVersion = versions[lang].current;
+
+    if (!languages.includes(lang as Language)) {
+      console.log(`${lang} is not in the given language list, skipping release`);
+
+      versionsToPublish[lang] = {
+        ...version,
+        noCommit: true,
+        releaseType: null,
+        skipRelease: true,
+        next: getNextVersion(currentVersion, null),
+      };
+
+      continue;
+    }
+
     const commitsPerLang = commits.filter(
       (commit) => commit.scope === lang || COMMON_SCOPES.includes(commit.scope),
     );
 
-    const currentVersion = versions[lang].current;
     let nbGitDiff = await getNbGitDiff({
       branch: await getLastReleasedTag(),
       head: null,
@@ -233,7 +252,7 @@ export async function decideReleaseStrategy({
       nbGitDiff = 1;
     }
 
-    if (nbGitDiff === 0 || commitsPerLang.length === 0) {
+    if (!major && (nbGitDiff === 0 || commitsPerLang.length === 0)) {
       versionsToPublish[lang] = {
         ...version,
         noCommit: true,
@@ -253,47 +272,33 @@ export async function decideReleaseStrategy({
       continue;
     }
 
-    // snapshots should not be bumped as prerelease
-    if (semver.prerelease(currentVersion) && !currentVersion.endsWith('-SNAPSHOT')) {
-      // if version is like 0.1.2-beta.1, it increases to 0.1.2-beta.2, even if there's a breaking change.
-      versionsToPublish[lang] = {
-        ...version,
-        releaseType: 'prerelease',
-        next: getNextVersion(currentVersion, 'prerelease'),
-      };
-
-      continue;
-    }
-
-    if (commitsPerLang.some((commit) => commit.message.includes('BREAKING CHANGE'))) {
-      versionsToPublish[lang] = {
-        ...version,
-        releaseType: 'major',
-        next: getNextVersion(currentVersion, 'major'),
-      };
-
-      continue;
-    }
-
+    let releaseType: semver.ReleaseType = 'patch';
+    let skipRelease = false;
     const commitTypes = new Set(commitsPerLang.map(({ type }) => type));
-    if (commitTypes.has('feat')) {
-      versionsToPublish[lang] = {
-        ...version,
-        releaseType: 'minor',
-        next: getNextVersion(currentVersion, 'minor'),
-      };
 
-      continue;
+    switch (true) {
+      case major || commitsPerLang.some((commit) => commit.message.includes('BREAKING CHANGE')):
+        releaseType = 'major';
+        break;
+      case semver.prerelease(currentVersion) && !currentVersion.endsWith('-SNAPSHOT'):
+        releaseType = 'prerelease';
+        break;
+      case commitTypes.has('feat'):
+        releaseType = 'minor';
+        break;
+      case !commitTypes.has('fix'):
+        skipRelease = true;
+        break;
+      default:
+        releaseType = 'patch';
     }
 
     versionsToPublish[lang] = {
       ...version,
-      releaseType: 'patch',
-      ...(commitTypes.has('fix') ? undefined : { skipRelease: true }),
-      next: getNextVersion(currentVersion, 'patch'),
+      releaseType,
+      skipRelease,
+      next: getNextVersion(currentVersion, releaseType),
     };
-
-    continue;
   }
 
   return versionsToPublish;
@@ -475,7 +480,13 @@ async function updateLTS(versions: Versions, withGraphs?: boolean): Promise<void
   );
 }
 
-async function createReleasePR(): Promise<void> {
+export async function createReleasePR({
+  languages,
+  major,
+}: {
+  languages: Language[];
+  major?: boolean;
+}): Promise<void> {
   await prepareGitEnvironment();
 
   console.log('Searching for commits since last release...');
@@ -484,11 +495,13 @@ async function createReleasePR(): Promise<void> {
   const versions = await decideReleaseStrategy({
     versions: readVersions(),
     commits: validCommits,
+    languages,
+    major,
   });
 
   const versionChanges = getVersionChangesText(versions);
 
-  console.log('Creating changelogs for all languages...');
+  console.log(`Creating changelogs for languages: ${languages}...`);
   const changelog: Changelog = LANGUAGES.reduce((newChangelog, lang) => {
     if (versions[lang].noCommit) {
       return newChangelog;
@@ -570,9 +583,4 @@ async function createReleasePR(): Promise<void> {
 
   console.log(`Release PR #${data.number} is ready for review.`);
   console.log(`  > ${data.html_url}`);
-}
-
-if (import.meta.url.endsWith(process.argv[1])) {
-  setVerbose(false);
-  createReleasePR();
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2444

### Changes included:

updates the release script to be able to only release a subset of clients, and also to promote that subset (or every) to the next major version

this will allow us to release the GA without introducing a breaking change commit, and also allows us to prevent bypassing `dart` which is already stable.

also moves the release script to the CLI script, makes more sense and allows leveraging the current logic