### PR TITLE
fix(python): required aggregator parameter in browse_*

### DIFF
--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -121,7 +121,7 @@
     {{^isSyncClient}}async {{/isSyncClient}}def browse_objects(
         self,
         index_name: str,
-        aggregator: Optional[Callable[[BrowseResponse], None]],
+        aggregator: Callable[[BrowseResponse], None],
         browse_params: BrowseParamsObject = BrowseParamsObject(),
         request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> BrowseResponse:
@@ -146,7 +146,7 @@
     {{^isSyncClient}}async {{/isSyncClient}}def browse_rules(
         self,
         index_name: str,
-        aggregator: Optional[Callable[[SearchRulesResponse], None]],
+        aggregator: Callable[[SearchRulesResponse], None],
         search_rules_params: SearchRulesParams = SearchRulesParams(hits_per_page=1000),
         request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> SearchRulesResponse:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3101

### Changes included:

closes https://github.com/algolia/algoliasearch-client-python/issues/573

the aggregator should be required in the browse context, there's no point of calling the helper for just the last response