### PR TITLE
fix(javascript): do not publish ts

### DIFF
--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -48,7 +48,6 @@
   "react-native": "./dist/builds/browser.js",
   "files": [
     "dist",
-    "model",
     "index.js",
     "index.d.ts"
   ],
@@ -112,10 +111,8 @@
   },
   "files": [
     "dist",
-    "builds",
     "index.js",
     "index.d.ts",
-    "lite",
     "lite.js",
     "lite.d.ts"
   ],


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3091

### Changes included:

closes https://github.com/algolia/algoliasearch-client-javascript/issues/1565
closes https://github.com/algolia/api-clients-automation/issues/3784

we shouldn't publish the typescript files for the clients as well, follow up of https://github.com/algolia/api-clients-automation/pull/3966, however I wonder why it worked in previous v5 versions? in v4, those files were not published