### PR TITLE
feat(specs): add (optional) _automaticInsights to search result

### DIFF
--- a/specs/common/schemas/SearchResponse.yml
+++ b/specs/common/schemas/SearchResponse.yml
@@ -146,6 +146,9 @@ baseSearchResponse:
       type: string
       description: Unique identifier for the query. This is used for [click analytics](https://www.algolia.com/doc/guides/analytics/click-analytics/).
       example: 'a00dbc80a8d13c4565a442e7e2dca80a'
+    _automaticInsights:
+      type: boolean
+      description: Whether automatic events collection is enabled for the application.
 
 nbHits:
   type: integer


### PR DESCRIPTION
## 🧭 What and Why

Return the parameter `_automaticInsights` (when possible) when calling search.


# Why 

I need this value in the Recommend mono-repository so that the Recommend API can forward this parameter to the Recommend client.