### PR TITLE
fix(javascript): deprecated publish options

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -2,7 +2,10 @@
   "name": "@algolia/client-common",
   "version": "5.0.0-beta.5",
   "description": "Common package for the Algolia JavaScript API client.",
-  "repository": "algolia/algoliasearch-client-javascript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
+  },
   "license": "MIT",
   "author": "Algolia",
   "type": "module",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -2,7 +2,10 @@
   "name": "@algolia/requester-browser-xhr",
   "version": "5.0.0-beta.5",
   "description": "Promise-based request library for browser using xhr.",
-  "repository": "algolia/algoliasearch-client-javascript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
+  },
   "license": "MIT",
   "author": "Algolia",
   "type": "module",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -2,7 +2,10 @@
   "name": "@algolia/requester-fetch",
   "version": "5.0.0-beta.5",
   "description": "Promise-based request library using Fetch.",
-  "repository": "algolia/algoliasearch-client-javascript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
+  },
   "license": "MIT",
   "author": "Algolia",
   "type": "module",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -2,7 +2,10 @@
   "name": "@algolia/requester-node-http",
   "version": "5.0.0-beta.5",
   "description": "Promise-based request library for node using the native http module.",
-  "repository": "algolia/algoliasearch-client-javascript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
+  },
   "license": "MIT",
   "author": "Algolia",
   "type": "module",

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -1,6 +1,9 @@
 {
   "version": "{{packageVersion}}",
-  "repository": "algolia/algoliasearch-client-javascript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
+  },
   "type":"module",
   "license": "MIT",
   "author": "Algolia",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://github.com/algolia/algoliasearch-client-javascript/actions/runs/9610985686/job/26508628098

### Changes included:

js release is using deprecated options