### PR TITLE
fix(specs): note on insights API server

### DIFF
--- a/specs/insights/spec.yml
+++ b/specs/insights/spec.yml
@@ -16,8 +16,9 @@ info:
 
     The base URLs for making requests to the Insights API are:
 
-    - `https://insights.us.algolia.io` (`https://insights.algolia.io` is an alias)
+    - `https://insights.us.algolia.io`
     - `https://insights.de.algolia.io`
+    - `https//insights.algolia.io` (routes requests to the closest of the above servers, based on your geographical location)
 
     **All requests must use HTTPS.**
 


### PR DESCRIPTION
## 🧭 What and Why

Correct a false statement about the Insights API's server `insights.algolia.io`. It uses geo routing to forward to either `insights.de.algolia.io` or `insights.us.algolia.io`.