### PR TITLE
chore(scripts): remove double usage client

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Validate gradle wrapper
       if: inputs.type != 'minimal'
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/actions/wrapper-validation@v3
 
     - name: Setup gradle
       if: inputs.type != 'minimal'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -325,7 +325,6 @@ jobs:
     runs-on: macos-latest
     needs:
       - setup
-      - client_gen
     if: |
       always() &&
       startsWith(github.head_ref, 'chore/prepare-release-') &&

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -325,6 +325,8 @@ jobs:
     runs-on: macos-latest
     needs:
       - setup
+      - specs
+      - scripts
     if: |
       always() &&
       startsWith(github.head_ref, 'chore/prepare-release-') &&

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -73,11 +73,7 @@ export const GENERATORS = Object.entries(clientsConfig).reduce(
 
 export const LANGUAGES = [...new Set(Object.values(GENERATORS).map((gen) => gen.language))];
 
-export const CLIENTS = [
-  ...new Set(Object.values(GENERATORS).map((gen) => gen.client)),
-  'usage',
-  'crawler',
-];
+export const CLIENTS = [...new Set(Object.values(GENERATORS).map((gen) => gen.client)), 'crawler'];
 
 export async function run(
   command: string,


### PR DESCRIPTION
## 🧭 What and Why

The `usage` client was generated twice for the clients, CTS, snippets, specs, wasting time on the CI and making the bundled spec contain duplicate.

Also run the macos swift CI in parallel now.