### PR TITLE
fix(scripts): dont fail on empty benchamrk

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -492,6 +492,10 @@ jobs:
       - name: Read benchmark results
         id: benchmark
         run: |
+          if [[ $(find tests/output -name benchmarkResult.json | wc -l) -eq 0 ]]; then
+            echo "No benchmark results found"
+            exit 0
+          fi
           # merge all benchmark results into a single json, and remove the files
           results=$(jq -s 'add' -c tests/output/**/benchmarkResult.json)
           {
@@ -501,8 +505,8 @@ jobs:
             echo "" # empty line is required to make the table work
             echo "Benchmarks performed on the `search` method using a mock server, the results might not reflect the real-world performance."
             # format the json to a markdown table with column "Language" and "rate"
-            echo "| Language | Rate |"
-            echo "| :------- | ---: |"
+            echo "| Language | Req/s |"
+            echo "| :------- | ----: |"
             echo "$results" | jq -r 'to_entries | map([.key, .value.rate]) | sort_by(.[1]) | reverse | .[] | @tsv' | awk -F'\t' '{printf "| %-10s | %10d |\n", $1, $2}'
             echo "</details>"
             echo 'EOF'

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -44,6 +44,8 @@ export const DEPENDENCIES = LANGUAGES.reduce(
     finalDependencies[key] = [
       ':!**node_modules',
       `templates/${lang}`,
+      `templates/issue.yml`,
+      `templates/LICENSE`,
       // language related files
       langFolder,
       getVersionFileForLanguage(lang),


### PR DESCRIPTION
## 🧭 What and Why

Ignore the benckmark report when the matrix is empty.
Also fix the common templates.