### PR TITLE
chore: skip website build/deploys on non main target

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -393,11 +393,11 @@ jobs:
         run: yarn cli build specs ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX).toRun }} --docs
 
       - name: Build website
-        if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'refs/head/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
         run: yarn website:build
 
       - name: Deploy documentation
-        if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'refs/head/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: 'website/build'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -393,9 +393,11 @@ jobs:
         run: yarn cli build specs ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX).toRun }} --docs
 
       - name: Build website
+        if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'refs/head/main' }}
         run: yarn website:build
 
       - name: Deploy documentation
+        if: ${{ github.ref == 'refs/heads/main' || github.head_ref == 'refs/head/main' }}
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: 'website/build'


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

we build the doc for every kind of PRs which consumes a lot of resources for nothing, we can at least limit it to the main branch and PRs that targets it
