### PR TITLE
fix(javascript): prefix with `node:` for node packages

### DIFF
--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -1,5 +1,5 @@
 {{#nodeSearchHelpers}}
-import {createHmac} from 'crypto';
+import {createHmac} from 'node:crypto';
 {{/nodeSearchHelpers}}
 
 import {

--- a/templates/javascript/clients/client/builds/definition.mustache
+++ b/templates/javascript/clients/client/builds/definition.mustache
@@ -27,7 +27,7 @@ import { GenerateSecuredApiKeyOptions, GetSecuredApiKeyRemainingValidityOptions 
 {{/isSearchClient}}
 
 {{#nodeSearchHelpers}}
-import {createHmac} from 'crypto';
+import {createHmac} from 'node:crypto';
 {{/nodeSearchHelpers}}
 
 /**


### PR DESCRIPTION
## 🧭 What and Why

It is a best practice to prefix node packages with `node:`

Introduced in Node 18: https://stateful.com/blog/node-18-prefix-only-modules

This also ease support for edge-runtime like Cloudflare Workers (https://developers.cloudflare.com/workers/runtime-apis/nodejs/crypto/)

### Changes included:

- Update import from `crypto` to `node:crypto`


