### PR TITLE
fix(javascript): add override to name property

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -1,7 +1,7 @@
 import type { Response, StackFrame } from '../types';
 
 export class AlgoliaError extends Error {
-  name: string = 'AlgoliaError';
+  override name: string = 'AlgoliaError';
 
   constructor(message: string, name: string) {
     super(message);

--- a/clients/algoliasearch-client-javascript/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "noImplicitOverride": true,
     "noLib": false,
     "noUnusedLocals": true,
     "outDir": "dist",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

imported from https://github.com/algolia/algoliasearch-client-javascript/pull/1552

----

When using this library with the newest angular version (v18.2.2), the following error will be thrown.

You can "fix" the issue by using `noImplicitOverride: false` in the `tsconfig`, but I guess it would make sense to fix it here...

```
✖ Compiling with Angular sources in Ivy partial compilation mode.
node_modules/@algolia/client-common/src/transporter/errors.ts:4:3 - error TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'Error'.

4   name: string = 'AlgoliaError';
   ```

This PR adds the missing `override` property and should fix this issue.