### PR TITLE
docs(insights): Example event name should change with eventType

### DIFF
--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -126,7 +126,8 @@ export async function runCts(
   clients: string[],
   suites: Record<CTSType, boolean>,
 ): Promise<void> {
-  const withBenchmarkServer = suites.benchmark && (clients.includes('search') || clients.includes('all'));
+  const withBenchmarkServer =
+    suites.benchmark && (clients.includes('search') || clients.includes('all') || languages.includes('swift'));
   const withClientServer = suites.client && (clients.includes('search') || clients.includes('all'));
   const closeTestServer = await startTestServer({
     ...suites,

--- a/specs/insights/common/schemas/AddedToCartObjectIDs.yml
+++ b/specs/insights/common/schemas/AddedToCartObjectIDs.yml
@@ -8,6 +8,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Added To Cart
   eventType:
     $ref: './ConversionEvent.yml'
   eventSubtype:

--- a/specs/insights/common/schemas/AddedToCartObjectIDsAfterSearch.yml
+++ b/specs/insights/common/schemas/AddedToCartObjectIDsAfterSearch.yml
@@ -7,6 +7,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Added To Cart
   eventType:
     $ref: './ConversionEvent.yml'
   eventSubtype:

--- a/specs/insights/common/schemas/ClickedFilters.yml
+++ b/specs/insights/common/schemas/ClickedFilters.yml
@@ -5,6 +5,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Filter Clicked
   eventType:
     $ref: './ClickEvent.yml'
   index:

--- a/specs/insights/common/schemas/ClickedObjectIDs.yml
+++ b/specs/insights/common/schemas/ClickedObjectIDs.yml
@@ -9,6 +9,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Clicked
   eventType:
     $ref: './ClickEvent.yml'
   index:

--- a/specs/insights/common/schemas/ClickedObjectIDsAfterSearch.yml
+++ b/specs/insights/common/schemas/ClickedObjectIDsAfterSearch.yml
@@ -10,6 +10,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Clicked
   eventType:
     $ref: './ClickEvent.yml'
   index:

--- a/specs/insights/common/schemas/ConvertedFilters.yml
+++ b/specs/insights/common/schemas/ConvertedFilters.yml
@@ -4,6 +4,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Filter Converted
   eventType:
     $ref: './ConversionEvent.yml'
   index:

--- a/specs/insights/common/schemas/ConvertedObjectIDs.yml
+++ b/specs/insights/common/schemas/ConvertedObjectIDs.yml
@@ -9,6 +9,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Converted
   eventType:
     $ref: './ConversionEvent.yml'
   index:

--- a/specs/insights/common/schemas/ConvertedObjectIDsAfterSearch.yml
+++ b/specs/insights/common/schemas/ConvertedObjectIDsAfterSearch.yml
@@ -11,6 +11,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Converted
   eventType:
     $ref: './ConversionEvent.yml'
   index:

--- a/specs/insights/common/schemas/EventAttributes.yml
+++ b/specs/insights/common/schemas/EventAttributes.yml
@@ -9,7 +9,6 @@ eventName:
     Consider naming events consistently—for example, by adopting Segment's
     [object-action](https://segment.com/academy/collecting-data/naming-conventions-for-clean-data/#the-object-action-framework)
     framework.
-  example: Product Clicked
 
 index:
   type: string

--- a/specs/insights/common/schemas/PurchasedObjectIDs.yml
+++ b/specs/insights/common/schemas/PurchasedObjectIDs.yml
@@ -8,6 +8,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Purchased
   eventType:
     $ref: './ConversionEvent.yml'
   eventSubtype:

--- a/specs/insights/common/schemas/PurchasedObjectIDsAfterSearch.yml
+++ b/specs/insights/common/schemas/PurchasedObjectIDsAfterSearch.yml
@@ -7,6 +7,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Purchased
   eventType:
     $ref: './ConversionEvent.yml'
   eventSubtype:

--- a/specs/insights/common/schemas/ViewedFilters.yml
+++ b/specs/insights/common/schemas/ViewedFilters.yml
@@ -8,6 +8,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Filter Viewed
   eventType:
     $ref: './ViewEvent.yml'
   index:

--- a/specs/insights/common/schemas/ViewedObjectIDs.yml
+++ b/specs/insights/common/schemas/ViewedObjectIDs.yml
@@ -5,6 +5,7 @@ additionalProperties: false
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'
+    example: Product Viewed
   eventType:
     $ref: './ViewEvent.yml'
   index:


### PR DESCRIPTION
## 🧭 What and Why

Looking at the spec for `View Filters` and seeing `example name: Product Clicked` is confusing.

<img width="797" alt="image" src="https://github.com/user-attachments/assets/1433b6b7-0293-4daa-bde6-20f68d15cd52">

🎟 JIRA Ticket: None

### Changes included:

- Added examples to the eventName attribute of each concretization of the event concept
- Removed based example on eventName attribute (to keep the spec json schema compliant)

## 🧪 Test

?? <- Let me know how I can do that! I ran `yarn website` to generate the bundled version and it seemed okay, but 🤷‍♂️ and I don't know how to view the website locally 😅 