### PR TITLE
fix(scripts): prevent errors on push to docs

### DIFF
--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -175,8 +175,8 @@ async function buildCustomGenerators(): Promise<void> {
   spinner.succeed();
 }
 
-export async function gitBranchExists(branchName: string): Promise<boolean> {
-  return Boolean(await run(`git ls-remote --heads origin ${branchName}`));
+export async function gitBranchExists(branchName: string, cwd?: string): Promise<boolean> {
+  return Boolean(await run(`git ls-remote --heads origin ${branchName}`, { cwd }));
 }
 
 export async function emptyDirExceptForDotGit(dir: string): Promise<void> {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

the script errors if the pull request is already opened, we can delete the branch so that it never fails

also updates the title and add a comment preview link