### PR TITLE
fix(scripts): js ci when algoliasearch is missing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,7 +190,7 @@ jobs:
         run: ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).buildCommand }}
 
       - name: Run common and requester tests
-        run: cd clients/algoliasearch-client-javascript && yarn test ${{ !contains(fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun, "algoliasearch") && '--ignore algoliasearch' }}
+        run: cd clients/algoliasearch-client-javascript && yarn test ${{ !contains(fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun, 'algoliasearch') && '--ignore algoliasearch' || '' }}
 
       - name: Test JavaScript bundle size
         if: ${{ startsWith(env.head_ref, 'chore/prepare-release-') }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,7 +190,7 @@ jobs:
         run: ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).buildCommand }}
 
       - name: Run common and requester tests
-        run: cd clients/algoliasearch-client-javascript && yarn test
+        run: cd clients/algoliasearch-client-javascript && yarn test ${{ !contains(fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun, "algoliasearch") && '--ignore algoliasearch' }}
 
       - name: Test JavaScript bundle size
         if: ${{ startsWith(env.head_ref, 'chore/prepare-release-') }}

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -11,7 +11,7 @@
     "clean": "lerna run clean --include-dependencies",
     "release:bump": "lerna version ${0:-patch} --no-changelog --no-git-tag-version --no-push --exact --force-publish --yes",
     "release:publish": "tsc --project tsconfig.script.json && node dist/scripts/publish.js",
-    "test": "lerna run test",
+    "test": "lerna run test $*",
     "test:size": "bundlesize"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

see https://github.com/algolia/api-clients-automation/pull/3212, js fails to run tests for algoliasearch because it's not supposed to run, we can ignore it when it's the case