### PR TITLE
fix(javascript): use transporter directly

### DIFF
--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -36,13 +36,15 @@ export function algoliasearch(appId: string, apiKey: string, options?: ClientOpt
     throw new Error('`apiKey` is missing.');
   }
 
+  const searchClient = searchClient(appId, apiKey, options);
+
   return {
-    ...searchClient(appId, apiKey, options),
+    ...searchClient,
     /**
      * Get the value of the `algoliaAgent`, used by our libraries internally and telemetry system.
      */
     get _ua(): string {
-      return this.transporter.algoliaAgent.value;
+      return searchClient.transporter.algoliaAgent.value;
     },
     initRecommend: (initOptions: InitClientOptions = {}): RecommendClient => {
       return recommendClient(initOptions.appId || appId, initOptions.apiKey || apiKey, initOptions.options);

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -21,26 +21,27 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
     ...options
   }: CreateClientOptions{{#hasRegionalHost}} & {region{{#fallbackToAliasHost}}?{{/fallbackToAliasHost}}: Region }{{/hasRegionalHost}}) {
   const auth = createAuth(appIdOption, apiKeyOption, authMode);
+  const transporter = createTransporter({
+    hosts: getDefaultHosts({{#hostWithAppID}}appIdOption{{/hostWithAppID}}{{#hasRegionalHost}}regionOption{{/hasRegionalHost}}),
+    ...options,
+    algoliaAgent: getAlgoliaAgent({
+      algoliaAgents,
+      client: '{{{algoliaAgent}}}',
+      version: apiClientVersion,
+    }),
+    baseHeaders: {
+      'content-type': 'text/plain',
+      ...auth.headers(),
+      ...options.baseHeaders,
+    },
+    baseQueryParameters: {
+      ...auth.queryParameters(),
+      ...options.baseQueryParameters,
+    },
+  });
 
   return {
-    transporter: createTransporter({
-      hosts: getDefaultHosts({{#hostWithAppID}}appIdOption{{/hostWithAppID}}{{#hasRegionalHost}}regionOption{{/hasRegionalHost}}),
-      ...options,
-      algoliaAgent: getAlgoliaAgent({
-        algoliaAgents,
-        client: '{{{algoliaAgent}}}',
-        version: apiClientVersion,
-      }),
-      baseHeaders: {
-        'content-type': 'text/plain',
-        ...auth.headers(),
-        ...options.baseHeaders,
-      },
-      baseQueryParameters: {
-        ...auth.queryParameters(),
-        ...options.baseQueryParameters,
-      },
-    }),
+    transporter,
 
     /**
      * The `appId` currently in use.
@@ -52,8 +53,8 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
      */
     clearCache(): Promise<void> {
       return Promise.all([
-        this.transporter.requestsCache.clear(),
-        this.transporter.responsesCache.clear(),
+        transporter.requestsCache.clear(),
+        transporter.responsesCache.clear(),
       ]).then(() => undefined);
     },
 
@@ -61,7 +62,7 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
      * Get the value of the `algoliaAgent`, used by our libraries internally and telemetry system.
      */
     get _ua(): string {
-      return this.transporter.algoliaAgent.value;
+      return transporter.algoliaAgent.value;
     },
 
     /**
@@ -71,7 +72,7 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
      * @param version - The version of the agent.
      */
     addAlgoliaAgent(segment: string, version?: string): void {
-      this.transporter.algoliaAgent.add({ segment, version });
+      transporter.algoliaAgent.add({ segment, version });
     },
 
     /**
@@ -82,9 +83,9 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
      */
     setClientApiKey({ apiKey }: { apiKey: string }): void {
       if (!authMode || authMode === 'WithinHeaders') {
-        this.transporter.baseHeaders['x-algolia-api-key'] = apiKey;
+        transporter.baseHeaders['x-algolia-api-key'] = apiKey;
       } else {
-        this.transporter.baseQueryParameters['x-algolia-api-key'] = apiKey;
+        transporter.baseQueryParameters['x-algolia-api-key'] = apiKey;
       }
     },
 
@@ -156,7 +157,7 @@ export function create{{#lambda.titlecase}}{{apiName}}{{/lambda.titlecase}}({
         {{/vendorExtensions}}
       };
 
-      return this.transporter.request(request, requestOptions);
+      return transporter.request(request, requestOptions);
     },
 
     {{/operation}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

using `this` forces is to bind the client, we can avoid it by directly using the transporter