### PR TITLE
fix(specs): API key description will be obfuscated

### DIFF
--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -7,7 +7,8 @@ get:
     Gets the permissions and restrictions of an API key.
 
     When authenticating with the admin API key, you can request information for any of your application's keys.
-    When authenticating with other API keys, you can only retrieve information for that key.
+    When authenticating with other API keys, you can only retrieve information for that key,
+    with the description replaced by `<redacted>`.
   parameters:
     - $ref: 'common/parameters.yml#/KeyString'
   responses:


### PR DESCRIPTION
## 🧭 What and Why

Update the description for the 'Get API key' operation.
API key description will be obfuscated if using a non-admin API key.
This is a port from a change made in the docs repo. More information in https://github.com/algolia/doc/pull/9412