### PR TITLE
fix(clients): use the correct host for search

### DIFF
--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -85,9 +85,9 @@ public class {{classname}} extends ApiClient {
       hosts.add(new Host(appId + ".algolia.net", EnumSet.of(CallType.WRITE)));
 
       List<Host> commonHosts = new ArrayList<>();
-      commonHosts.add(new Host(appId + "-1.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
-      commonHosts.add(new Host(appId + "-2.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
-      commonHosts.add(new Host(appId + "-3.algolianet.net", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-1.algolianet.com", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-2.algolianet.com", EnumSet.of(CallType.READ, CallType.WRITE)));
+      commonHosts.add(new Host(appId + "-3.algolianet.com", EnumSet.of(CallType.READ, CallType.WRITE)));
 
       Collections.shuffle(commonHosts, new Random());
 

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -64,9 +64,9 @@ object {{classname}} {
   private def hosts(appId: String): Seq[Host] = {
     val commonHosts = Random.shuffle(
       List(
-        Host(appId + "-1.algolianet.net", Set(CallType.Read, CallType.Write)),
-        Host(appId + "-2.algolianet.net", Set(CallType.Read, CallType.Write)),
-        Host(appId + "-3.algolianet.net", Set(CallType.Read, CallType.Write))
+        Host(appId + "-1.algolianet.com", Set(CallType.Read, CallType.Write)),
+        Host(appId + "-2.algolianet.com", Set(CallType.Read, CallType.Write)),
+        Host(appId + "-3.algolianet.com", Set(CallType.Read, CallType.Write))
       )
     )
     List(


### PR DESCRIPTION
## 🧭 What and Why

The host for the retry stategy should end in .com