### PR TITLE
fix(javascript): missing search dependency

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -181,6 +181,7 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
         dependencies.add(dependency);
       }
       additionalProperties.put("dependencies", dependencies);
+      additionalProperties.put("searchVersion", Helpers.getPackageJsonVersion("client-search"));
 
       // Files used to generate the `lite` client
       clientName = "lite" + Helpers.API_SUFFIX;

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -123,6 +123,7 @@
     {{#dependencies}}
     "{{{dependencyPackage}}}": "{{{dependencyVersion}}}",
     {{/dependencies}}
+    "@algolia/client-search": "{{searchVersion}}",
     "@algolia/client-common": "{{utilsPackageVersion}}",
     "@algolia/requester-browser-xhr": "{{utilsPackageVersion}}",
     "@algolia/requester-node-http": "{{utilsPackageVersion}}",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3085

### Changes included:

closes https://github.com/algolia/algoliasearch-client-javascript/issues/1562

the search client wasn't in the dependencies anymore