### PR TITLE
chore: keep guides for docs close to snippets

### DIFF
--- a/scripts/ci/codegen/pushToAlgoliaDoc.ts
+++ b/scripts/ci/codegen/pushToAlgoliaDoc.ts
@@ -48,7 +48,7 @@ async function pushToAlgoliaDoc(): Promise<void> {
   await run(`cp ${toAbsolutePath('specs/bundled/README.md')} ${pathToSpecs}`);
   await run(`cp ${toAbsolutePath('specs/bundled/*.doc.yml')} ${pathToSpecs}`);
   await run(`cp ${toAbsolutePath('config/release.config.json')} ${pathToSpecs}`);
-  await run(`cp ${toAbsolutePath('website/src/generated/*.json')} ${pathToSpecs}`);
+  await run(`cp ${toAbsolutePath('snippets/guides/*.json')} ${pathToSpecs}`);
 
   if ((await getNbGitDiff({ head: null, cwd: tempGitDir })) === 0) {
     console.log(`❎ Skipping push docs because there is no change.`);

--- a/scripts/specs/format.ts
+++ b/scripts/specs/format.ts
@@ -75,10 +75,7 @@ export async function transformBundle({
       toAbsolutePath(`website/src/generated/${clientName}-snippets.js`),
       `export const snippets = ${snippets}`,
     );
-    await fsp.writeFile(
-      toAbsolutePath(`website/src/generated/${clientName}-snippets.json`),
-      snippets,
-    );
+    await fsp.writeFile(toAbsolutePath(`snippets/guides/${clientName}-snippets.json`), snippets);
   }
 
   for (const [pathKey, pathMethods] of Object.entries(bundledSpec.paths)) {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

since the split of the CI, the generation of the snippets is done outside of the release step, but the website generated folder isn't pushed to the repo, see https://github.com/algolia/api-clients-automation/actions/runs/9908119385/job/27373697603

since this folder will disappear when the algolia doc leverages our snippets, we can already move our snippet guides in a dedicated folder that we push and keep code in, so the release step can also leverage it