### PR TITLE
chore: prepare release 2024-08-29 [skip-bc]

### DIFF
--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -375,10 +375,12 @@ async function prepareGitEnvironment(): Promise<void> {
     errorMessage: '`released` tag is missing in this repository.',
   });
 
-  console.log('Pulling from origin...');
-  await run('git fetch origin');
-  await run('git fetch --tags --force');
-  await run('git pull origin $(git branch --show-current)');
+  if (!process.env.FORCE) {
+    console.log('Pulling from origin...');
+    await run('git fetch origin');
+    await run('git fetch --tags --force');
+    await run('git pull origin $(git branch --show-current)');
+  }
 }
 
 export async function createReleasePR({

--- a/templates/javascript/clients/README.mustache
+++ b/templates/javascript/clients/README.mustache
@@ -19,7 +19,7 @@
   <a href="https://discourse.algolia.com" target="_blank">Community Forum</a>  •
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-javascript/issues" target="_blank">Report a bug</a>  •
-  <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/" target="_blank">FAQ</a>  •
+  <a href="https://www.algolia.com/doc/libraries/javascript/v5/" target="_blank">FAQ</a>  •
   <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
@@ -74,7 +74,7 @@ For full documentation, visit the **[Algolia JavaScript API Client](https://www.
 
 ## ❓ Troubleshooting
 
-Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/) where you will find answers for the most common issues and gotchas with the client. You can also open [a GitHub issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=&projects=&template=Bug_report.md)
+Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/libraries/javascript/v5/) where you will find answers for the most common issues and gotchas with the client. You can also open [a GitHub issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=&projects=&template=Bug_report.md)
 
 ## 📄 License
 

--- a/templates/javascript/clients/README.mustache
+++ b/templates/javascript/clients/README.mustache
@@ -19,7 +19,7 @@
   <a href="https://discourse.algolia.com" target="_blank">Community Forum</a>  •
   <a href="http://stackoverflow.com/questions/tagged/algolia" target="_blank">Stack Overflow</a>  •
   <a href="https://github.com/algolia/algoliasearch-client-javascript/issues" target="_blank">Report a bug</a>  •
-  <a href="https://www.algolia.com/doc/libraries/javascript/v5/" target="_blank">FAQ</a>  •
+  <a href="https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/" target="_blank">FAQ</a>  •
   <a href="https://alg.li/support" target="_blank">Support</a>
 </p>
 
@@ -74,7 +74,7 @@ For full documentation, visit the **[Algolia JavaScript API Client](https://www.
 
 ## ❓ Troubleshooting
 
-Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/libraries/javascript/v5/) where you will find answers for the most common issues and gotchas with the client. You can also open [a GitHub issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=&projects=&template=Bug_report.md)
+Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://www.algolia.com/doc/api-client/troubleshooting/faq/javascript/) where you will find answers for the most common issues and gotchas with the client. You can also open [a GitHub issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=&projects=&template=Bug_report.md)
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

This PR has been created using the `apic release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- csharp: 7.2.1 -> **`patch` _(e.g. 7.2.2)_**
- dart: 1.23.1 -> **`patch` _(e.g. 1.23.2)_**
- go: 4.2.1 -> **`patch` _(e.g. 4.2.2)_**
- java: 4.2.2 -> **`patch` _(e.g. 4.2.3)_**
- javascript: 5.2.2 -> **`patch` _(e.g. 5.2.3)_**
- kotlin: 3.2.1 -> **`patch` _(e.g. 3.2.2)_**
- php: 4.3.2 -> **`patch` _(e.g. 4.3.3)_**
- python: 4.2.1 -> **`patch` _(e.g. 4.2.2)_**
- ruby: 3.2.1 -> **`patch` _(e.g. 3.2.2)_**
- scala: 2.2.1 -> **`patch` _(e.g. 2.2.2)_**
- swift: 9.2.1 -> **`patch` _(e.g. 9.2.2)_**

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - chore: prepare release 2024-08-29 (#3615)
- chore: fix the bug report template (#3614)
- chore: add a bug report template to github (#3606)
</details>

<details>
  <summary>
    <i>Commits with unknown language scope:</i>
  </summary>

  - chore(ci): add ability to skip e2e when something is down [skip-e2e] (#3612)
</details>