### PR TITLE
docs: fix typo in docs contribution guide

### DIFF
--- a/specs/ingestion/common/schemas/common.yml
+++ b/specs/ingestion/common/schemas/common.yml
@@ -1,29 +1,29 @@
 createdAt:
   type: string
-  description: Date of creation in RFC3339 format.
+  description: Date of creation in RFC 3339 format.
 
 updatedAt:
   type: string
-  description: Date of last update in RFC3339 format.
+  description: Date of last update in RFC 3339 format.
 
 startedAt:
   type: string
-  description: Date of start in RFC3339 format.
+  description: Date of start in RFC 3339 format.
 
 finishedAt:
   type: string
-  description: Date of finish in RFC3339 format.
+  description: Date of finish in RFC 3339 format.
 
 publishedAt:
   type: string
-  description: Date of publish RFC3339 format.
+  description: Date of publish RFC 3339 format.
 
 DeleteResponse:
   type: object
   properties:
     deletedAt:
       type: string
-      description: Date of deletion in RFC3339 format.
+      description: Date of deletion in RFC 3339 format.
   required:
     - deletedAt
 
@@ -74,10 +74,10 @@ Window:
   properties:
     startDate:
       type: string
-      description: Date in RFC3339 format representing the oldest data in the time window.
+      description: Date in RFC 3339 format representing the oldest data in the time window.
     endDate:
       type: string
-      description: Date in RFC3339 format representing the newest data in the time window.
+      description: Date in RFC 3339 format representing the newest data in the time window.
   required:
     - startDate
     - endDate

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -188,7 +188,7 @@ TriggerType:
 # schedule trigger
 
 LastRun:
-  description: The last time the scheduled task ran in RFC3339 format.
+  description: The last time the scheduled task ran in RFC 3339 format.
   type: string
 
 Cron:
@@ -227,7 +227,7 @@ ScheduleTrigger:
     lastRun:
       $ref: '#/LastRun'
     nextRun:
-      description: The next scheduled run of the task in RFC3339 format.
+      description: The next scheduled run of the task in RFC 3339 format.
       type: string
   required:
     - type
@@ -368,10 +368,10 @@ OnDemandDateUtilsInput:
   description: Input for a manually-triggered task whose source is of type `bigquery` and for which extracted data spans a given time range.
   properties:
     startDate:
-      description: Earliest date in RFC3339 format of the extracted data from Big Query.
+      description: Earliest date in RFC 3339 format of the extracted data from Big Query.
       type: string
     endDate:
-      description: Latest date in RFC3339 format of the extracted data from Big Query.
+      description: Latest date in RFC 3339 format of the extracted data from Big Query.
       type: string
     mapping:
       $ref: '#/MappingInput'

--- a/specs/ingestion/paths/runs/events/events.yml
+++ b/specs/ingestion/paths/runs/events/events.yml
@@ -18,12 +18,12 @@ get:
     - $ref: '../../../common/parameters.yml#/order'
     - name: startDate
       in: query
-      description: Date and time in RFC3339 format for the earliest events to retrieve. By default, the current time minus three hours is used.
+      description: Date and time in RFC 3339 format for the earliest events to retrieve. By default, the current time minus three hours is used.
       schema:
         type: string
     - name: endDate
       in: query
-      description: Date and time in RFC3339 format for the latest events to retrieve. By default, the current time is used.
+      description: Date and time in RFC 3339 format for the latest events to retrieve. By default, the current time is used.
       schema:
         type: string
   responses:

--- a/specs/ingestion/paths/runs/runs.yml
+++ b/specs/ingestion/paths/runs/runs.yml
@@ -17,12 +17,12 @@ get:
     - $ref: '../../common/parameters.yml#/order'
     - name: startDate
       in: query
-      description: Date in RFC3339 format for the earliest run to retrieve. By default, the current day minus seven days is used.
+      description: Date in RFC 3339 format for the earliest run to retrieve. By default, the current day minus seven days is used.
       schema:
         type: string
     - name: endDate
       in: query
-      description: Date in RFC3339 format for the latest run to retrieve. By default, the current day is used.
+      description: Date in RFC 3339 format for the latest run to retrieve. By default, the current day is used.
       schema:
         type: string
   responses:

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -19,7 +19,7 @@ see [Add a new API client](./add-new-api-client.md).
 ## Prefer plain text
 
 The `description` properties of OpenAPI objects support [CommonMark](https://commonmark.org/),
-the specs are used in contexts where Markdown isn't supported.
+but the specs are used in contexts where Markdown isn't supported.
 
 To make using the specs in these contexts easier, follow these guidelines:
 
@@ -249,7 +249,7 @@ createdAt:
 RFC 3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
 Since RFC 3339 is a _profile_ of ISO 8601,
 every RFC 3339 date also complies with ISO 8601,
-but not every ISO 8601 date complies with ISO 8601.
+but not every ISO 8601 date complies with RFC 3339.
 
 For example, `2024-04-06T00:00:00` conforms to both RFC 3339 and ISO 8601.
 But `20240406T000000` only conforms to ISO 8601, which allows omitting the `-` and `:` separators.

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -227,7 +227,7 @@ Instead, include the expected format in the description and provide examples.
 To help users distinguish between dates (strings) and timestamps (integers),
 use the following terms consistently:
 
-- Use **Date and time** for dates in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
+- Use **Date and time** for dates in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
 - Use **Timestamp** for timestamps in seconds or milliseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 #### Example: date and time
@@ -244,18 +244,18 @@ createdAt:
 ```
 
 <details>
-<summary>RFC 3339 vs ISO 8601</summary>
+<summary>RFC3339 vs ISO 8601</summary>
 
-RFC 3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
-Since RFC 3339 is a _profile_ of ISO 8601,
-every RFC 3339 date also complies with ISO 8601,
-but not every ISO 8601 date complies with RFC 3339.
+RFC3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
+Since RFC3339 is a _profile_ of ISO 8601,
+every RFC3339 date also complies with ISO 8601,
+but not every ISO 8601 date complies with RFC3339.
 
-For example, `2024-04-06T00:00:00` conforms to both RFC 3339 and ISO 8601.
+For example, `2024-04-06T00:00:00` conforms to both RFC3339 and ISO 8601.
 But `20240406T000000` only conforms to ISO 8601, which allows omitting the `-` and `:` separators.
 
 **Exception:** ISO 8601 requires date and time to be separated by `T`,
-whereas RFC 3339 permits a space character for the sake of readability.
+whereas RFC3339 permits a space character for the sake of readability.
 It's best to avoid this ambiguity.
 
 </details>

--- a/website/docs/contributing/docs.md
+++ b/website/docs/contributing/docs.md
@@ -227,35 +227,35 @@ Instead, include the expected format in the description and provide examples.
 To help users distinguish between dates (strings) and timestamps (integers),
 use the following terms consistently:
 
-- Use **Date and time** for dates in [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
+- Use **Date and time** for dates in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) (ISO 8601) format.
 - Use **Timestamp** for timestamps in seconds or milliseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 #### Example: date and time
 
-Use _Date and time ..., in RFC3339 format_.
+Use _Date and time ..., in RFC 3339 format_.
 Don't link to the RFC, and don't use ISO 8601.
 Don't use _timestamp_ for dates and times.
 
 ```
 createdAt:
   type: string
-  description: Date and time when the object was created, in RFC3339 format.
+  description: Date and time when the object was created, in RFC 3339 format.
   example: 2024-04-06T08:08:08Z
 ```
 
 <details>
-<summary>RFC3339 vs ISO 8601</summary>
+<summary>RFC 3339 vs ISO 8601</summary>
 
-RFC3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
-Since RFC3339 is a _profile_ of ISO 8601,
-every RFC3339 date also complies with ISO 8601,
-but not every ISO 8601 date complies with RFC3339.
+RFC 3339 is slightly less ambiguous than ISO 8601 and leads to more readable dates.
+Since RFC 3339 is a _profile_ of ISO 8601,
+every RFC 3339 date also complies with ISO 8601,
+but not every ISO 8601 date complies with RFC 3339.
 
-For example, `2024-04-06T00:00:00` conforms to both RFC3339 and ISO 8601.
+For example, `2024-04-06T00:00:00` conforms to both RFC 3339 and ISO 8601.
 But `20240406T000000` only conforms to ISO 8601, which allows omitting the `-` and `:` separators.
 
 **Exception:** ISO 8601 requires date and time to be separated by `T`,
-whereas RFC3339 permits a space character for the sake of readability.
+whereas RFC 3339 permits a space character for the sake of readability.
 It's best to avoid this ambiguity.
 
 </details>


### PR DESCRIPTION
## 🧭 What and Why

Fixes a typo in the docs contribution guide.