### PR TITLE
fix(scripts): skip failure report for ruby

### DIFF
--- a/scripts/ci/codegen/waitForAllReleases.ts
+++ b/scripts/ci/codegen/waitForAllReleases.ts
@@ -94,7 +94,9 @@ async function waitForAllReleases(languagesReleased: Language[]): Promise<void> 
         console.log(
           `${success ? '✅' : '❌'} ${ciRun.language} CI finished with conclusion: ${ciRun.run.conclusion}`,
         );
-        if (!success) {
+
+        // Ruby action is flaky for now but the release succeed
+        if (!success && ciRun.language !== 'ruby') {
           failures.push(ciRun.language);
         }
         // stop fetching this run.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2494

### Changes included:

le ruby release succeed but the ruby release action then lookup on the registry to find the version and somehow fails (but it worked!)

since the GA release approach and we need wait release to succeed in order to spread new versions to the docs, we can skip ruby for now