### PR TITLE
fix(clients): escape char in comments

### DIFF
--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -35,7 +35,7 @@ namespace Algolia.Search.Clients;
       {{/x-acl}}
       {{/vendorExtensions}}
       {{#allParams}}
-      /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+      /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
       {{/allParams}}
       /// <param name="options">Add extra http header or query parameters to Algolia.</param>
       /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
@@ -58,7 +58,7 @@ namespace Algolia.Search.Clients;
       {{/x-acl}}
       {{/vendorExtensions}}
       {{#allParams}}
-      /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+      /// <param name="{{paramName}}">{{{description}}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
       {{/allParams}}
       /// <param name="options">Add extra http header or query parameters to Algolia.</param>
       /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>

--- a/templates/csharp/modelEnum.mustache
+++ b/templates/csharp/modelEnum.mustache
@@ -10,7 +10,7 @@
         {{#allowableValues}}
         {{#enumVars}}
         /// <summary>
-        /// Enum {{name}} for value: {{value}}
+        /// Enum {{name}} for value: {{{value}}}
         /// </summary>
         {{#isString}}
         {{^useGenericHost}}

--- a/templates/csharp/modelGeneric.mustache
+++ b/templates/csharp/modelGeneric.mustache
@@ -126,7 +126,7 @@
         /// </summary>
         {{#readWriteVars}}
         {{#required}}
-        /// <param name="{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}">{{description}}{{^description}}{{nameInCamelCase}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}.</param>
+        /// <param name="{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}">{{{description}}}{{^description}}{{nameInCamelCase}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}.</param>
         {{/required}}
         {{/readWriteVars}}
     {{#hasOnlyReadOnly}}

--- a/templates/csharp/snippets/method.mustache
+++ b/templates/csharp/snippets/method.mustache
@@ -21,7 +21,7 @@ public class Snippet{{client}}
   /// </summary>
   public async Task SnippetFor{{client}}{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}()
   {
-    // >SEPARATOR {{method}} {{testName}}
+    // >SEPARATOR {{method}} {{{testName}}}
     // Initialize the client
     {{> snippets/init}}
 

--- a/templates/dart/snippets/method.mustache
+++ b/templates/dart/snippets/method.mustache
@@ -9,7 +9,7 @@
 //
 // {{{description}}}
 void snippetFor{{method}}{{testIndex}}() async {
-  // >SEPARATOR {{method}} {{testName}}
+  // >SEPARATOR {{method}} {{{testName}}}
   // Initialize the client
   {{> snippets/init}}
   

--- a/templates/go/snippets/method.mustache
+++ b/templates/go/snippets/method.mustache
@@ -15,7 +15,7 @@ func SnippetFor{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}Of{{#lambda.p
     {{{description}}}
     */
     
-    // >SEPARATOR {{method}} {{testName}}
+    // >SEPARATOR {{method}} {{{testName}}}
     // Initialize the client{{#hasRegionalHost}} with your application region, eg. {{clientPrefix}}.ALGOLIA_APPLICATION_REGION{{/hasRegionalHost}}
     {{> snippets/init}}
 

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -133,7 +133,7 @@ public class {{classname}} extends ApiClient {
     {{#operation}}
     /**
      * {{{notes}}}{{#allParams}}
-     * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+     * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
      {{#vendorExtensions}}{{#x-is-generic}}* @param innerType The class held by the index, could be your custom class or {@link Object}.{{/x-is-generic}}{{/vendorExtensions}}
      * @param requestOptions The requestOptions to send along with the query, they will be merged with the transporter requestOptions.
     {{> api_javadoc}}
@@ -145,7 +145,7 @@ public class {{classname}} extends ApiClient {
   {{! This case only sets `requestOptions` as optional }}
   /**
     * {{{notes}}}{{#allParams}}
-    * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+    * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
     {{#vendorExtensions}}{{#x-is-generic}}* @param innerType The class held by the index, could be your custom class or {@link Object}.{{/x-is-generic}}{{/vendorExtensions}}
     {{> api_javadoc}}
   public {{> return_type}} {{operationId}}({{#requiredParams}}@Nonnull {{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}},{{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/optionalParams}}{{#vendorExtensions}}{{#x-is-generic}}, Class<T> innerType{{/x-is-generic}}{{/vendorExtensions}}) throws AlgoliaRuntimeException {
@@ -180,7 +180,7 @@ public class {{classname}} extends ApiClient {
   /**
   * (asynchronously)
   * {{{notes}}}{{#allParams}}
-  * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}{{#vendorExtensions}}{{#x-is-generic}}
+  * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}{{#vendorExtensions}}{{#x-is-generic}}
   * @param innerType The class held by the index, could be your custom class or {@link Object}.{{/x-is-generic}}{{/vendorExtensions}}
   * @param requestOptions The requestOptions to send along with the query, they will be merged with the transporter requestOptions.
   {{> api_javadoc}}
@@ -204,7 +204,7 @@ public class {{classname}} extends ApiClient {
   /**
   * (asynchronously)
   * {{{notes}}}{{#allParams}}
-  * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}{{#vendorExtensions}}{{#x-is-generic}}
+  * @param {{paramName}} {{{description}}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}{{#vendorExtensions}}{{#x-is-generic}}
   * @param innerType The class held by the index, could be your custom class or {@link Object}.{{/x-is-generic}}{{/vendorExtensions}}
   {{> api_javadoc}}
   public {{> return_type_async}} {{operationId}}Async({{#requiredParams}}@Nonnull {{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}},{{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/optionalParams}}{{#vendorExtensions}}{{#x-is-generic}}, Class<T> innerType{{/x-is-generic}}{{/vendorExtensions}}) throws AlgoliaRuntimeException {

--- a/templates/java/snippets/method.mustache
+++ b/templates/java/snippets/method.mustache
@@ -13,7 +13,7 @@ class Snippet{{client}} {
   //
   // {{{description}}}
   void snippetFor{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}() throws Exception {
-    // >SEPARATOR {{method}} {{testName}}
+    // >SEPARATOR {{method}} {{{testName}}}
     // Initialize the client
     {{> snippets/init}}
 

--- a/templates/javascript/snippets/method.mustache
+++ b/templates/javascript/snippets/method.mustache
@@ -11,7 +11,7 @@ import type { RequestOptions } from '@algolia/client-common';
 //
 // {{{description}}}
 export {{#isAsyncMethod}}async{{/isAsyncMethod}} function snippetFor{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}(): {{#isAsyncMethod}}Promise<void>{{/isAsyncMethod}}{{^isAsyncMethod}}void{{/isAsyncMethod}} {
-  // >SEPARATOR {{method}} {{testName}}
+  // >SEPARATOR {{method}} {{{testName}}}
   // Initialize the client
   // {{#hasRegionalHost}}Replace '{{defaultRegion}}' with your Algolia Application Region{{/hasRegionalHost}}
   {{> snippets/init}}

--- a/templates/kotlin/snippets/method.mustache
+++ b/templates/kotlin/snippets/method.mustache
@@ -12,7 +12,7 @@ class Snippet{{client}} {
   {{#blocksRequests}}
   {{#snippets}}
   suspend fun snippetFor{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}() {
-      // >SEPARATOR {{method}} {{testName}}
+      // >SEPARATOR {{method}} {{{testName}}}
       // Initialize the client
       {{> snippets/init}}
 

--- a/templates/php/model.mustache
+++ b/templates/php/model.mustache
@@ -16,7 +16,7 @@ use Algolia\AlgoliaSearch\Model\ModelInterface;
  *
  * @category Class
 {{#description}}
- * @description {{.}}
+ * @description {{{.}}}
 {{/description}}
  * @package {{invokerPackage}}
  */

--- a/templates/php/snippets/method.mustache
+++ b/templates/php/snippets/method.mustache
@@ -19,7 +19,7 @@ class Snippet{{client}}
     */
     public function snippetFor{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}{{testIndex}}(): void
     {
-        // >SEPARATOR {{method}} {{testName}}
+        // >SEPARATOR {{method}} {{{testName}}}
         // Initialize the client
         {{> snippets/init}}
 

--- a/templates/python/snippets/method.mustache
+++ b/templates/python/snippets/method.mustache
@@ -11,7 +11,7 @@ def snippet_for_{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{testIndex}
 
     {{{description}}}
     """
-    # >SEPARATOR {{method}} {{testName}}
+    # >SEPARATOR {{method}} {{{testName}}}
     # Initialize the client
     # In an asynchronous context, you can use {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}} instead, which exposes the exact same methods.
     {{> snippets/init}}

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -77,7 +77,7 @@ module {{moduleName}}
 
 {{#operation}}
     {{#notes}}
-    # {{.}}
+    # {{{.}}}
     {{/notes}}
     {{#vendorExtensions}}
     {{#x-acl.0}}
@@ -89,10 +89,10 @@ module {{moduleName}}
     {{/vendorExtensions}}
 {{#allParams}}
 {{#required}}
-    # @param {{paramName}} [{{{dataType}}}] {{description}} (required)
+    # @param {{paramName}} [{{{dataType}}}] {{{description}}} (required)
 {{/required}}
 {{^required}}
-    # @param {{paramName}} [{{{dataType}}}] {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    # @param {{paramName}} [{{{dataType}}}] {{{description}}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/required}}
 {{/allParams}}
     # @param request_options: The request options to send along with the query, they will be merged with the transporter base parameters (headers, query params, timeouts, etc.). (optional)
@@ -153,10 +153,10 @@ module {{moduleName}}
     {{/vendorExtensions}}
 {{#allParams}}
 {{#required}}
-    # @param {{paramName}} [{{{dataType}}}] {{description}} (required)
+    # @param {{paramName}} [{{{dataType}}}] {{{description}}} (required)
 {{/required}}
 {{^required}}
-    # @param {{paramName}} [{{{dataType}}}] {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
+    # @param {{paramName}} [{{{dataType}}}] {{{description}}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/required}}
 {{/allParams}}
     # @param request_options: The request options to send along with the query, they will be merged with the transporter base parameters (headers, query params, timeouts, etc.). (optional)

--- a/templates/ruby/snippets/method.mustache
+++ b/templates/ruby/snippets/method.mustache
@@ -9,7 +9,7 @@
 #
 # {{{description}}}
 def snippet_for_{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{testIndex}}
-  # >SEPARATOR {{method}} {{testName}}
+  # >SEPARATOR {{method}} {{{testName}}}
   # Initialize the client
   {{> snippets/init}}
 

--- a/templates/scala/enum.mustache
+++ b/templates/scala/enum.mustache
@@ -9,7 +9,7 @@ object {{classname}} {
     {{#allowableValues}}
     {{#values}}
     case object {{#fnEnumEntry}}{{.}}{{/fnEnumEntry}} extends {{classname}} {
-        override def toString = "{{.}}"
+        override def toString = "{{{.}}}"
     }
     {{/values}}
     {{/allowableValues}}

--- a/templates/scala/snippets/method.mustache
+++ b/templates/scala/snippets/method.mustache
@@ -24,7 +24,7 @@ class Snippet{{client}} {
     * {{{description}}}
     */
   def snippetFor{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}(): Unit = {
-    // >SEPARATOR {{method}} {{testName}}
+    // >SEPARATOR {{method}} {{{testName}}}
     // Initialize the client
     {{> snippets/init}}
 

--- a/templates/swift/model.mustache
+++ b/templates/swift/model.mustache
@@ -7,7 +7,7 @@ import Foundation
 
 {{#description}}
 
-/** {{.}} */{{/description}}{{#isDeprecated}}
+/** {{{.}}} */{{/description}}{{#isDeprecated}}
 @available(*, deprecated, message: "This schema is deprecated."){{/isDeprecated}}{{#vendorExtensions.x-is-one-of-interface}}
 {{> modelOneOf}}{{/vendorExtensions.x-is-one-of-interface}}{{^vendorExtensions.x-is-one-of-interface}}{{#isArray}}
 {{> modelArray}}{{/isArray}}{{^isArray}}{{#isEnum}}

--- a/templates/swift/snippets/method.mustache
+++ b/templates/swift/snippets/method.mustache
@@ -12,7 +12,7 @@ final class {{client}}Snippet {
   //
   // {{{description}}}
   func snippetFor{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}() async throws {
-    // >SEPARATOR {{method}} {{testName}}
+    // >SEPARATOR {{method}} {{{testName}}}
     // Initialize the client
     {{> snippets/init}}
 


### PR DESCRIPTION
## 🧭 What and Why

Remove all the ugly `&#x60;` or `&quot;` that are actually breaking the scala client.