### PR TITLE
feat(javascript): legacy `getRecommendations` signature

### DIFF
--- a/specs/recommend/paths/getRecommendations.yml
+++ b/specs/recommend/paths/getRecommendations.yml
@@ -6,6 +6,7 @@ post:
   x-cacheable: true
   x-acl:
     - search
+  x-legacy-signature-recommend: true
   summary: Retrieve recommendations
   description: |
     Retrieves recommendations from selected AI models.

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -85,6 +85,10 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
         {{> client/api/operation/legacySearchCompatible/implementation}}
       {{/vendorExtensions.x-legacy-signature}}
 
+      {{#vendorExtensions.x-legacy-signature-recommend}}
+        {{> client/api/operation/legacyGetRecommendationsCompatible/implementation}}
+      {{/vendorExtensions.x-legacy-signature-recommend}}
+
       {{#allParams}}
       {{#required}}
       if ({{#isBoolean}}{{paramName}} === null || {{paramName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}{{/isBoolean}}) {

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -43,6 +43,9 @@ import type {
       {{#x-legacy-signature}}
         LegacySearchMethodProps,
       {{/x-legacy-signature}}
+      {{#x-legacy-signature-recommend}}
+        LegacyGetRecommendationsParams,
+      {{/x-legacy-signature-recommend}}
     {{/vendorExtensions}}
   {{/operation}}
 } from '../model/clientMethodProps';

--- a/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/implementation.mustache
+++ b/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/implementation.mustache
@@ -1,0 +1,8 @@
+if (getRecommendationsParams && Array.isArray(getRecommendationsParams)) {
+  const newSignatureRequest: GetRecommendationsParams = {
+    requests: getRecommendationsParams,
+  };
+
+  // eslint-disable-next-line no-param-reassign
+  getRecommendationsParams = newSignatureRequest;
+}

--- a/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/imports.mustache
+++ b/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/imports.mustache
@@ -1,0 +1,1 @@
+import type { RecommendationsRequest } from './recommendationsRequest';

--- a/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/model.mustache
+++ b/templates/javascript/clients/client/api/operation/legacyGetRecommendationsCompatible/model.mustache
@@ -1,0 +1,6 @@
+/**
+ * Recommend method signature compatible with the `algoliasearch` v4 package. When using this signature, extra computation will be required to make it match the new signature.
+ *
+ * @deprecated This signature will be removed from the next major version, we recommend using the `GetRecommendationsParams` type for performances and future proof reasons.
+ */
+export type LegacyGetRecommendationsParams = RecommendationsRequest[];

--- a/templates/javascript/clients/client/api/operation/parameters.mustache
+++ b/templates/javascript/clients/client/api/operation/parameters.mustache
@@ -8,7 +8,7 @@
   {{/x-create-wrapping-object}}
   {{#x-is-single-body-param}}
     {{#bodyParams}}
-      {{paramName}}: {{{dataType}}} {{#x-legacy-signature}} | LegacySearchMethodProps{{/x-legacy-signature}},
+      {{paramName}}: {{{dataType}}} {{#x-legacy-signature}} | LegacySearchMethodProps{{/x-legacy-signature}} {{#x-legacy-signature-recommend}} | LegacyGetRecommendationsParams{{/x-legacy-signature-recommend}},
     {{/bodyParams}}
   {{/x-is-single-body-param}}
 {{/vendorExtensions}}

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -7,7 +7,10 @@ import { {{classname}} } from '{{filename}}';
 {{/imports}}
 
 {{! Imports for the legacy search method signature }}
-{{#operations}}{{#operation}}{{#vendorExtensions.x-legacy-signature}}{{> client/api/operation/legacySearchCompatible/imports}}{{/vendorExtensions.x-legacy-signature}}{{/operation}}{{/operations}}
+{{#operations}}
+  {{#operation}}{{#vendorExtensions.x-legacy-signature}}{{> client/api/operation/legacySearchCompatible/imports}}{{/vendorExtensions.x-legacy-signature}}{{/operation}}
+  {{#operation}}{{#vendorExtensions.x-legacy-signature-recommend}}{{> client/api/operation/legacyGetRecommendationsCompatible/imports}}{{/vendorExtensions.x-legacy-signature-recommend}}{{/operation}}
+{{/operations}}
 
 {{! Imports for the helpers method of the search client }}
 {{#isSearchClient}}
@@ -36,6 +39,7 @@ export type {{#lambda.titlecase}}{{nickname}}{{/lambda.titlecase}}Props = {
 {{/x-create-wrapping-object}}
 
 {{#x-legacy-signature}}{{> client/api/operation/legacySearchCompatible/model}}{{/x-legacy-signature}}
+{{#x-legacy-signature-recommend}}{{> client/api/operation/legacyGetRecommendationsCompatible/model}}{{/x-legacy-signature-recommend}}
 
 {{/vendorExtensions}}
 


### PR DESCRIPTION
I tested the client with InstantSearch a little bit and some things don't work : 

- `algoliasearch/lite` does not have a default export
- `getRecommendations` does not default `threshold` to `0` like it does in v4, this makes our current implem fail
- Our client hydration logic in InstantSearch doesn't work as the transporter has `baseHeaders` and `baseQueryParamaters` rather than `headers` and `queryParameters`