### PR TITLE
chore(scripts): improve generation commit message

### DIFF
--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -32,13 +32,12 @@ describe('spread generation', () => {
     `);
     });
 
-    it('provides a link to the automation repo for commit with hash', () => {
-      const commitMessage = `${text.commitStartMessage} ed33e02f3e45fd72b4f420a56e4be7c6929fca9f. [skip ci]`;
-      expect(cleanUpCommitMessage(commitMessage, '')).toMatchInlineSnapshot(`
-      "chore: generated code for commit ed33e02f. [skip ci]
-
-      https://github.com/algolia/api-clients-automation/commit/ed33e02f3e45fd72b4f420a56e4be7c6929fca9f"
-    `);
+    it('generated commits have a link to the origin pull request', () => {
+      expect(
+        cleanUpCommitMessage('feat(ci): make ci push generated code (#244) (generated).', '')
+      ).toEqual(
+        `feat(ci): make ci push generated code\n\nhttps://github.com/algolia/api-clients-automation/pull/244`
+      );
     });
   });
 });

--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -58,7 +58,7 @@ export async function pushGeneratedCode(): Promise<void> {
 
   const skipCi = isMainBranch ? '[skip ci]' : '';
   let message = await run(
-    `git show -s ${baseBranch} --format="${text.commitStartMessage} %H. ${skipCi}"`,
+    `git show -s ${baseBranch} --format="%s ${text.commitEndMessage} ${skipCi}"`,
   );
   const authors = await run(
     `git show -s ${baseBranch} --format="

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -18,29 +18,14 @@ import { getNewReleasedTag } from '../../release/common.js';
 import type { Language } from '../../types.js';
 import { cloneRepository, getNbGitDiff } from '../utils.js';
 
-import text, { commitStartRelease } from './text.js';
+import { commitStartRelease } from './text.js';
 
 export function cleanUpCommitMessage(commitMessage: string, version: string): string {
   if (commitMessage.startsWith(commitStartRelease)) {
     return `chore: release ${version}`;
   }
 
-  const isCodeGenCommit = commitMessage.startsWith(text.commitStartMessage);
-
-  if (isCodeGenCommit) {
-    const hash = commitMessage.split(text.commitStartMessage)[1].replace('. [skip ci]', '').trim();
-
-    if (!hash) {
-      return commitMessage;
-    }
-
-    return [
-      `${text.commitStartMessage} ${hash.substring(0, 8)}. [skip ci]`,
-      `${REPO_URL}/commit/${hash}`,
-    ].join('\n\n');
-  }
-
-  const prCommit = commitMessage.match(/(.+)\s\(#(\d+)\)$/);
+  const prCommit = commitMessage.match(/(.+)\s\(#(\d+)\)/);
 
   if (!prCommit) {
     return commitMessage;

--- a/scripts/ci/codegen/text.ts
+++ b/scripts/ci/codegen/text.ts
@@ -3,8 +3,14 @@ import { TODAY } from '../../common.js';
 export const commitStartPrepareRelease = 'chore: prepare release';
 export const commitStartRelease = 'chore: release';
 
+const commitEndMessage = '(generated).';
+
 export default {
-  commitStartMessage: 'chore: generated code for commit',
+  commitEndMessage,
   commitPrepareReleaseMessage: `${commitStartPrepareRelease} ${TODAY}`,
   commitReleaseMessage: `${commitStartRelease} ${TODAY}`,
 };
+
+export function isGeneratedCommit(text: string): boolean {
+  return text.endsWith(commitEndMessage);
+}

--- a/scripts/release/__tests__/createReleasePR.test.ts
+++ b/scripts/release/__tests__/createReleasePR.test.ts
@@ -132,21 +132,8 @@ describe('createReleasePR', () => {
       expect(
         await parseCommit(
           buildTestCommit({
-            type: 'chore',
-            message: 'generated code for commit',
-          })
-        )
-      ).toEqual({
-        error: 'generation-commit',
-      });
-    });
-
-    it('returns error when it is a generated commit, even with other casing', async () => {
-      expect(
-        await parseCommit(
-          buildTestCommit({
-            type: 'chore',
-            message: 'GENERATED CODE FOR COMMIT',
+            type: 'feat(specs)',
+            message: 'foo bar baz (generated).',
           })
         )
       ).toEqual({

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import dotenv from 'dotenv';
 import semver from 'semver';
 
-import generationCommitText from '../ci/codegen/text.js';
+import generationCommitText, { isGeneratedCommit } from '../ci/codegen/text.js';
 import { getNbGitDiff } from '../ci/utils.js';
 import {
   LANGUAGES,
@@ -133,7 +133,7 @@ export async function parseCommit(commit: string): Promise<Commit> {
   }
 
   // We skip generation commits as they do not appear in changelogs
-  if (message.toLocaleLowerCase().startsWith(generationCommitText.commitStartMessage)) {
+  if (isGeneratedCommit(message)) {
     return {
       error: 'generation-commit',
     };


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

While commit messages have little context here https://github.com/algolia/api-clients-automation/commits/main/, it's super ugly on client repositories https://github.com/algolia/algoliasearch-client-go/commits/next/

In this PR, we try to provide the exact same message as the original commit, plus a link to the repo's PR