### PR TITLE
fix(specs): built-in ops accept also int

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ParametersWithDataType.java
@@ -146,7 +146,7 @@ public class ParametersWithDataType {
       handleEnum(param, testOutput);
     } else if (spec.getIsModel() || isCodegenModel) {
       // recursive object
-      handleModel(paramName, param, testOutput, spec, baseType, parent, depth, isParentFreeFormObject);
+      handleModel(paramName, param, testOutput, spec, baseType, parent, depth, isParentFreeFormObject, isRequired != null && isRequired);
     } else if (baseType.equals("Object")) {
       // not var, no item, pure free form
       handleObject(paramName, param, testOutput, true, depth);
@@ -259,7 +259,8 @@ public class ParametersWithDataType {
     String baseType,
     String parent,
     int depth,
-    boolean isParentFreeFormObject
+    boolean isParentFreeFormObject,
+    boolean parentIsRequired
   ) throws CTSException {
     if (!spec.getHasVars()) {
       // In this case we might have a complex `allOf`, we will first check if it exists
@@ -326,6 +327,8 @@ public class ParametersWithDataType {
       oneOfModel.put("x-one-of-explicit-name", useExplicitName);
       oneOfModel.put("hasWrapper", isList || isString(current) || current.getIsNumber() || current.getIsBoolean());
       testOutput.put("oneOfModel", oneOfModel);
+      // use required from the parent since oneOf don't have that property
+      testOutput.put("required", parentIsRequired);
       return;
     }
 

--- a/specs/search/paths/objects/common/schemas.yml
+++ b/specs/search/paths/objects/common/schemas.yml
@@ -10,6 +10,13 @@ builtInOperationType:
     - IncrementSet
   description: How to change the attribute.
 
+builtInOperationValue:
+  oneOf:
+    - type: string
+      description: A string to append or remove for the `Add`, `Remove`, and `AddUnique` operations.
+    - type: integer
+      description: A number fo add, remove, or append, depending on the operation.
+
 attribute:
   type: string
   description: Value of the attribute to update.
@@ -22,8 +29,7 @@ builtInOperation:
     _operation:
       $ref: '#/builtInOperationType'
     value:
-      type: string
-      description: Value that corresponds to the operation, for example an `Increment` or `Decrement` step, or an `Add` or `Remove` value.
+      $ref: '#/builtInOperationValue'
   required:
     - _operation
     - value

--- a/specs/search/paths/objects/common/schemas.yml
+++ b/specs/search/paths/objects/common/schemas.yml
@@ -15,7 +15,7 @@ builtInOperationValue:
     - type: string
       description: A string to append or remove for the `Add`, `Remove`, and `AddUnique` operations.
     - type: integer
-      description: A number fo add, remove, or append, depending on the operation.
+      description: A number to add, remove, or append, depending on the operation.
 
 attribute:
   type: string

--- a/tests/CTS/requests/search/partialUpdateObject.json
+++ b/tests/CTS/requests/search/partialUpdateObject.json
@@ -1,6 +1,6 @@
 [
   {
-    "requestName": "Partial update with string value",
+    "testName": "Partial update with string value",
     "parameters": {
       "indexName": "theIndexName",
       "objectID": "uniqueID",
@@ -29,7 +29,7 @@
     }
   },
   {
-    "requestName": "Partial update with integer value",
+    "testName": "Partial update with integer value",
     "parameters": {
       "indexName": "theIndexName",
       "objectID": "uniqueID",

--- a/tests/CTS/requests/search/partialUpdateObject.json
+++ b/tests/CTS/requests/search/partialUpdateObject.json
@@ -1,5 +1,6 @@
 [
   {
+    "requestName": "Partial update with string value",
     "parameters": {
       "indexName": "theIndexName",
       "objectID": "uniqueID",
@@ -24,6 +25,29 @@
       },
       "queryParameters": {
         "createIfNotExists": "true"
+      }
+    }
+  },
+  {
+    "requestName": "Partial update with integer value",
+    "parameters": {
+      "indexName": "theIndexName",
+      "objectID": "uniqueID",
+      "attributesToUpdate": {
+        "attributeId": {
+          "_operation": "Increment",
+          "value": 2
+        }
+      }
+    },
+    "request": {
+      "path": "/1/indexes/theIndexName/uniqueID/partial",
+      "method": "POST",
+      "body": {
+        "attributeId": {
+          "_operation": "Increment",
+          "value": 2
+        }
       }
     }
   }


### PR DESCRIPTION
## 🧭 What and Why

Make `search.BuiltInOperation` accept also integers for values.
All built-in operations accept integers, only some also accept strings (`Add`, `Remove`, `AddUnique`). Currently, `value` only accepts strings, which makes partial updates with `Increment`, etc. fail.