### PR TITLE
fix(csharp): add helpers to ISearchClient

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Http/AlgoliaUserAgent.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Http/AlgoliaUserAgent.cs
@@ -19,7 +19,8 @@ public class AlgoliaUserAgent
   /// <summary>
   /// Create a new user-agent header
   /// </summary>
-  /// <param name="clientName"></param>
+  /// <param name="clientName">The client name</param>
+  /// <param name="clientVersion">The client version</param>
   public AlgoliaUserAgent(string clientName, string clientVersion)
   {
     AddSegment("Algolia for Csharp", $"({clientVersion})");

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -22,41 +22,53 @@ namespace Algolia.Search.Clients;
   /// <summary>
   /// Represents a collection of functions to interact with the API endpoints
   /// </summary>
-  {{> visibility}} interface {{interfacePrefix}}{{classname}}
+  {{> visibility}} {{#isSearchClient}}partial {{/isSearchClient}}interface {{interfacePrefix}}{{classname}}
   {
       {{#operation}}
       /// <summary>
       /// {{{notes}}}
-      /// </summary>
+      /// </summary>{{#vendorExtensions}}{{#x-acl.0}}
+      ///
+      /// Required API Key ACLs:{{/x-acl.0}}
+      {{#x-acl}}
+      ///   - {{.}}
+      {{/x-acl}}
+      {{/vendorExtensions}}
       {{#allParams}}
       /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
       {{/allParams}}
       /// <param name="options">Add extra http header or query parameters to Algolia.</param>
       /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-      {{#isDeprecated}}
-      [Obsolete]
-      {{/isDeprecated}}
       /// <exception cref="ArgumentException">Thrown when arguments are not correct</exception>
       /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
       /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
       /// <returns>Task of {{> return_type_doc}}</returns>
+      {{#isDeprecated}}
+      [Obsolete]
+      {{/isDeprecated}}
       Task{{#returnType}}<{{> return_type}}>{{/returnType}} {{operationId}}Async{{#returnType}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{/returnType}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}RequestOptions options = null, CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// {{{notes}}} (Synchronous version)
-        /// </summary>
+      /// <summary>
+      /// {{{notes}}} (Synchronous version)
+      /// </summary>{{#vendorExtensions}}{{#x-acl.0}}
+      ///
+      /// Required API Key ACLs:{{/x-acl.0}}
+      {{#x-acl}}
+        ///   - {{.}}
+      {{/x-acl}}
+      {{/vendorExtensions}}
       {{#allParams}}
-          /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+      /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
       {{/allParams}}
-        /// <param name="options">Add extra http header or query parameters to Algolia.</param>
-        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+      /// <param name="options">Add extra http header or query parameters to Algolia.</param>
+      /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+      /// <exception cref="ArgumentException">Thrown when arguments are not correct</exception>
+      /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
+      /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
+      /// <returns>{{> return_type_doc}}</returns>
       {{#isDeprecated}}
-          [Obsolete]
+      [Obsolete]
       {{/isDeprecated}}
-        /// <exception cref="ArgumentException">Thrown when arguments are not correct</exception>
-        /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
-        /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
-        /// <returns>{{> return_type_doc}}</returns>
       {{^returnType}}void{{/returnType}}{{#returnType}}{{> return_type}}{{/returnType}} {{operationId}}{{#returnType}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{/returnType}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}RequestOptions options = null, CancellationToken cancellationToken = default);
 
       {{/operation}}
@@ -131,27 +143,10 @@ namespace Algolia.Search.Clients;
       {{#operation}}
       {{#supportsAsync}}
 
-      /// <summary>
-      /// {{{notes}}}
-      /// </summary>{{#vendorExtensions}}{{#x-acl.0}}
-      ///
-      /// Required API Key ACLs:{{/x-acl.0}}
-      {{#x-acl}}
-      ///   - {{.}}
-      {{/x-acl}}
-      {{/vendorExtensions}}
-      {{#allParams}}
-      /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
-      {{/allParams}}
-      /// <param name="options">Add extra http header or query parameters to Algolia.</param>
-      /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+      /// <inheritdoc />
       {{#isDeprecated}}
       [Obsolete]
       {{/isDeprecated}}
-      /// <exception cref="ArgumentException">Thrown when arguments are not correct</exception>
-      /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
-      /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
-      /// <returns>Task of {{> return_type_doc}}</returns>
       public async Task{{#returnType}}<{{> return_type}}>{{/returnType}} {{operationId}}Async{{#returnType}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{/returnType}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}RequestOptions options = null, CancellationToken cancellationToken = default)
       {
           {{#allParams}}
@@ -225,32 +220,14 @@ namespace Algolia.Search.Clients;
       }
 
 
-          /// <summary>
-          /// {{{notes}}} (Synchronous version)
-          /// </summary>{{#vendorExtensions}}{{#x-acl.0}}
-            ///
-            /// Required API Key ACLs:{{/x-acl.0}}
-        {{#x-acl}}
-            ///   - {{.}}
-        {{/x-acl}}
-        {{/vendorExtensions}}
-        {{#allParams}}
-            /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
-        {{/allParams}}
-          /// <param name="options">Add extra http header or query parameters to Algolia.</param>
-          /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        {{#isDeprecated}}
-            [Obsolete]
-        {{/isDeprecated}}
-          /// <exception cref="ArgumentException">Thrown when arguments are not correct</exception>
-          /// <exception cref="Algolia.Search.Exceptions.AlgoliaApiException">Thrown when the API call was rejected by Algolia</exception>
-          /// <exception cref="Algolia.Search.Exceptions.AlgoliaUnreachableHostException">Thrown when the client failed to call the endpoint</exception>
-          /// <returns>{{> return_type_doc}}</returns>
-          public {{^returnType}}void{{/returnType}}{{#returnType}}{{> return_type}}{{/returnType}} {{operationId}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}RequestOptions options = null, CancellationToken cancellationToken = default) =>
-            AsyncHelper.RunSync(() => {{operationId}}Async{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}} options, cancellationToken));
+      /// <inheritdoc />
+      {{#isDeprecated}}
+      [Obsolete]
+      {{/isDeprecated}}
+      public {{^returnType}}void{{/returnType}}{{#returnType}}{{> return_type}}{{/returnType}} {{operationId}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}RequestOptions options = null, CancellationToken cancellationToken = default) =>
+        AsyncHelper.RunSync(() => {{operationId}}Async{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}} options, cancellationToken));
 
       {{/supportsAsync}}
       {{/operation}}
   }
   {{/operations}}
-

--- a/templates/csharp/netcore_project.mustache
+++ b/templates/csharp/netcore_project.mustache
@@ -41,7 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/output/csharp/src/Algolia.Search.Tests.csproj
+++ b/tests/output/csharp/src/Algolia.Search.Tests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Quibble.Xunit" Version="0.3.1" />
-        <PackageReference Include="System.Text.Json" Version="8.0.2" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
         <PackageReference Include="xunit" Version="2.6.5" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-2888](https://algolia.atlassian.net/browse/DI-2888). closes https://github.com/algolia/algoliasearch-client-csharp/issues/864

Added all the helpers to the search interface, and cleaned up the documentation by using `inheritdoc`.

Also fix all the warnings, such as missing doc or vulnerable lib:
<img width="143" alt="Screenshot 2024-09-06 at 09 03 13" src="https://github.com/user-attachments/assets/843ead0f-9390-4f1f-8b70-17156efcc9a5">


[DI-2888]: https://algolia.atlassian.net/browse/DI-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ