### PR TITLE
Changed x-use-read-transporter for searchSingleIndex

### DIFF
--- a/specs/search/paths/search/searchSingleIndex.yml
+++ b/specs/search/paths/search/searchSingleIndex.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - Search
   operationId: searchSingleIndex
-  x-use-read-transporter: true
+  x-use-read-transporter: false
   x-cacheable: true
   x-acl:
     - search


### PR DESCRIPTION
Changed x-use-read-transporter for searchSingleIndex, the reason behind that is to be able to pass body when querying single index with filters

Closes https://github.com/algolia/api-clients-automation/issues/3698

## 🧭 What and Why

TBH I'm not 100% this the correct approach to the issue I've created (https://github.com/algolia/api-clients-automation/issues/3698) but it does the job when I set the filters in body attribute which was the case before v4

```
$searchResponse = $client->searchSingleIndex(
    indexName: $indexName,
    searchParams: ['query' => ''],
    requestOptions: [
        'body' => [
            'filters' => 'value=1',
        ],
    ],
);
```

🎟 JIRA Ticket:

### Changes included:

- List changes

## 🧪 Test
