### PR TITLE
docs(analytics): constrain pagination only to limit query parameter

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
-      CACHE_VERSION: 1.01 # bump this to run all clients on the CI.
+      CACHE_VERSION: 1.02 # bump this to run all clients on the CI.
     steps:
       - name: debugging - dump GitHub context
         env:

--- a/specs/analytics/common/parameters.yml
+++ b/specs/analytics/common/parameters.yml
@@ -24,23 +24,17 @@ Offset:
   name: offset
   description: |
     Position of the first item to return.
-
-    Combined with the `limit` parameter, only the first 1000 items can be retrieved.
   required: false
   schema:
     type: integer
     default: 0
     minimum: 0
-    maximum: 1000
 
 Limit:
   in: query
   name: limit
   description: |
     Number of items to return.
-
-    Combined with the `offset` parameter, only the first 1000 items can be retrieved.
-
   required: false
   schema:
     type: integer


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [OPTIM-1314]

### Changes included:

Update documents to reflect changes in the API brought by https://github.com/algolia/go/pull/16694

- Remove limitation on `offset + limit` combined limit and update documentation to reflect the changes

## 🧪 Test


[OPTIM-1314]: https://algolia.atlassian.net/browse/OPTIM-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ