### PR TITLE
fix(dart): add LICENSE to client_core

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -100,6 +100,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
 
     supportingFiles.add(new SupportingFile("version.mustache", srcFolder, "version.dart"));
     supportingFiles.add(new SupportingFile("LICENSE", "", "LICENSE"));
+    supportingFiles.add(new SupportingFile("LICENSE", "../client_core/", "LICENSE"));
 
     // Search config
     additionalProperties.put("isSearchClient", client.equals("search"));


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

dart release failed because I've forgot to generate the LICENSE for the core client too, which is the manually written part https://github.com/algolia/algoliasearch-client-dart/actions/runs/9685244779/job/26724943976