### PR TITLE
feat(swift): guide gen

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/guides/GuidesGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/guides/GuidesGenerator.java
@@ -39,11 +39,14 @@ public class GuidesGenerator extends TestsGenerator {
 
     File templates = new File("templates/" + language + "/guides/" + client);
     for (File f : templates.listFiles()) {
+      String fileName = f.getName().replace(".mustache", "");
+
+      if (language.equals("swift")) {
+        fileName = Helpers.capitalize(fileName) + "/main";
+      }
+
       supportingFiles.add(
-        new SupportingFile(
-          "guides/" + client + "/" + f.getName(),
-          "guides/" + language + outputFolder + f.getName().replace(".mustache", "") + extension
-        )
+        new SupportingFile("guides/" + client + "/" + f.getName(), "guides/" + language + outputFolder + fileName + extension)
       );
     }
   }
@@ -54,6 +57,14 @@ public class GuidesGenerator extends TestsGenerator {
       bundle.put("isSearchClient", true);
     }
     bundle.put("isSyncClient", true);
-    // nothing to do here, the mustache uses dynamicSnippets lambda
+
+    if (language.equals("swift")) {
+      File templates = new File("templates/" + language + "/guides/" + client);
+      bundle.put(
+        "guides",
+        Arrays.stream(templates.listFiles()).map(File::getName).map(name -> Helpers.capitalize(name.replace(".mustache", ""))).toArray()
+      );
+    }
+    // no data to add to the bundle, the mustache uses dynamicSnippets lambda
   }
 }

--- a/templates/swift/guides/Package.mustache
+++ b/templates/swift/guides/Package.mustache
@@ -3,6 +3,13 @@
 
 import PackageDescription
 
+let dependencies: [Target.Dependency] = [{{#packageList}}
+  .product(
+    name: "{{{.}}}",
+    package: "algoliasearch-client-swift"
+  ),{{/packageList}}
+]
+
 let package = Package(
   name: "AlgoliaSearchClientGuides",
   platforms: [
@@ -15,14 +22,12 @@ let package = Package(
       .package(path: "../../clients/algoliasearch-client-swift")
   ],
   targets: [
-    .executableTarget(
-      name: "AlgoliaSearchClientGuides",
-      dependencies: [{{#packageList}}
-        .product(
-          name: "{{{.}}}",
-          package: "algoliasearch-client-swift"
-        ),{{/packageList}}
-      ]
-    )
+    {{#guides}}
+      .executableTarget(
+        name: "{{{.}}}",
+        dependencies: dependencies,
+        path: "Sources/{{{.}}}"
+      ),
+    {{/guides}}
   ]
 )

--- a/templates/swift/guides/search/saveObjectsMovies.mustache
+++ b/templates/swift/guides/search/saveObjectsMovies.mustache
@@ -6,7 +6,7 @@ import Foundation
 import Core
 {{> snippets/import}}
 
-func saveObjectsMovies() async throws {
+Task {
     let url = URL(string: "https://dashboard.algolia.com/sample_datasets/movie.json")!
     var data: Data? = nil
     #if os(Linux) // For linux interop
@@ -22,7 +22,11 @@ func saveObjectsMovies() async throws {
     do {
         // Save records in Algolia index
         {{#dynamicSnippet}}saveObjectsMovies{{/dynamicSnippet}}
+        exit(EXIT_SUCCESS)
     } catch {
         print(error.localizedDescription)
+        exit(EXIT_FAILURE)
     }
 }
+
+RunLoop.current.run()


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

- one gen per guide template
- in its own folder
- with the guide name as a folder name
- the file name is always main.swift
- with a gen Package.swift with all the guides
- each has its own taget
- so it can build on macos and linux and be copy/pasted by users