### PR TITLE
chore(ci): add a workflow to push to Algolia doc

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -72,6 +72,14 @@ module.exports = {
       ],
     },
     {
+      // actions yml linter
+      files: ['.github/**/*.yml'],
+
+      rules: {
+        'yml/no-empty-mapping-value': 0,
+      },
+    },
+    {
       // es linter
       files: ['*.ts', '*.js'],
 

--- a/.github/workflows/push-to-algolia-doc.yml
+++ b/.github/workflows/push-to-algolia-doc.yml
@@ -1,11 +1,6 @@
 name: Push specs and snippets to Algolia doc
 
-on:
-  workflow_dispatch:
-    inputs:
-      fake_input:
-        description: input needed to satisfy the yaml linter
-        required: false
+on: workflow_dispatch
 
 jobs:
   release:
@@ -23,6 +18,7 @@ jobs:
         with:
           type: minimal
 
-      - run: FORCE=true yarn workspace scripts pushToAlgoliaDoc
+      - run: yarn workspace scripts pushToAlgoliaDoc
         env:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+          FORCE: true

--- a/.github/workflows/push-to-algolia-doc.yml
+++ b/.github/workflows/push-to-algolia-doc.yml
@@ -1,0 +1,28 @@
+name: Push specs and snippets to Algolia doc
+
+on:
+  workflow_dispatch:
+    inputs:
+      fake_input:
+        description: input needed to satisfy the yaml linter
+        required: false
+
+jobs:
+  release:
+    name: Scheduled Release
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup
+        id: setup
+        uses: ./.github/actions/setup
+        with:
+          type: minimal
+
+      - run: FORCE=true yarn workspace scripts pushToAlgoliaDoc
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron: '0 14 * * 5' # At 14:00 on Friday.
   workflow_dispatch:
-    inputs:
-      fake_input:
-        description: input needed to satisfy the yaml linter
-        required: false
 
 jobs:
   renovate:

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron: '30 6 * * 2'
   workflow_dispatch:
-    inputs:
-      fake_input:
-        description: input needed to satisfy the yaml linter
-        required: false
 
 jobs:
   release:

--- a/scripts/ci/codegen/pushToAlgoliaDoc.ts
+++ b/scripts/ci/codegen/pushToAlgoliaDoc.ts
@@ -28,7 +28,7 @@ async function pushToAlgoliaDoc(): Promise<void> {
     .map((coAuthor) => coAuthor.trim())
     .filter(Boolean);
 
-  if (!process.env.DRY_RUN && !lastCommitMessage.startsWith(commitStartRelease)) {
+  if (!process.env.FORCE && !lastCommitMessage.startsWith(commitStartRelease)) {
     return;
   }
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-2969

### Changes included:

add a simple action to be able to manually trigger the push to algolia doc script, so that we don't have to setup a github token nor know how to run the script