### PR TITLE
fix(specs): body is not required in multiple batch request

### DIFF
--- a/specs/search/paths/objects/multipleBatch.yml
+++ b/specs/search/paths/objects/multipleBatch.yml
@@ -34,7 +34,6 @@ post:
                     $ref: '../../../common/parameters.yml#/indexName'
                 required:
                   - action
-                  - body
                   - indexName
           required:
             - requests


### PR DESCRIPTION
## 🧭 What and Why

For multipleBatch requests, the `body` property can be empty if the action is `delete` or `clear`, thus, it shouldn't be marked as required.

### Changes included:

- Remove `body` from the list of required properties for the multipleBatch operation.