### PR TITLE
fix(ruby): add the base64 dependency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -520,7 +520,7 @@ jobs:
     needs:
       - codegen
       - check_green
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       pull-requests: write
     steps:

--- a/clients/algoliasearch-client-ruby/algolia.gemspec
+++ b/clients/algoliasearch-client-ruby/algolia.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '>= 1.0.1', '< 3.0'
   s.add_dependency 'faraday-net_http_persistent', ['>= 0.15', '< 3']
+  s.add_dependency 'base64', '>= 0.2.0', '< 1'
 
   s.add_dependency 'net-http-persistent'
 

--- a/playground/ruby/Gemfile.lock
+++ b/playground/ruby/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ../../clients/algoliasearch-client-ruby
   specs:
-    algolia (3.0.0.beta.4)
+    algolia (3.0.0.beta.8)
+      base64 (>= 0.2.0, < 1)
       faraday (>= 1.0.1, < 3.0)
       faraday-net_http_persistent (>= 0.15, < 3)
       net-http-persistent
@@ -9,6 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
     connection_pool (2.4.1)
     dotenv (3.1.2)
     faraday (2.9.0)


### PR DESCRIPTION
## 🧭 What and Why

Add the `base64` library because it won't be included by default in ruby 3.4