### PR TITLE
fix(javascript): umd export name

### DIFF
--- a/templates/javascript/clients/rollup.config.mustache
+++ b/templates/javascript/clients/rollup.config.mustache
@@ -6,10 +6,10 @@ export default [
       esModule: false,
       file: 'dist/{{#isAlgoliasearchClient}}lite/{{/isAlgoliasearchClient}}builds/browser.umd.js',
       {{#isAlgoliasearchClient}}
-      name: 'lite',
+      name: 'algoliasearch/lite',
       {{/isAlgoliasearchClient}}
       {{^isAlgoliasearchClient}}
-      name: '{{apiName}}',
+      name: '@algolia/{{packageName}}',
       {{/isAlgoliasearchClient}}
       format: 'umd',
       sourcemap: false,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2909

### Changes included:

close https://github.com/algolia/api-clients-automation/issues/3700

see context here https://github.com/algolia/api-clients-automation/issues/3700

the tsup build changed the exported global name on `window`, previously exposed `window['algoliasearch/lite']` changed to `window.lite`, which is incorrect, and a breaking change.

we now provide the previous names