### PR TITLE
chore: prevent ad block spec files

### DIFF
--- a/scripts/ci/codegen/pushToAlgoliaDoc.ts
+++ b/scripts/ci/codegen/pushToAlgoliaDoc.ts
@@ -54,6 +54,8 @@ async function pushToAlgoliaDoc(): Promise<void> {
   await run(`cp ${toAbsolutePath('specs/bundled/*.doc.yml')} ${pathToSpecs}`);
   await run(`cp ${toAbsolutePath('config/release.config.json')} ${pathToSpecs}`);
   await run(`cp ${toAbsolutePath('snippets/guides/*.json')} ${pathToSpecs}`);
+  // add block extension ban words like `analytics` so we use a different file name just so the doc dans render it
+  await run(`mv ${pathToSpecs}/analytics.doc.yml ${pathToSpecs}/searchstats.doc.yml`);
 
   if ((await getNbGitDiff({ head: null, cwd: tempGitDir })) === 0) {
     console.log(`❎ Skipping push docs because there is no change.`);


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2752

### Changes included:

ad blocker extensions prevent the analytics spec from rendering, we need to provide a different name when pushing the doc to prevent that