### PR TITLE
feat(scripts): push to docs on release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -431,6 +431,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
+      - name: Push specs to algolia documentation
+        if: github.ref == 'refs/heads/main'
+        run: yarn workspace scripts pushToAlgoliaDoc
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+
       - name: Set output
         id: setoutput
         run: echo "success=true" >> "$GITHUB_OUTPUT"

--- a/scripts/buildSpecs.ts
+++ b/scripts/buildSpecs.ts
@@ -149,6 +149,10 @@ async function transformBundle({
       toAbsolutePath(`website/src/generated/${clientName}-snippets.js`),
       `export const snippets = ${transformCodeSamplesToGuideMethods(JSON.parse(JSON.stringify(snippetSamples)))}`,
     );
+    await fsp.writeFile(
+      toAbsolutePath(`website/src/generated/${clientName}-snippets.json`),
+      transformCodeSamplesToGuideMethods(JSON.parse(JSON.stringify(snippetSamples))),
+    );
   }
 
   for (const [pathKey, pathMethods] of Object.entries(bundledSpec.paths)) {

--- a/scripts/buildSpecs.ts
+++ b/scripts/buildSpecs.ts
@@ -145,13 +145,15 @@ async function transformBundle({
     : ({} as SnippetSamples);
 
   if (docs) {
+    const snippets = transformCodeSamplesToGuideMethods(JSON.parse(JSON.stringify(snippetSamples)));
+    // the JS file will be removed once algolia/doc leverages the JSON one
     await fsp.writeFile(
       toAbsolutePath(`website/src/generated/${clientName}-snippets.js`),
-      `export const snippets = ${transformCodeSamplesToGuideMethods(JSON.parse(JSON.stringify(snippetSamples)))}`,
+      `export const snippets = ${snippets}`,
     );
     await fsp.writeFile(
       toAbsolutePath(`website/src/generated/${clientName}-snippets.json`),
-      transformCodeSamplesToGuideMethods(JSON.parse(JSON.stringify(snippetSamples))),
+      snippets,
     );
   }
 

--- a/scripts/ci/codegen/pushToAlgoliaDoc.ts
+++ b/scripts/ci/codegen/pushToAlgoliaDoc.ts
@@ -28,7 +28,7 @@ async function pushToAlgoliaDoc(): Promise<void> {
     .map((coAuthor) => coAuthor.trim())
     .filter(Boolean);
 
-  if (!lastCommitMessage.startsWith(commitStartRelease)) {
+  if (!process.env.DRY_RUN && !lastCommitMessage.startsWith(commitStartRelease)) {
     return;
   }
 
@@ -48,7 +48,7 @@ async function pushToAlgoliaDoc(): Promise<void> {
   await emptyDirExceptForDotGit(dest);
   await run(`cp ${toAbsolutePath('specs/bundled/*.doc.yml')} ${dest}`);
   await run(`cp ${toAbsolutePath('config/release.config.json')} ${dest}`);
-  await run(`cp ${toAbsolutePath('website/src/generated/*.js')} ${dest}`);
+  await run(`cp ${toAbsolutePath('website/src/generated/*.json')} ${dest}`);
   await run(`cp ${toAbsolutePath('website/static/img/*-sla.png')} ${dest}`);
 
   if ((await getNbGitDiff({ head: null, cwd: tempGitDir })) === 0) {

--- a/scripts/ci/codegen/pushToAlgoliaDoc.ts
+++ b/scripts/ci/codegen/pushToAlgoliaDoc.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-console */
+import fsp from 'fs/promises';
+import { resolve } from 'path';
+
+import {
+  emptyDirExceptForDotGit,
+  gitCommit,
+  run,
+  toAbsolutePath,
+  ensureGitHubToken,
+  OWNER,
+  configureGitHubAuthor,
+  getOctokit,
+  setVerbose,
+} from '../../common.js';
+import { getNbGitDiff } from '../utils.js';
+
+import { commitStartRelease } from './text.js';
+
+async function pushToAlgoliaDoc(): Promise<void> {
+  const githubToken = ensureGitHubToken();
+
+  const repository = 'doc';
+  const lastCommitMessage = await run('git log -1 --format="%s"');
+  const author = (await run('git log -1 --format="Co-authored-by: %an <%ae>"')).trim();
+  const coAuthors = (await run('git log -1 --format="%(trailers:key=Co-authored-by)"'))
+    .split('\n')
+    .map((coAuthor) => coAuthor.trim())
+    .filter(Boolean);
+
+  if (!lastCommitMessage.startsWith(commitStartRelease)) {
+    return;
+  }
+
+  console.log(`Pushing to ${OWNER}/${repository}`);
+
+  const targetBranch = 'feat/automated-update-from-api-clients-automation-repository';
+  const githubURL = `https://${githubToken}:${githubToken}@github.com/${OWNER}/${repository}`;
+  const tempGitDir = resolve(
+    process.env.RUNNER_TEMP! || toAbsolutePath('foo/local/test'),
+    repository,
+  );
+  await fsp.rm(tempGitDir, { force: true, recursive: true });
+  await run(`git clone --depth 1 ${githubURL} ${tempGitDir}`);
+  await run(`git checkout -B ${targetBranch}`, { cwd: tempGitDir });
+
+  const dest = toAbsolutePath(`${tempGitDir}/app_data/api/specs`);
+  await emptyDirExceptForDotGit(dest);
+  await run(`cp ${toAbsolutePath('specs/bundled/*.doc.yml')} ${dest}`);
+  await run(`cp ${toAbsolutePath('config/release.config.json')} ${dest}`);
+  await run(`cp ${toAbsolutePath('website/src/generated/*.js')} ${dest}`);
+  await run(`cp ${toAbsolutePath('website/static/img/*-sla.png')} ${dest}`);
+
+  if ((await getNbGitDiff({ head: null, cwd: tempGitDir })) === 0) {
+    console.log(`❎ Skipping push docs because there is no change.`);
+
+    return;
+  }
+
+  await configureGitHubAuthor(tempGitDir);
+
+  const message = 'feat(clients): automatic update from api-clients-automation repository';
+  await run('git add .', { cwd: tempGitDir });
+  await gitCommit({
+    message,
+    coAuthors: [author, ...coAuthors],
+    cwd: tempGitDir,
+  });
+  await run(`git push -f -u origin ${targetBranch}`, { cwd: tempGitDir });
+
+  console.log(`Creating pull request on ${OWNER}/${repository}...`);
+  const octokit = getOctokit();
+  const { data } = await octokit.pulls.create({
+    owner: OWNER,
+    repo: repository,
+    title: message,
+    body: [
+      'This PR is automatically created by https://github.com/algolia/api-clients-automation',
+      'It contains the latest released OpenAPI specs, the release SLA dates and PNGs, and the generated code snippets.',
+    ].join('\n\n'),
+    base: 'master',
+    head: targetBranch,
+  });
+
+  console.log(`Pull request created on ${OWNER}/${repository}`);
+  console.log(`  > ${data.url}`);
+}
+
+if (import.meta.url.endsWith(process.argv[1])) {
+  setVerbose(false);
+  pushToAlgoliaDoc();
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,6 +12,7 @@
     "lint:deadcode": "knip",
     "pre-commit": "node ./ci/husky/pre-commit.mjs",
     "pushGeneratedCode": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/pushGeneratedCode.js",
+    "pushToAlgoliaDoc": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/pushToAlgoliaDoc.js",
     "setRunVariables": "NODE_NO_WARNINGS=1 node dist/scripts/ci/githubActions/setRunVariables.js",
     "spreadGeneration": "NODE_NO_WARNINGS=1 node dist/scripts/ci/codegen/spreadGeneration.js",
     "start": "NODE_NO_WARNINGS=1 node dist/scripts/cli/index.js",

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 specs
 
 src/generated/*.js
+src/generated/*.json


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2458

### Changes included:

bring back our beloved spread script, which publishes to the official documentation:
- the documentation specs
- the generated code snippets
- the SLA chart and PNGs

we only spread after a successful release, see example PR here: https://github.com/algolia/doc/pull/9098