### PR TITLE
fix(clients): correly parse usage hosts

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
@@ -133,9 +133,13 @@ public class Helpers {
       }
 
       if (!hasRegionalHost) {
-        if (servers.size() == 1 && hostWithFallback.isEmpty()) {
-          URL url = new URL(servers.get(0).url);
-          bundle.put("uniqueHost", url.getHost());
+        if (hostWithFallback.isEmpty()) {
+          List<String> hostsWithoutAppID = new ArrayList<>();
+          for (CodegenServer otherServer : servers) {
+            URL url = new URL(otherServer.url);
+            hostsWithoutAppID.add(url.getHost());
+          }
+          bundle.put("hostsWithoutAppID", hostsWithoutAppID);
         } else {
           bundle.put("hostWithAppID", true);
         }

--- a/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
@@ -92,6 +92,7 @@ public class Helpers {
     try {
       boolean hasRegionalHost = false;
       boolean fallbackToAliasHost = false;
+      boolean hasVariables = false;
       String regionalHost = "";
       String hostWithFallback = "";
       Set<String> allowedRegions = new HashSet<>();
@@ -117,6 +118,7 @@ public class Helpers {
         if (server.variables == null || server.variables.isEmpty()) {
           continue;
         }
+        hasVariables = true;
         CodegenServerVariable regionVar = server.variables.stream().filter(v -> v.name.equals("region")).findFirst().orElse(null);
         if (regionVar == null || regionVar.enumValues == null || regionVar.enumValues.isEmpty()) {
           continue;
@@ -133,13 +135,13 @@ public class Helpers {
       }
 
       if (!hasRegionalHost) {
-        if (hostWithFallback.isEmpty()) {
-          List<String> hostsWithoutAppID = new ArrayList<>();
+        if (!hasVariables && hostWithFallback.isEmpty()) {
+          List<String> hostsWithoutVariables = new ArrayList<>();
           for (CodegenServer otherServer : servers) {
             URL url = new URL(otherServer.url);
-            hostsWithoutAppID.add(url.getHost());
+            hostsWithoutVariables.add(url.getHost());
           }
-          bundle.put("hostsWithoutAppID", hostsWithoutAppID);
+          bundle.put("hostsWithoutVariables", hostsWithoutVariables);
         } else {
           bundle.put("hostWithAppID", true);
         }

--- a/templates/csharp/Configuration.mustache
+++ b/templates/csharp/Configuration.mustache
@@ -116,12 +116,12 @@ private static List<StatefulHost> GetDefaultHosts(string region)
   return hosts;
 }
 {{/hasRegionalHost}}
-{{#hostsWithoutAppID.size}}
+{{#hostsWithoutVariables.size}}
 private static List<StatefulHost> GetDefaultHosts()
 {
   return new List<StatefulHost>
   {
-    {{#hostsWithoutAppID}}
+    {{#hostsWithoutVariables}}
     new()
     {
       Url = "{{{.}}}",
@@ -129,8 +129,8 @@ private static List<StatefulHost> GetDefaultHosts()
       LastUse = DateTime.UtcNow,
       Accept =  CallType.Read | CallType.Write
     },
-    {{/hostsWithoutAppID}}
+    {{/hostsWithoutVariables}}
   };
 }
-{{/hostsWithoutAppID.size}}
+{{/hostsWithoutVariables.size}}
 }

--- a/templates/csharp/Configuration.mustache
+++ b/templates/csharp/Configuration.mustache
@@ -116,20 +116,21 @@ private static List<StatefulHost> GetDefaultHosts(string region)
   return hosts;
 }
 {{/hasRegionalHost}}
-{{#uniqueHost}}
+{{#hostsWithoutAppID.size}}
 private static List<StatefulHost> GetDefaultHosts()
 {
   return new List<StatefulHost>
   {
+    {{#hostsWithoutAppID}}
     new()
     {
       Url = "{{{.}}}",
       Up = true,
       LastUse = DateTime.UtcNow,
       Accept =  CallType.Read | CallType.Write
-    }
+    },
+    {{/hostsWithoutAppID}}
   };
 }
-{{/uniqueHost}}
+{{/hostsWithoutAppID.size}}
 }
-

--- a/templates/dart/api.mustache
+++ b/templates/dart/api.mustache
@@ -68,13 +68,13 @@ final class {{classname}} implements ApiClient {
             {{/hasRegionalHost}}
             {{#uniqueHost}}
             {{/uniqueHost}}
-            {{#hostsWithoutAppID.size}}
+            {{#hostsWithoutVariables.size}}
             defaultHosts: () => [
-              {{#hostsWithoutAppID}}
+              {{#hostsWithoutVariables}}
                 Host(url: '{{{.}}}'),
-              {{/hostsWithoutAppID}}
+              {{/hostsWithoutVariables}}
             ],
-            {{/hostsWithoutAppID.size}}
+            {{/hostsWithoutVariables.size}}
             ) {
     assert(appId.isNotEmpty, '`appId` is missing.');
     assert(apiKey.isNotEmpty, '`apiKey` is missing.');

--- a/templates/dart/api.mustache
+++ b/templates/dart/api.mustache
@@ -67,8 +67,14 @@ final class {{classname}} implements ApiClient {
             }  
             {{/hasRegionalHost}}
             {{#uniqueHost}}
-            defaultHosts: () => [Host(url: '{{{.}}}')],
             {{/uniqueHost}}
+            {{#hostsWithoutAppID.size}}
+            defaultHosts: () => [
+              {{#hostsWithoutAppID}}
+                Host(url: '{{{.}}}'),
+              {{/hostsWithoutAppID}}
+            ],
+            {{/hostsWithoutAppID.size}}
             ) {
     assert(appId.isNotEmpty, '`appId` is missing.');
     assert(apiKey.isNotEmpty, '`apiKey` is missing.');

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -100,11 +100,15 @@ func getDefaultHosts(appID string) []transport.StatefulHost {
 	return hosts
 }
 {{/hostWithAppID}}
-{{#uniqueHost}}
+{{#hostsWithoutAppID.size}}
 func getDefaultHosts() []transport.StatefulHost {
-  return []transport.StatefulHost{transport.NewStatefulHost("https", "{{{.}}}", call.IsReadWrite)}
+  return []transport.StatefulHost{
+    {{#hostsWithoutAppID}}
+    transport.NewStatefulHost("https", "{{{.}}}", call.IsReadWrite),
+    {{/hostsWithoutAppID}}
+  }
 }
-{{/uniqueHost}}
+{{/hostsWithoutAppID.size}}
 
 func getUserAgent() string {
   return fmt.Sprintf("Algolia for Go ({{{packageVersion}}}); Go (%s); {{#lambda.titlecase}}{{#lambda.camelcase}}{{client}}{{/lambda.camelcase}}{{/lambda.titlecase}} ({{{packageVersion}}})", runtime.Version())

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -100,15 +100,15 @@ func getDefaultHosts(appID string) []transport.StatefulHost {
 	return hosts
 }
 {{/hostWithAppID}}
-{{#hostsWithoutAppID.size}}
+{{#hostsWithoutVariables.size}}
 func getDefaultHosts() []transport.StatefulHost {
   return []transport.StatefulHost{
-    {{#hostsWithoutAppID}}
+    {{#hostsWithoutVariables}}
     transport.NewStatefulHost("https", "{{{.}}}", call.IsReadWrite),
-    {{/hostsWithoutAppID}}
+    {{/hostsWithoutVariables}}
   }
 }
-{{/hostsWithoutAppID.size}}
+{{/hostsWithoutVariables.size}}
 
 func getUserAgent() string {
   return fmt.Sprintf("Algolia for Go ({{{packageVersion}}}); Go (%s); {{#lambda.titlecase}}{{#lambda.camelcase}}{{client}}{{/lambda.camelcase}}{{/lambda.titlecase}} ({{{packageVersion}}})", runtime.Version())

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -120,15 +120,15 @@ public class {{classname}} extends ApiClient {
     }
     {{/hasRegionalHost}}
     
-    {{#hostsWithoutAppID.size}}
+    {{#hostsWithoutVariables.size}}
     private static List<Host> getDefaultHosts() {
       List<Host> hosts = new ArrayList<>();
-      {{#hostsWithoutAppID}}
+      {{#hostsWithoutVariables}}
       hosts.add(new Host("{{{.}}}", EnumSet.of(CallType.READ, CallType.WRITE)));
-      {{/hostsWithoutAppID}}
+      {{/hostsWithoutVariables}}
       return hosts;
     }
-    {{/hostsWithoutAppID.size}}
+    {{/hostsWithoutVariables.size}}
 
     {{#operation}}
     /**

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -120,13 +120,15 @@ public class {{classname}} extends ApiClient {
     }
     {{/hasRegionalHost}}
     
-    {{#uniqueHost}}
+    {{#hostsWithoutAppID.size}}
     private static List<Host> getDefaultHosts() {
       List<Host> hosts = new ArrayList<>();
+      {{#hostsWithoutAppID}}
       hosts.add(new Host("{{{.}}}", EnumSet.of(CallType.READ, CallType.WRITE)));
+      {{/hostsWithoutAppID}}
       return hosts;
     }
-    {{/uniqueHost}}
+    {{/hostsWithoutAppID.size}}
 
     {{#operation}}
     /**

--- a/templates/javascript/clients/client/api/hosts.mustache
+++ b/templates/javascript/clients/client/api/hosts.mustache
@@ -5,8 +5,14 @@ export type Region = (typeof REGIONS)[number];
 
 {{^hasRegionalHost}}
 function getDefaultHosts({{#hostWithAppID}}appId: string{{/hostWithAppID}}): Host[] {
+  {{#hostsWithoutAppID.size}}
+  return [
+    {{#hostsWithoutAppID}}
+    {url: "{{{.}}}", accept: 'readWrite', protocol: 'https' },
+    {{/hostsWithoutAppID}}
+  ];
+  {{/hostsWithoutAppID.size}}
   {{#uniqueHost}}
-  return [{url: "{{{.}}}", accept: 'readWrite', protocol: 'https' }];
   {{/uniqueHost}}
   {{#hostWithAppID}}
   return (

--- a/templates/javascript/clients/client/api/hosts.mustache
+++ b/templates/javascript/clients/client/api/hosts.mustache
@@ -5,13 +5,13 @@ export type Region = (typeof REGIONS)[number];
 
 {{^hasRegionalHost}}
 function getDefaultHosts({{#hostWithAppID}}appId: string{{/hostWithAppID}}): Host[] {
-  {{#hostsWithoutAppID.size}}
+  {{#hostsWithoutVariables.size}}
   return [
-    {{#hostsWithoutAppID}}
+    {{#hostsWithoutVariables}}
     {url: "{{{.}}}", accept: 'readWrite', protocol: 'https' },
-    {{/hostsWithoutAppID}}
+    {{/hostsWithoutVariables}}
   ];
-  {{/hostsWithoutAppID.size}}
+  {{/hostsWithoutVariables.size}}
   {{#uniqueHost}}
   {{/uniqueHost}}
   {{#hostWithAppID}}

--- a/templates/kotlin/api.mustache
+++ b/templates/kotlin/api.mustache
@@ -46,9 +46,13 @@ public class {{classname}}(
     val url = {{#fallbackToAliasHost}}if (region == null) "{{{hostWithFallback}}}" else {{/fallbackToAliasHost}} "{{{hostForKotlin}}}"
     listOf(Host(url)) 
   {{/hasRegionalHost}}
-  {{#uniqueHost}}
-  listOf(Host("{{.}}"))
-  {{/uniqueHost}}
+  {{#hostsWithoutAppID.size}}
+  listOf(
+  {{#hostsWithoutAppID}}
+  Host("{{.}}"),
+  {{/hostsWithoutAppID}}
+  )
+  {{/hostsWithoutAppID.size}}
   }
 
   {{#operation}}

--- a/templates/kotlin/api.mustache
+++ b/templates/kotlin/api.mustache
@@ -46,13 +46,13 @@ public class {{classname}}(
     val url = {{#fallbackToAliasHost}}if (region == null) "{{{hostWithFallback}}}" else {{/fallbackToAliasHost}} "{{{hostForKotlin}}}"
     listOf(Host(url)) 
   {{/hasRegionalHost}}
-  {{#hostsWithoutAppID.size}}
+  {{#hostsWithoutVariables.size}}
   listOf(
-  {{#hostsWithoutAppID}}
+  {{#hostsWithoutVariables}}
   Host("{{.}}"),
-  {{/hostsWithoutAppID}}
+  {{/hostsWithoutVariables}}
   )
-  {{/hostsWithoutAppID.size}}
+  {{/hostsWithoutVariables.size}}
   }
 
   {{#operation}}

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -128,14 +128,18 @@ use {{invokerPackage}}\Support\Helpers;
         }
         {{/hasRegionalHost}}
 
-        {{#uniqueHost}}
+        {{#hostsWithoutAppID.size}}
         if ($hosts = $config->getHosts()) {
             // If a list of hosts was passed, we ignore the cache
             $clusterHosts = ClusterHosts::create($hosts);
         } else {
-            $clusterHosts = ClusterHosts::create('{{.}}');
+            $clusterHosts = ClusterHosts::create([
+            {{#hostsWithoutAppID}}
+            '{{.}}',
+            {{/hostsWithoutAppID}}
+            ]);
         }
-        {{/uniqueHost}}
+        {{/hostsWithoutAppID.size}}
 
         return $clusterHosts;
     }

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -128,18 +128,18 @@ use {{invokerPackage}}\Support\Helpers;
         }
         {{/hasRegionalHost}}
 
-        {{#hostsWithoutAppID.size}}
+        {{#hostsWithoutVariables.size}}
         if ($hosts = $config->getHosts()) {
             // If a list of hosts was passed, we ignore the cache
             $clusterHosts = ClusterHosts::create($hosts);
         } else {
             $clusterHosts = ClusterHosts::create([
-            {{#hostsWithoutAppID}}
+            {{#hostsWithoutVariables}}
             '{{.}}',
-            {{/hostsWithoutAppID}}
+            {{/hostsWithoutVariables}}
             ]);
         }
-        {{/hostsWithoutAppID.size}}
+        {{/hostsWithoutVariables.size}}
 
         return $clusterHosts;
     }

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -44,11 +44,13 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
 
         {{^hasRegionalHost}}
         self.hosts = HostsCollection(
-            {{#uniqueHost}}
+            {{#hostsWithoutAppID.size}}
             [
+              {{#hostsWithoutAppID}}
                 Host("{{{.}}}"),
+              {{/hostsWithoutAppID}}
             ]
-            {{/uniqueHost}}
+            {{/hostsWithoutAppID.size}}
             {{#hostWithAppID}}
             [
                 Host(url="{}-dsn.algolia.net".format(self.app_id), priority=10, accept=CallType.READ),

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -44,13 +44,13 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
 
         {{^hasRegionalHost}}
         self.hosts = HostsCollection(
-            {{#hostsWithoutAppID.size}}
+            {{#hostsWithoutVariables.size}}
             [
-              {{#hostsWithoutAppID}}
+              {{#hostsWithoutVariables}}
                 Host("{{{.}}}"),
-              {{/hostsWithoutAppID}}
+              {{/hostsWithoutVariables}}
             ]
-            {{/hostsWithoutAppID.size}}
+            {{/hostsWithoutVariables.size}}
             {{#hostWithAppID}}
             [
                 Host(url="{}-dsn.algolia.net".format(self.app_id), priority=10, accept=CallType.READ),

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -45,9 +45,11 @@ module {{moduleName}}
         Transport::StatefulHost.new("#{app_id}-#{i}.algolianet.com", accept: CallType::READ | CallType::WRITE)
       end.shuffle
       {{/hostWithAppID}}
-      {{#uniqueHost}}
+      {{#hostsWithoutAppID.size}}
+      {{#hostsWithoutAppID}}
       hosts << Transport::StatefulHost.new('{{.}}', accept: CallType::READ | CallType::WRITE)
-      {{/uniqueHost}}
+      {{/hostsWithoutAppID}}
+      {{/hostsWithoutAppID.size}}
 
       config = Algolia::Configuration.new(app_id, api_key, hosts, '{{{baseName}}}', opts)
       create_with_config(config)

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -45,11 +45,11 @@ module {{moduleName}}
         Transport::StatefulHost.new("#{app_id}-#{i}.algolianet.com", accept: CallType::READ | CallType::WRITE)
       end.shuffle
       {{/hostWithAppID}}
-      {{#hostsWithoutAppID.size}}
-      {{#hostsWithoutAppID}}
+      {{#hostsWithoutVariables.size}}
+      {{#hostsWithoutVariables}}
       hosts << Transport::StatefulHost.new('{{.}}', accept: CallType::READ | CallType::WRITE)
-      {{/hostsWithoutAppID}}
-      {{/hostsWithoutAppID.size}}
+      {{/hostsWithoutVariables}}
+      {{/hostsWithoutVariables.size}}
 
       config = Algolia::Configuration.new(app_id, api_key, hosts, '{{{baseName}}}', opts)
       create_with_config(config)

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -79,7 +79,7 @@ object {{classname}} {
   private def hosts(): Seq[Host] = {
     List(
     {{#hostsWithoutVariables}}
-    Host("{{.}}", Set(CallType.Read, CallType.Write))
+    Host("{{.}}", Set(CallType.Read, CallType.Write)),
     {{/hostsWithoutVariables}}
     )
   }

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -75,11 +75,15 @@ object {{classname}} {
     ) ++ commonHosts
   }
   {{/hostWithAppID}}
-  {{#uniqueHost}}
+  {{#hostsWithoutAppID.size}}
   private def hosts(): Seq[Host] = {
-    List(Host("{{.}}", Set(CallType.Read, CallType.Write)))
+    List(
+    {{#hostsWithoutAppID}}
+    Host("{{.}}", Set(CallType.Read, CallType.Write))
+    {{/hostsWithoutAppID}}
+    )
   }
-  {{/uniqueHost}}
+  {{/hostsWithoutAppID.size}}
 }
 
 class {{classname}}(

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -75,15 +75,15 @@ object {{classname}} {
     ) ++ commonHosts
   }
   {{/hostWithAppID}}
-  {{#hostsWithoutAppID.size}}
+  {{#hostsWithoutVariables.size}}
   private def hosts(): Seq[Host] = {
     List(
-    {{#hostsWithoutAppID}}
+    {{#hostsWithoutVariables}}
     Host("{{.}}", Set(CallType.Read, CallType.Write))
-    {{/hostsWithoutAppID}}
+    {{/hostsWithoutVariables}}
     )
   }
-  {{/hostsWithoutAppID.size}}
+  {{/hostsWithoutVariables.size}}
 }
 
 class {{classname}}(

--- a/templates/swift/client_configuration.mustache
+++ b/templates/swift/client_configuration.mustache
@@ -80,12 +80,11 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
       self.hosts = hosts + commonHosts
   {{/hasRegionalHost}}{{/hostsWithoutVariables}}
   {{#hostsWithoutVariables.size}}
-    self.hosts = []
+    self.hosts = [
     {{#hostsWithoutVariables}}
-    self.hosts.append(.init(url: URL(string: "https://{{{.}}}") else {
-      throw AlgoliaError.runtimeError("Malformed URL")
-    }))
+    .init(url: URL(string: "https://{{{.}}}")!),
     {{/hostsWithoutVariables}}
+    ]
   {{/hostsWithoutVariables.size}}
   {{#uniqueHost}}
 

--- a/templates/swift/client_configuration.mustache
+++ b/templates/swift/client_configuration.mustache
@@ -55,7 +55,7 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
     UserAgentController.append(UserAgent(title: "{{#lambda.client-to-name}}{{client}}{{/lambda.client-to-name}}", version: Version.current.description))
 
     guard let hosts = hosts else {
-      {{^uniqueHost}}{{^hasRegionalHost}}
+      {{^hostsWithoutAppID}}{{^hasRegionalHost}}
       func buildHost(_ components: (suffix: String, callType: RetryableHost.CallTypeSupport)) throws
         -> RetryableHost
       {
@@ -78,15 +78,17 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
       ].map(buildHost).shuffled()
 
       self.hosts = hosts + commonHosts
-  {{/hasRegionalHost}}{{/uniqueHost}}
-  {{#uniqueHost}}
-    guard let url = URL(string: "https://{{{.}}}") else {
+  {{/hasRegionalHost}}{{/hostsWithoutAppID}}
+  {{#hostsWithoutAppID.size}}
+    self.hosts = []
+    {{#hostsWithoutAppID}}
+    self.hosts.append(.init(url: URL(string: "https://{{{.}}}") else {
       throw AlgoliaError.runtimeError("Malformed URL")
-    }
+    }))
+    {{/hostsWithoutAppID}}
+  {{/hostsWithoutAppID.size}}
+  {{#uniqueHost}}
 
-    self.hosts = [
-      .init(url: url)
-    ]
   {{/uniqueHost}}
   {{#hasRegionalHost}}
       guard {{#fallbackToAliasHost}}region == nil || {{/fallbackToAliasHost}}authorizedRegions.contains(region{{#fallbackToAliasHost}}!{{/fallbackToAliasHost}}) else {

--- a/templates/swift/client_configuration.mustache
+++ b/templates/swift/client_configuration.mustache
@@ -55,7 +55,7 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
     UserAgentController.append(UserAgent(title: "{{#lambda.client-to-name}}{{client}}{{/lambda.client-to-name}}", version: Version.current.description))
 
     guard let hosts = hosts else {
-      {{^hostsWithoutAppID}}{{^hasRegionalHost}}
+      {{^hostsWithoutVariables}}{{^hasRegionalHost}}
       func buildHost(_ components: (suffix: String, callType: RetryableHost.CallTypeSupport)) throws
         -> RetryableHost
       {
@@ -78,15 +78,15 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
       ].map(buildHost).shuffled()
 
       self.hosts = hosts + commonHosts
-  {{/hasRegionalHost}}{{/hostsWithoutAppID}}
-  {{#hostsWithoutAppID.size}}
+  {{/hasRegionalHost}}{{/hostsWithoutVariables}}
+  {{#hostsWithoutVariables.size}}
     self.hosts = []
-    {{#hostsWithoutAppID}}
+    {{#hostsWithoutVariables}}
     self.hosts.append(.init(url: URL(string: "https://{{{.}}}") else {
       throw AlgoliaError.runtimeError("Malformed URL")
     }))
-    {{/hostsWithoutAppID}}
-  {{/hostsWithoutAppID.size}}
+    {{/hostsWithoutVariables}}
+  {{/hostsWithoutVariables.size}}
   {{#uniqueHost}}
 
   {{/uniqueHost}}

--- a/tests/CTS/client/usage/api.json
+++ b/tests/CTS/client/usage/api.json
@@ -18,7 +18,7 @@
         },
         "expected": {
           "type": "host",
-          "match": "test-app-id-dsn.algolia.net"
+          "match": "usage.algolia.com"
         }
       }
     ]
@@ -42,7 +42,7 @@
         },
         "expected": {
           "type": "host",
-          "match": "test-app-id.algolia.net"
+          "match": "usage.algolia.com"
         }
       }
     ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2857

### Changes included:

closes https://github.com/algolia/api-clients-automation/issues/3621

correctly parses the servers when it's not an appID or regional host
