### PR TITLE
fix(go): better network error

### DIFF
--- a/clients/algoliasearch-client-go/algolia/errs/no_more_host_to_try_err.go
+++ b/clients/algoliasearch-client-go/algolia/errs/no_more_host_to_try_err.go
@@ -1,5 +1,10 @@
 package errs
 
+import (
+	"errors"
+	"fmt"
+)
+
 var ErrNoMoreHostToTry = NewNoMoreHostToTryError()
 
 type NoMoreHostToTryError struct {
@@ -17,5 +22,8 @@ func (e *NoMoreHostToTryError) IntermediateNetworkErrors() []error {
 }
 
 func (e *NoMoreHostToTryError) Error() string {
+	if len(e.intermediateNetworkErrors) > 0 {
+		return fmt.Errorf("all hosts have been contacted unsuccessfully, it can either be a server or a network error or wrong appID/key credentials were used. %w", errors.Join(e.intermediateNetworkErrors...)).Error()
+	}
 	return "all hosts have been contacted unsuccessfully, it can either be a server or a network error or wrong appID/key credentials were used. You can use 'ExposeIntermediateNetworkErrors: true' in the config to investigate."
 }


### PR DESCRIPTION
## 🧭 What and Why

The message `You can use 'ExposeIntermediateNetworkErrors: true'` should not appear when it is true, we can show the real errors instead.