### PR TITLE
feat(templates): add request_options to python helpers consistently

### DIFF
--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -244,32 +244,35 @@
         self,
         index_name: str,
         objects: List[Dict[str, Any]],
+        request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> List[BatchResponse]:
         """
         Helper: Saves the given array of objects in the given index. The `chunked_batch` helper is used under the hood, which creates a `batch` requests with at most 1000 objects in it.
         """
-        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.ADDOBJECT)
+        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.ADDOBJECT, request_options=request_options)
 
     {{^isSyncClient}}async {{/isSyncClient}}def delete_objects(
         self,
         index_name: str,
         object_ids: List[str],
+        request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> List[BatchResponse]:
         """
         Helper: Deletes every records for the given objectIDs. The `chunked_batch` helper is used under the hood, which creates a `batch` requests with at most 1000 objectIDs in it.
         """
-        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=[{"objectID": id} for id in object_ids], action=Action.DELETEOBJECT)
+        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=[{"objectID": id} for id in object_ids], action=Action.DELETEOBJECT, request_options=request_options)
 
     {{^isSyncClient}}async {{/isSyncClient}}def partial_update_objects(
         self,
         index_name: str,
         objects: List[Dict[str, Any]],
         create_if_not_exists: Optional[bool] = False,
+        request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> List[BatchResponse]:
         """
         Helper: Replaces object content of all the given objects according to their respective `objectID` field. The `chunked_batch` helper is used under the hood, which creates a `batch` requests with at most 1000 objects in it.
         """
-        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.PARTIALUPDATEOBJECT if create_if_not_exists else Action.PARTIALUPDATEOBJECTNOCREATE)
+        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.PARTIALUPDATEOBJECT if create_if_not_exists else Action.PARTIALUPDATEOBJECTNOCREATE, request_options=request_options)
 
     {{^isSyncClient}}async {{/isSyncClient}}def chunked_batch(
         self,

--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -194,7 +194,7 @@
     {{^isSyncClient}}async {{/isSyncClient}}def generate_secured_api_key(
         self,
         parent_api_key: str,
-        restrictions: Optional[SecuredApiKeyRestrictions] = SecuredApiKeyRestrictions(),
+        restrictions: Optional[Union[dict, SecuredApiKeyRestrictions]] = SecuredApiKeyRestrictions(),
     ) -> str:
         """
         Helper: Generates a secured API key based on the given `parent_api_key` and given `restrictions`.


### PR DESCRIPTION
## 🧭 What and Why

Make the Python helpers more consistent by supporting `request_options` for all helpers
that are based on `chunked_batch`.

### Changes included:

Add `request_options` to the following helpers:

- `save_objects`
- `delete_objects`
- `partial_update_objects`

The rest of them already work with `request_options`.

Also provide `dict` as accepted type for API key restrictions in `generate_secured_api_key`, since the function already handles that case.