### PR TITLE
fix(specs): update search api specs [skip-bc]

### DIFF
--- a/specs/common/schemas/HighlightResult.yml
+++ b/specs/common/schemas/HighlightResult.yml
@@ -34,25 +34,11 @@ matchLevel:
   description: Whether the whole query string matches or only a part.
   enum: [none, partial, full]
 
-highlightResultOptionMap:
-  type: object
-  description: Surround words that match the query with HTML tags for highlighting.
-  additionalProperties:
-    x-additionalPropertiesName: attribute
-    $ref: '#/highlightResultOption'
-
-highlightResultOptionArray:
+highlightResultArray:
   type: array
   description: Surround words that match the query with HTML tags for highlighting.
   items:
-    $ref: '#/highlightResultOption'
-
-highlightResult:
-  oneOf:
-    - $ref: '#/highlightResultMap'
-    - $ref: '#/highlightResultOption'
-    - $ref: '#/highlightResultOptionMap'
-    - $ref: '#/highlightResultOptionArray'
+    $ref: '#/highlightResult'
 
 highlightResultMap:
   type: object
@@ -60,3 +46,9 @@ highlightResultMap:
   additionalProperties:
     x-additionalPropertiesName: attribute
     $ref: '#/highlightResult'
+
+highlightResult:
+  oneOf:
+    - $ref: '#/highlightResultOption'
+    - $ref: '#/highlightResultMap'
+    - $ref: '#/highlightResultArray'

--- a/specs/common/schemas/SearchResponse.yml
+++ b/specs/common/schemas/SearchResponse.yml
@@ -208,8 +208,3 @@ SearchPagination:
       $ref: '#/nbPages'
     hitsPerPage:
       $ref: './IndexSettings.yml#/hitsPerPage'
-  required:
-    - page
-    - nbHits
-    - nbPages
-    - hitsPerPage

--- a/specs/common/schemas/SnippetResult.yml
+++ b/specs/common/schemas/SnippetResult.yml
@@ -13,29 +13,21 @@ snippetResultOption:
   x-discriminator-fields:
     - matchLevel
 
-snippetResultOptionMap:
-  type: object
-  description: Snippets that show the context around a matching search query.
-  additionalProperties:
-    x-additionalPropertiesName: attribute
-    $ref: '#/snippetResultOption'
-
-snippetResultOptionArray:
-  type: array
-  description: Snippets that show the context around a matching search query.
-  items:
-    $ref: '#/snippetResultOption'
-
-snippetResult:
-  oneOf:
-    - $ref: '#/snippetResultMap'
-    - $ref: '#/snippetResultOption'
-    - $ref: '#/snippetResultOptionMap'
-    - $ref: '#/snippetResultOptionArray'
-
 snippetResultMap:
   type: object
   description: Snippets that show the context around a matching search query.
   additionalProperties:
     x-additionalPropertiesName: attribute
     $ref: '#/snippetResult'
+
+snippetResultArray:
+  type: array
+  description: Snippets that show the context around a matching search query.
+  items:
+    $ref: '#/snippetResult'
+
+snippetResult:
+  oneOf:
+    - $ref: '#/snippetResultOption'
+    - $ref: '#/snippetResultMap'
+    - $ref: '#/snippetResultArray'


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-2912] & closes [#425](https://github.com/algolia/algoliasearch-client-kotlin/issues/425)

### Changes included:

- Makes search response pagination props optional
- Fixes recursive spec for `highlightResult` and `snippetResult`

[DI-2912]: https://algolia.atlassian.net/browse/DI-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ