### PR TITLE
fix(scripts): escape "double quotes"

### DIFF
--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -54,25 +54,22 @@ export async function pushGeneratedCode(): Promise<void> {
     return;
   }
 
-  const skipCi = isMainBranch ? '[skip ci]' : '';
-  let message = await run(`git show -s ${baseBranch} --format=%s ${text.commitEndMessage} ${skipCi}"`);
-  const authors = await run(
-    `git show -s ${baseBranch} --format="
+  let skipCi = '';
+  if (IS_RELEASE_COMMIT || isMainBranch) {
+    console.log('Processing release commit');
+    skipCi = '[skip ci]';
+  }
+
+  const commitMessage = await run(
+    `git show -s ${baseBranch} --format="%s ${text.commitEndMessage} ${skipCi}
 
 Co-authored-by: %an <%ae>
 %(trailers:key=Co-authored-by)"`,
   );
 
-  if (IS_RELEASE_COMMIT && isMainBranch) {
-    console.log('Processing release commit');
-    message = `${text.commitReleaseMessage} [skip ci]`;
-  }
-
-  message += authors;
-
   console.log(`Pushing code to generated branch: '${branchToPush}'`);
   await run('git add .');
-  await run(`git commit -m "${message}"`);
+  await run(`git commit -m "${commitMessage.replaceAll('"', '\\"')}"`);
   await run(`git push origin ${branchToPush}`);
 
   setOutput('GENERATED_COMMIT', await run('git rev-parse HEAD'));

--- a/scripts/ci/codegen/pushGeneratedCode.ts
+++ b/scripts/ci/codegen/pushGeneratedCode.ts
@@ -44,7 +44,7 @@ export async function pushGeneratedCode(): Promise<void> {
     await run(`git push -d origin generated/${baseBranch} || true`);
 
     console.log(`Creating branch for generated code: '${branchToPush}'`);
-    await run(`git checkout -b ${branchToPush}`);
+    await run(`git checkout -B ${branchToPush}`);
   }
 
   if (!(await isUpToDate(baseBranch))) {
@@ -55,7 +55,7 @@ export async function pushGeneratedCode(): Promise<void> {
   }
 
   const skipCi = isMainBranch ? '[skip ci]' : '';
-  let message = await run(`git show -s ${baseBranch} --format="%s ${text.commitEndMessage} ${skipCi}"`);
+  let message = await run(`git show -s ${baseBranch} --format=%s ${text.commitEndMessage} ${skipCi}"`);
   const authors = await run(
     `git show -s ${baseBranch} --format="
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

double quotes in commit message makes the script fail

tested on this branch with `yarn workspace scripts pushGeneratedCode`