### PR TITLE
fix(javascript): do not publish ts

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/common';

--- a/clients/algoliasearch-client-javascript/packages/client-common/index.js
+++ b/clients/algoliasearch-client-javascript/packages/client-common/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/common.cjs');

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -11,8 +11,8 @@
   "type": "module",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.js",
+    "index.d.ts"
   ],
   "exports": {
     ".": {

--- a/clients/algoliasearch-client-javascript/packages/logger-console/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/logger';

--- a/clients/algoliasearch-client-javascript/packages/logger-console/index.js
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/logger.cjs');

--- a/clients/algoliasearch-client-javascript/packages/logger-console/package.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/package.json
@@ -11,8 +11,8 @@
   "type": "module",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.js",
+    "index.d.ts"
   ],
   "exports": {
     ".": {

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/requester.xhr';

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/index.js
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/requester.xhr.js');

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -21,8 +21,8 @@
   "react-native": "./dist/requester.xhr.js",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.d.ts",
+    "index.js"
   ],
   "scripts": {
     "build": "yarn clean && yarn tsup",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/requester.fetch.node';

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/index.js
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/requester.fetch.node.cjs');

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -37,8 +37,8 @@
   "react-native": "./dist/requester.fetch.browser.js",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.d.ts",
+    "index.js"
   ],
   "scripts": {
     "build": "yarn clean && yarn tsup",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/requester.http';

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/index.js
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/requester.http.cjs');

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -11,8 +11,8 @@
   "type": "module",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.d.ts",
+    "index.js"
   ],
   "exports": {
     ".": {

--- a/clients/algoliasearch-client-javascript/packages/requester-testing/index.d.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-testing/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/node';

--- a/clients/algoliasearch-client-javascript/packages/requester-testing/index.js
+++ b/clients/algoliasearch-client-javascript/packages/requester-testing/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/node.cjs');

--- a/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
@@ -12,8 +12,8 @@
   "type": "module",
   "files": [
     "dist",
-    "src",
-    "index.ts"
+    "index.d.ts",
+    "index.js"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3052

### Changes included:

closes https://github.com/algolia/algoliasearch-client-javascript/issues/1561

we shouldn't publish the source files, it can causes downstream issues if different typescript rules are applied