### PR TITLE
fix(javascript): assert helpers and fix setClientApiKey helper

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.browser.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.browser.test.ts
@@ -20,6 +20,18 @@ describe('api', () => {
 
   it('provides a `clearCache` method', () => {
     expect(client.clearCache).not.toBeUndefined();
+    expect(() => client.clearCache()).not.toThrow();
+  });
+
+  it('provides a `setClientApiKey` method', () => {
+      const _client = algoliasearch('foo', 'bar', {
+        requester: echoRequester(),
+      });
+
+    expect(_client.transporter.baseQueryParameters['x-algolia-api-key']).toEqual('bar')
+    expect(_client.setClientApiKey).not.toBeUndefined();
+    _client.setClientApiKey({apiKey:'tabac'})
+    expect(_client.transporter.baseQueryParameters['x-algolia-api-key']).toEqual('tabac')
   });
 
   it('sets the user agent', async () => {

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
@@ -20,6 +20,18 @@ describe('api', () => {
 
   it('provides a `clearCache` method', () => {
     expect(client.clearCache).not.toBeUndefined();
+    expect(() => client.clearCache()).not.toThrow();
+  });
+
+  it('provides a `setClientApiKey` method', () => {
+      const _client = algoliasearch('foo', 'bar', {
+        requester: echoRequester(),
+      });
+
+    expect(_client.transporter.baseHeaders['x-algolia-api-key']).toEqual('bar')
+    expect(_client.setClientApiKey).not.toBeUndefined();
+    _client.setClientApiKey({apiKey:'tabac'})
+    expect(_client.transporter.baseHeaders['x-algolia-api-key']).toEqual('tabac')
   });
 
   it('sets the user agent', async () => {

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -81,7 +81,7 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
      * @param params.apiKey - The new API Key to use.
      */
     setClientApiKey({ apiKey }: { apiKey: string }): void {
-      if (!authMode || authMode == 'WithinHeaders') {
+      if (!authMode || authMode === 'WithinHeaders') {
         this.transporter.baseHeaders['x-algolia-api-key'] = apiKey;
       } else {
         this.transporter.baseQueryParameters['x-algolia-api-key'] = apiKey;

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -75,13 +75,17 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
     },
 
     /**
-    * Helper method to switch the API key used to authenticate the requests.
-    *
-    * @param params - Method params.
-    * @param params.apiKey - The new API Key to use.
-    */
+     * Helper method to switch the API key used to authenticate the requests.
+     *
+     * @param params - Method params.
+     * @param params.apiKey - The new API Key to use.
+     */
     setClientApiKey({ apiKey }: { apiKey: string }): void {
-      this.transporter.baseHeaders['x-algolia-api-key'] = apiKey;
+      if (!authMode || authMode == 'WithinHeaders') {
+        this.transporter.baseHeaders['x-algolia-api-key'] = apiKey;
+      } else {
+        this.transporter.baseQueryParameters['x-algolia-api-key'] = apiKey;
+      }
     },
 
     {{#isSearchClient}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2894

### Changes included:

asserts the inherited helpers from search client and reflect different auth modes for the `setClientApiKey` helper