### PR TITLE
fix(ruby): add helper to add segment to user agent

### DIFF
--- a/clients/algoliasearch-client-ruby/lib/algolia/configuration.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia/configuration.rb
@@ -33,11 +33,17 @@ module Algolia
 
       @user_agent = UserAgent.new.add(client_name, VERSION)
 
+      if opts[:user_agent_segments]
+        opts[:user_agent_segments].each do |segment|
+          @user_agent.add(segment)
+        end
+      end
+
       @header_params = {
         "X-Algolia-Application-Id" => app_id,
         "X-Algolia-API-Key" => api_key,
         "Content-Type" => "application/json",
-        "User-Agent" => @user_agent
+        "User-Agent" => @user_agent.value
       }
       @header_params.transform_keys!(&:downcase)
 
@@ -47,11 +53,20 @@ module Algolia
     def set_client_api_key(api_key)
       @api_key = api_key
       @header_params["X-Algolia-API-Key"] = api_key
+
+      self
     end
 
     # The default Configuration object.
     def self.default
       @@default ||= Configuration.new
+    end
+
+    def add_user_agent_segment(segment, version = nil)
+      @user_agent.add(segment, version)
+      @header_params["user-agent"] = @user_agent.value
+
+      self
     end
   end
 end

--- a/clients/algoliasearch-client-ruby/lib/algolia/user_agent.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia/user_agent.rb
@@ -8,8 +8,14 @@ module Algolia
 
     # Adds a segment to the UserAgent
     #
-    def add(segment, version)
-      @value += format("; %<segment>s (%<version>s)", segment: segment, version: version)
+    def add(segment, version = nil)
+      if version.nil?
+        @value += format("; %<segment>s", segment: segment)
+      else
+        @value += format("; %<segment>s (%<version>s)", segment: segment, version: version)
+      end
+
+      self
     end
   end
 end

--- a/playground/ruby/Gemfile.lock
+++ b/playground/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../clients/algoliasearch-client-ruby
   specs:
-    algolia (3.3.1)
+    algolia (3.5.1)
       base64 (>= 0.2.0, < 1)
       faraday (>= 1.0.1, < 3.0)
       faraday-net_http_persistent (>= 0.15, < 3)

--- a/playground/ruby/search.rb
+++ b/playground/ruby/search.rb
@@ -4,6 +4,8 @@ require 'algolia'
 Dotenv.load('../.env')
 
 client = Algolia::SearchClient.create(ENV['ALGOLIA_APPLICATION_ID'], ENV['ALGOLIA_ADMIN_KEY'])
+# set a custom user agent
+client.add_user_agent_segment('Algolia for rails', "test")
 res = client.search_single_index('contacts', Algolia::Search::SearchParamsObject.new(query: 'Jimmie'))
 puts res
 

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -65,6 +65,14 @@ module {{moduleName}}
     # @return [void]
     def set_client_api_key(api_key)
       @api_client.set_client_api_key(api_key)
+
+      self
+    end
+
+    def add_user_agent_segment(segment, version = nil)
+      @api_client.config.add_user_agent_segment(segment, version)
+
+      self
     end
 
 {{#operation}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-3070](https://algolia.atlassian.net/browse/DI-3070)

Add helpers to customize ruby user agent, either with: 
`client = Algolia::SearchClient.create(appID, apiKey, {user_agent_segments: ['Rails (3.0.0)']})`

or with `client.add_user_agent_segment('Rails', '3.0.0)`