### PR TITLE
chore(scripts): allow variadic compilation for javascript

### DIFF
--- a/playground/javascript/node/package.json
+++ b/playground/javascript/node/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsc && node --env-file=../../.env dist/$0.js",
-    "build": "tsc"
+    "start": "tsc && node --env-file=../../.env dist/$0.js"
   },
   "dependencies": {
     "@algolia/client-abtesting": "link:../../../clients/algoliasearch-client-javascript/packages/client-abtesting",

--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -1,7 +1,7 @@
 import { Argument, program } from 'commander';
 import semver from 'semver';
 
-import { buildClients, buildGuides, buildPlaygrounds, buildSnippets } from '../buildLanguages.js';
+import { buildLanguages } from '../buildLanguages.js';
 import { CI, CLIENTS, LANGUAGES, run, setVerbose, toAbsolutePath } from '../common.js';
 import { getLanguageFolder } from '../config.js';
 import { ctsGenerateMany } from '../cts/generate.js';
@@ -82,40 +82,58 @@ buildCommand
 
     setVerbose(Boolean(verbose));
 
-    await buildClients(generatorList({ language, client, clientList }));
+    await buildLanguages(generatorList({ language, client, clientList }), 'client');
   });
 
 buildCommand
   .command('playground')
   .description('Build a specified playground')
   .addArgument(args.language)
+  .addArgument(args.clients)
   .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, { verbose }) => {
+  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+    const { language, client, clientList } = transformSelection({
+      langArg,
+      clientArg,
+    });
+
     setVerbose(Boolean(verbose));
 
-    await buildPlaygrounds(langArg === ALL || langArg === undefined ? LANGUAGES : [langArg]);
+    await buildLanguages(generatorList({ language, client, clientList }), 'playground');
   });
 
 buildCommand
   .command('snippets')
   .description('Build a specified snippets')
   .addArgument(args.language)
+  .addArgument(args.clients)
   .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, { verbose }) => {
+  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+    const { language, client, clientList } = transformSelection({
+      langArg,
+      clientArg,
+    });
+
     setVerbose(Boolean(verbose));
 
-    await buildSnippets(langArg === ALL || langArg === undefined ? LANGUAGES : [langArg]);
+    await buildLanguages(generatorList({ language, client, clientList }), 'snippets');
   });
 
 buildCommand
   .command('guides')
   .description('Build a specified guides')
   .addArgument(args.language)
+  .addArgument(args.clients)
   .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, { verbose }) => {
+  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+    const { language, client, clientList } = transformSelection({
+      langArg,
+      clientArg,
+    });
+
     setVerbose(Boolean(verbose));
 
-    await buildGuides(langArg === ALL || langArg === undefined ? LANGUAGES : [langArg]);
+    await buildLanguages(generatorList({ language, client, clientList }), 'guides');
   });
 
 buildCommand


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

this pr updates the build script to allow variadic client compilation on the javascript client, since this is the only fully variadic client.

not sure if it breaks other things, will see with the CI

example: https://github.com/algolia/api-clients-automation/actions/runs/11253862443/job/31290141181?pr=3932 -- the ci runs only for a subset of clients, but we ask for every playground/snippets/guides to be compiled, since it requires the client to be compiled too, this would fail