### PR TITLE
fix(php): put banner after php tag

### DIFF
--- a/templates/php/ApiException.mustache
+++ b/templates/php/ApiException.mustache
@@ -1,5 +1,6 @@
-// {{{generationBanner}}}
 <?php
+
+// {{{generationBanner}}}
 
 namespace {{invokerPackage}};
 

--- a/templates/php/ConfigWithRegion.mustache
+++ b/templates/php/ConfigWithRegion.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{invokerPackage}}\Configuration;

--- a/templates/php/Configuration.mustache
+++ b/templates/php/Configuration.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{invokerPackage}}\Configuration;

--- a/templates/php/ModelInterface.mustache
+++ b/templates/php/ModelInterface.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{modelPackage}};

--- a/templates/php/ObjectSerializer.mustache
+++ b/templates/php/ObjectSerializer.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{invokerPackage}};

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{apiPackage}};

--- a/templates/php/client_config.mustache
+++ b/templates/php/client_config.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 namespace {{invokerPackage}}\Configuration;

--- a/templates/php/model.mustache
+++ b/templates/php/model.mustache
@@ -1,4 +1,5 @@
 <?php
+
 // {{{generationBanner}}}
 
 {{#models}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-2878](https://algolia.atlassian.net/browse/DI-2878). closes https://github.com/algolia/algoliasearch-client-php/issues/736

The banner must be after `<?php`. I checked all the files and this was the only one.

`find . -name "*.php" -not -path "./clients/algoliasearch-client-php/vendor/*" -exec sh -c 'head -n 1 "$1" | grep -q "^<?php$" || echo "$1 does not start with <?php"' _ {} \;`


[DI-2878]: https://algolia.atlassian.net/browse/DI-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ