### PR TITLE
fix(clients): use the dsn with the read transporter

### DIFF
--- a/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/internal/HttpRequester.java
+++ b/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/internal/HttpRequester.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import okhttp3.*;
 import okhttp3.internal.http.HttpMethod;
 import okio.BufferedSink;
+import com.algolia.utils.UseReadTransporter;
 
 /**
  * HttpRequester is responsible for making HTTP requests using the OkHttp client. It provides a
@@ -72,7 +73,12 @@ public final class HttpRequester implements Requester {
     RequestBody requestBody = createRequestBody(httpRequest);
 
     // Build the HTTP request.
-    Request request = new Request.Builder().url(url).headers(headers).method(httpRequest.getMethod(), requestBody).build();
+    Request.Builder requestBuilder = new Request.Builder().url(url).headers(headers).method(httpRequest.getMethod(), requestBody);
+    if (httpRequest.isRead()) {
+      requestBuilder.tag(new UseReadTransporter());
+    }
+    
+    Request request = requestBuilder.build();
 
     // Get or adjust the HTTP client according to request options.
     OkHttpClient client = getOkHttpClient(requestOptions);

--- a/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/internal/HttpRequester.scala
+++ b/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/internal/HttpRequester.scala
@@ -4,6 +4,7 @@ import algoliasearch.config._
 import algoliasearch.exception.{AlgoliaApiException, AlgoliaClientException}
 import algoliasearch.internal.interceptor.{GzipRequestInterceptor, HeaderInterceptor, LogInterceptor}
 import algoliasearch.internal.util.escape
+import algoliasearch.internal.util.UseReadTransporter
 import okhttp3._
 import okhttp3.internal.http.HttpMethod
 import okio.BufferedSink
@@ -140,11 +141,12 @@ private[algoliasearch] class HttpRequester private (
     val headers = createHeaders(httpRequest, requestOptions)
     val requestBody = createRequestBody(httpRequest)
     // Build the HTTP request.
-    val request = new Request.Builder()
+    val requestBuilder = new Request.Builder()
       .url(url)
       .headers(headers)
       .method(httpRequest.method, requestBody)
-      .build
+    if (httpRequest.read) requestBuilder.tag(UseReadTransporter)
+    val request = requestBuilder.build
     // Get or adjust the HTTP client according to request options.
     val client = okHttpClient(requestOptions)
     // Execute the request.

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -85,9 +85,9 @@ public class {{classname}} extends ApiClient {
       hosts.add(new Host(appId + ".algolia.net", EnumSet.of(CallType.WRITE)));
 
       List<Host> commonHosts = new ArrayList<>();
-      hosts.add(new Host(appId + "-1.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
-      hosts.add(new Host(appId + "-2.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
-      hosts.add(new Host(appId + "-3.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-1.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-2.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-3.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
 
       Collections.shuffle(commonHosts, new Random());
 

--- a/tests/CTS/client/search/api.json
+++ b/tests/CTS/client/search/api.json
@@ -24,6 +24,30 @@
     ]
   },
   {
+    "testName": "read transporter with POST method",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key"
+        }
+      },
+      {
+        "type": "method",
+        "method": "searchSingleIndex",
+        "parameters": {
+          "indexName": "indexName"
+        },
+        "expected": {
+          "type": "host",
+          "match": "test-app-id-dsn.algolia.net"
+        }
+      }
+    ]
+  },
+  {
     "testName": "calls api with correct write host",
     "autoCreateClient": false,
     "steps": [


### PR DESCRIPTION
## 🧭 What and Why

The java search client is not using the read transporter at all.