### PR TITLE
fix(specs): correct typos is Search API

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -531,6 +531,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: git push -d origin generated/${{ github.head_ref }} || true
+      - run: git push -d origin "generated/${{ github.head_ref }}" || true

--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -29,7 +29,7 @@ baseIndexSettings:
         **Modifiers**
 
         - `filterOnly("ATTRIBUTE")`.
-          Allows using this attribute as a filter, but doesn't evalue the facet values.
+          Allows the attribute to be used as a filter but doesn't evaluate the facet values.
 
         - `searchable("ATTRIBUTE")`.
           Allows searching for facet values.
@@ -53,7 +53,7 @@ baseIndexSettings:
         If you want to offer a different ranking or sorting of your search results, you'll use replica indices.
         All index operations on a primary index are automatically forwarded to its replicas.
         To add a replica index, you must provide the complete set of replicas to this parameter.
-        If you omit a replica from this list, the replica turns into a regular, standalone index that will no longer by synced with the primary index.
+        If you omit a replica from this list, the replica turns into a regular, standalone index that will no longer be synced with the primary index.
 
         **Modifier**
 
@@ -196,7 +196,7 @@ baseIndexSettings:
         By default, all numeric attributes are available as numerical filters.
         For faster indexing, reduce the number of numeric attributes.
 
-        If you want to turn off filtering for all numeric attributes, specifiy an attribute that doesn't exist in your index, such as `NO_NUMERIC_FILTERING`.
+        To turn off filtering for all numeric attributes, specify an attribute that doesn't exist in your index, such as `NO_NUMERIC_FILTERING`.
 
         **Modifier**
 
@@ -246,7 +246,7 @@ baseIndexSettings:
         - `unordered("ATTRIBUTE")`.
           Ignore the position of a match within the attribute.
 
-        Without modifier, matches at the beginning of an attribute rank higer than matches at the end.
+        Without a modifier, matches at the beginning of an attribute rank higher than matches at the end.
       default: []
       x-categories:
         - Attributes
@@ -587,7 +587,7 @@ indexSettingsAsSearchParams:
 
         - If `optionalWords` has less than 10 words, the required number of matched words increases by 1:
           results 1 to 1,000 require 1 matched word, results 1,001 to 2000 need 2 matched words.
-        - If `optionalWords` has 10 or more words, the number of required matched words increases by the number of optional words dividied by 5 (rounded down).
+        - If `optionalWords` has 10 or more words, the number of required matched words increases by the number of optional words divided by 5 (rounded down).
           For example, with 18 optional words: results 1 to 1,000 require 1 matched word, results 1,001 to 2000 need 4 matched words.
 
         For more information, see [Optional words](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/empty-or-insufficient-results/#creating-a-list-of-optional-words).
@@ -604,7 +604,7 @@ indexSettingsAsSearchParams:
         Searchable attributes for which you want to [turn off the Exact ranking criterion](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/override-search-engine-defaults/in-depth/adjust-exact-settings/#turn-off-exact-for-some-attributes).
         Attribute names are case-sensitive.
 
-        This can be useful for attributes with long values, where the likelyhood of an exact match is high,
+        This can be useful for attributes with long values, where the likelihood of an exact match is high,
         such as product descriptions.
         Turning off the Exact ranking criterion for these attributes favors exact matching on other attributes.
         This reduces the impact of individual attributes with a lot of content on ranking.
@@ -663,7 +663,7 @@ indexSettingsAsSearchParams:
         and either "home" or "house" are highlighted.
 
         With `replaceSynonymsInHighlight` set to `true`, a search for `home` still matches the same records,
-        but all occurences of "house" are replaced by "home" in the highlighted response.
+        but all occurrences of "house" are replaced by "home" in the highlighted response.
       default: false
       x-categories:
         - Highlighting and Snippeting
@@ -802,7 +802,7 @@ queryType:
   description: |
     Determines if and how query words are interpreted as prefixes.
 
-    By default, only the last query word is treated as prefix (`prefixLast`).
+    By default, only the last query word is treated as a prefix (`prefixLast`).
     To turn off prefix search, use `prefixNone`.
     Avoid `prefixAll`, which treats all query words as prefixes.
     This might lead to counterintuitive results and makes your search slower.
@@ -925,7 +925,7 @@ typoTolerance:
   description: |
     Whether [typo tolerance](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/typo-tolerance/) is enabled and how it is applied.
 
-    If typo tolerance is true, `min`, or `strict`, [word splitting and concetenation](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/handling-natural-languages-nlp/in-depth/splitting-and-concatenation/) is also active.
+    If typo tolerance is true, `min`, or `strict`, [word splitting and concatenation](https://www.algolia.com/doc/guides/managing-results/optimize-search-results/handling-natural-languages-nlp/in-depth/splitting-and-concatenation/) are also active.
   oneOf:
     - type: boolean
       default: true
@@ -992,7 +992,7 @@ renderingContent:
   description: |
     Extra data that can be used in the search UI.
 
-    You can use this to control aspects of your search UI, such as, the order of facet names and values
+    You can use this to control aspects of your search UI, such as the order of facet names and values
     without changing your frontend code.
   type: object
   additionalProperties: false

--- a/specs/common/schemas/SearchParams.yml
+++ b/specs/common/schemas/SearchParams.yml
@@ -321,7 +321,7 @@ aroundLatLng:
   description: |
     Coordinates for the center of a circle, expressed as a comma-separated string of latitude and longitude.
 
-    Only records included within circle around this central location are included in the results.
+    Only records included within a circle around this central location are included in the results.
     The radius of the circle is determined by the `aroundRadius` and `minimumAroundRadius` settings.
     This parameter is ignored if you also specify `insidePolygon` or `insideBoundingBox`.
   example: '40.71,-74.01'
@@ -455,7 +455,8 @@ numericFilters:
 
     **Prefer using the `filters` parameter, which supports all filter types and combinations with boolean operators.**
 
-    You can use numeric comparison operators: `<`, `<=`, `=`, `!=`, `>`, `>=`. Comparsions are precise up to 3 decimals.
+    You can use numeric comparison operators: `<`, `<=`, `=`, `!=`, `>`, `>=`.
+    Comparisons are precise up to 3 decimals.
     You can also provide ranges: `facet:<lower> TO <upper>`. The range includes the lower and upper boundaries.
     The same combination rules apply as for `facetFilters`.
   example: [['inStock = 1', 'deliveryDate < 1441755506'], 'price < 1000']

--- a/specs/search/paths/keys/common/schemas.yml
+++ b/specs/search/paths/keys/common/schemas.yml
@@ -59,7 +59,7 @@ apiKey:
         To restrict this API key to specific IP addresses, add the `restrictSources` parameter.
         You can only add a single source, but you can provide a range of IP addresses.
 
-        Creating an API key fails if the request is made from an IP address that's outside the restricted range.
+        Creating an API key fails if the request is made from an IP address outside the restricted range.
       example: 'typoTolerance=strict&restrictSources=192.168.1.0/24'
       default: ''
     referers:

--- a/specs/search/paths/manage_indices/operationIndex.yml
+++ b/specs/search/paths/manage_indices/operationIndex.yml
@@ -23,7 +23,7 @@ post:
     **Move**
 
     - Moving a source index that doesn't exist is ignored without returning an error.
-    - When moving an index, the analytics data keep their original name and a new set of analytics data is started for the new name.
+    - When moving an index, the analytics data keeps its original name, and a new set of analytics data is started for the new name.
       To access the original analytics in the dashboard, create an index with the original name.
     - If the destination index has replicas, moving will overwrite the existing index and copy the data to the replica indices.
     - Related guide: [Move indices](https://www.algolia.com/doc/guides/sending-and-managing-data/manage-indices-and-apps/manage-indices/how-to/move-indices/).

--- a/specs/search/paths/objects/object.yml
+++ b/specs/search/paths/objects/object.yml
@@ -62,7 +62,7 @@ put:
     - $ref: '../../../common/parameters.yml#/ObjectID'
   requestBody:
     required: true
-    description: The record, a schemaless object with attributes that are useful in the context of search and discovery.
+    description: The record. A schemaless object with attributes that are useful in the context of search and discovery.
     content:
       application/json:
         schema:

--- a/specs/search/paths/objects/objects.yml
+++ b/specs/search/paths/objects/objects.yml
@@ -19,7 +19,7 @@ post:
     - $ref: '../../../common/parameters.yml#/IndexName'
   requestBody:
     required: true
-    description: The record, a schemaless object with attributes that are useful in the context of search and discovery.
+    description: The record. A schemaless object with attributes that are useful in the context of search and discovery.
     content:
       application/json:
         schema:

--- a/specs/search/paths/objects/partialUpdate.yml
+++ b/specs/search/paths/objects/partialUpdate.yml
@@ -7,7 +7,7 @@ post:
   summary: Add or update attributes
   x-codegen-request-body-name: attributesToUpdate
   description: |
-    Adds new attributes to a record, or update existing ones.
+    Adds new attributes to a record, or updates existing ones.
 
     - If a record with the specified object ID doesn't exist,
       a new record is added to the index **if** `createIfNotExists` is true.
@@ -23,7 +23,7 @@ post:
     - Remove: remove all matching number or string elements from an array attribute made of numbers or strings
     - AddUnique: add a number or string element to an array attribute made of numbers or strings only if it's not already present
     - IncrementFrom: increment a numeric integer attribute only if the provided value matches the current value, and otherwise ignore the whole object update. For example, if you pass an IncrementFrom value of 2 for the version attribute, but the current value of the attribute is 1, the engine ignores the update. If the object doesn't exist, the engine only creates it if you pass an IncrementFrom value of 0.
-    - IncrementSet: increment a numeric integer attribute only if the provided value is greater than the current value, and otherwise ignore the whole object update. For example, if you pass an IncrementSet value of 2 for the version attribute, and the current value of the attribute is 1, the engine updates the object. If the object doesn't exist yet, the engine only creates it if you pass an IncrementSet value that's greater than 0.
+    - IncrementSet: increment a numeric integer attribute only if the provided value is greater than the current value, and otherwise ignore the whole object update. For example, if you pass an IncrementSet value of 2 for the version attribute, and the current value of the attribute is 1, the engine updates the object. If the object doesn't exist yet, the engine only creates it if you pass an IncrementSet value greater than 0.
 
     You can specify an operation by providing an object with the attribute to update as the key and its value being an object with the following properties:
 

--- a/specs/search/paths/rules/common/schemas.yml
+++ b/specs/search/paths/rules/common/schemas.yml
@@ -69,12 +69,12 @@ anchoring:
   description: |
     Which part of the search query the pattern should match:
 
-    - `startsWith`. The pattern must match the begginning of the query.
+    - `startsWith`. The pattern must match the beginning of the query.
     - `endsWith`. The pattern must match the end of the query.
     - `is`. The pattern must match the query exactly.
     - `contains`. The pattern must match anywhere in the query.
 
-    Empty queries are only allowed as pattern with `anchoring: is`.
+    Empty queries are only allowed as patterns with `anchoring: is`.
   enum: [is, startsWith, endsWith, contains]
 
 consequence:

--- a/specs/search/paths/search/browse.yml
+++ b/specs/search/paths/search/browse.yml
@@ -28,7 +28,7 @@ post:
     - `getRankingInfo`: `false`
     - `ignorePlurals`: `false`
     - `optionalFilters`: `[]`
-    - `typoTolerance`: `true` or `false` (`min` and `strict` is evaluated to `true`)
+    - `typoTolerance`: `true` or `false` (`min` and `strict` evaluate to `true`)
 
     If you send these parameters with your browse requests, they'll be ignored.
   parameters:

--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -9,7 +9,7 @@ post:
     - search
   summary: Search multiple indices
   description: |
-    Sends multiple search request to one or more indices.
+    Sends multiple search requests to one or more indices.
 
     This can be useful in these cases:
 

--- a/specs/search/paths/search/searchSingleIndex.yml
+++ b/specs/search/paths/search/searchSingleIndex.yml
@@ -8,7 +8,7 @@ post:
     - search
   summary: Search an index
   description: |
-    Searches a single index and return matching search results (_hits_).
+    Searches a single index and returns matching search results (_hits_).
 
     This method lets you retrieve up to 1,000 hits.
     If you need more, use the [`browse` operation](#tag/Search/operation/browse) or increase the `paginatedLimitedTo` index setting.

--- a/specs/search/paths/synonyms/synonym.yml
+++ b/specs/search/paths/synonyms/synonym.yml
@@ -6,7 +6,7 @@ get:
     - settings
   summary: Retrieve a synonym
   description: |
-    Retrieves a syonym by its ID.
+    Retrieves a synonym by its ID.
     To find the object IDs for your synonyms,
     use the [`search` operation](#tag/Synonyms/operation/searchSynonyms).
   parameters:

--- a/specs/search/spec.yml
+++ b/specs/search/spec.yml
@@ -2,7 +2,7 @@ openapi: 3.0.2
 info:
   title: Search API
   description: |
-    The Algolia Search API lets you search, configure, and mange your indices and records.
+    The Algolia Search API lets you search, configure, and manage your indices and records.
 
     ## Client libraries
 
@@ -26,7 +26,7 @@ info:
 
     ## Retry strategy
 
-    To guarantee a high availability, implement a retry strategy for all API requests using the URLs of your servers as fallbacks:
+    To guarantee high availability, implement a retry strategy for all API requests using the URLs of your servers as fallbacks:
 
     - `https://{APPLICATION_ID}-1.algolianet.com`
     - `https://{APPLICATION_ID}-2.algolianet.com`
@@ -170,8 +170,8 @@ tags:
       Create, update, delete, and search for rules.
 
       Rules are _if-then_ statements that you can use to curate search results.
-      Rules have _conditions_ which can trigger _consequences_.
-      Consequences are changes to the search results, such as changing the order of search results, or boosting a facet.
+      Rules have _conditions_ that can trigger _consequences_.
+      Consequences are changes to the search results, such as changing the order of search results or boosting a facet.
       This can be useful for tuning specific queries or for merchandising.
     externalDocs:
       url: https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/


### PR DESCRIPTION
## 🧭 What and Why

Spotted a couple of typos when looking through the docs site output and decided to check for more.

### Changes included:

- Just fixing some typos in the search API descriptions
