### PR TITLE
 fix(javascript): react-native lite resolution

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -18,6 +18,7 @@
     },
     "./src/*": "./src/*.ts"
   },
+  "react-native": "./dist/requester.xhr.js",
   "files": [
     "dist",
     "src",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -34,6 +34,7 @@
     },
     "./src/*": "./src/*.ts"
   },
+  "react-native": "./dist/requester.fetch.browser.js",
   "files": [
     "dist",
     "src",

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -106,7 +106,10 @@
   },
   "jsdelivr": "./dist/algoliasearch.umd.js",
   "unpkg": "./dist/algoliasearch.umd.js",
-  "react-native": "./dist/browser.js",
+  "react-native": {
+    ".": "./dist/browser.js",
+    "./lite": "./dist/lite/builds/browser.js"
+  },
   "files": [
     "dist",
     "builds",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2948

### Changes included:

fixes https://github.com/algolia/algoliasearch-client-javascript/issues/1554#issuecomment-2358671330

the lite package also needs to have an entry point in the `react-native` field.

this object syntax is supported for every fields normally, so I hope it also works for react native

also adds the `react-native` field for the browser-xhr and fetch requester