### PR TITLE
fix(javascript): import type for bundler

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -6,8 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build:all": "lerna run build --include-dependencies",
-    "build:many": "lerna run build --scope 'algoliasearch' --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope ${0:-'{@algolia/*,algoliasearch}'} --include-dependencies",
+    "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --include-dependencies",
     "clean": "lerna run clean",
     "release:bump": "lerna version ${0:-patch} --no-changelog --no-git-tag-version --no-push --exact --force-publish --yes",
     "release:publish": "tsc --project scripts/tsconfig.json && node scripts/dist/scripts/publish.js",

--- a/clients/algoliasearch-client-javascript/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
+    "verbatimModuleSyntax": true,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,

--- a/scripts/buildLanguages.ts
+++ b/scripts/buildLanguages.ts
@@ -48,10 +48,7 @@ async function buildLanguage(language: Language, gens: Generator[], buildType: B
     case 'javascript':
       await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', { cwd, language });
       if (buildType === 'client') {
-        const packageNames = gens.map(({ additionalProperties: { packageName } }) =>
-          packageName === 'algoliasearch' ? packageName : `@algolia/${packageName}`,
-        );
-        await run(`yarn build:many '{${packageNames.join(',')},}'`, { cwd, language });
+        await run(`yarn build`, { cwd, language });
         break;
       }
 

--- a/scripts/ci/githubActions/createMatrix.ts
+++ b/scripts/ci/githubActions/createMatrix.ts
@@ -112,14 +112,7 @@ async function createClientMatrix(baseBranch: string): Promise<void> {
         languageMatrix.testsToStore = `${languageMatrix.testsToStore} ${testsRootFolder}/build.gradle`;
         break;
       case 'javascript':
-        const packageNames = matrix[language].toRun.map((client) => {
-          const packageName = GENERATORS[`${language}-${client}`].additionalProperties.packageName;
-
-          // `algoliasearch` is not preceded by `@algolia`
-          return client === 'algoliasearch' ? packageName : `@algolia/${packageName}`;
-        });
-
-        languageMatrix.buildCommand = `cd ${matrix[language].path} && yarn build:many '{${packageNames.join(',')},}'`;
+        languageMatrix.buildCommand = `cd ${matrix[language].path} && yarn build`;
         languageMatrix.testsToStore = `${languageMatrix.testsToStore} ${testsRootFolder}/package.json`;
 
         setOutput('JAVASCRIPT_DATA', JSON.stringify(languageMatrix));

--- a/templates/javascript/clients/algoliasearch/builds/models.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/models.mustache
@@ -98,10 +98,10 @@ import type {
   Widgets,
 } from '@algolia/client-search';
 import { apiClientVersion } from '@algolia/client-search';
-import {
+import type {
   Status,
 } from '@algolia/client-abtesting';
-import {
+import type {
   EventType,
 } from '@algolia/client-personalization';
 

--- a/templates/javascript/clients/algoliasearch/builds/models.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/models.mustache
@@ -113,7 +113,7 @@ export * from '{{{dependencyPackage}}}';
 {{/dependencies}}
 export * from '@algolia/client-search';
 
-export {
+export type {
   Action,
   AdvancedSyntaxFeatures,
   AlternativesAsExact,

--- a/templates/javascript/clients/client/api/operation/legacySearchCompatible/imports.mustache
+++ b/templates/javascript/clients/client/api/operation/legacySearchCompatible/imports.mustache
@@ -1,3 +1,3 @@
 import type { SearchForFacetsOptions } from './searchForFacetsOptions';
 import type { SearchForHitsOptions } from './searchForHitsOptions';
-import { SearchParamsObject } from './searchParamsObject';
+import type { SearchParamsObject } from './searchParamsObject';

--- a/templates/javascript/clients/client/builds/definition.mustache
+++ b/templates/javascript/clients/client/builds/definition.mustache
@@ -1,31 +1,33 @@
 import { createXhrRequester } from '@algolia/requester-browser-xhr';
 import { createHttpRequester } from '@algolia/requester-node-http';
 import { createFetchRequester } from '@algolia/requester-fetch';
-import { createNullLogger, createMemoryCache, createFallbackableCache, createBrowserLocalStorageCache, createNullCache,  ClientOptions, serializeQueryParameters, DEFAULT_CONNECT_TIMEOUT_NODE, DEFAULT_READ_TIMEOUT_NODE, DEFAULT_WRITE_TIMEOUT_NODE, DEFAULT_CONNECT_TIMEOUT_BROWSER, DEFAULT_READ_TIMEOUT_BROWSER, DEFAULT_WRITE_TIMEOUT_BROWSER } from '@algolia/client-common';
+import { createNullLogger, createMemoryCache, createFallbackableCache, createBrowserLocalStorageCache, createNullCache, serializeQueryParameters, DEFAULT_CONNECT_TIMEOUT_NODE, DEFAULT_READ_TIMEOUT_NODE, DEFAULT_WRITE_TIMEOUT_NODE, DEFAULT_CONNECT_TIMEOUT_BROWSER, DEFAULT_READ_TIMEOUT_BROWSER, DEFAULT_WRITE_TIMEOUT_BROWSER } from '@algolia/client-common';
+
+import type { ClientOptions } from '@algolia/client-common';
 
 import { create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}, apiClientVersion } from '../src/{{clientName}}';
 
 {{#hasRegionalHost}}
-import { Region, REGIONS, RegionOptions } from '../src/{{clientName}}';
+import { REGIONS } from '../src/{{clientName}}';
+import type { Region, RegionOptions } from '../src/{{clientName}}'; 
+
+export type { Region, RegionOptions } from '../src/{{clientName}}';
 {{/hasRegionalHost}}
 
 {{! We don't use `export *` to prevent exposing the factory, to avoid confusion for the user }}
 export {
   apiClientVersion,
-  {{#hasRegionalHost}}
-  Region,
-  RegionOptions,
-  {{/hasRegionalHost}}
   {{#isIngestionClient}}
   isOnDemandTrigger,
   isScheduleTrigger,
   isSubscriptionTrigger,
   {{/isIngestionClient}}
 } from '../src/{{clientName}}';
+
 export * from '../model';
 
 {{#isSearchClient}}
-import { GenerateSecuredApiKeyOptions, GetSecuredApiKeyRemainingValidityOptions, SearchClientNodeHelpers } from '../model';
+import type { GenerateSecuredApiKeyOptions, GetSecuredApiKeyRemainingValidityOptions, SearchClientNodeHelpers } from '../model';
 {{/isSearchClient}}
 
 {{#nodeSearchHelpers}}

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -3,7 +3,7 @@
 {{#apiInfo.apis.0}}
 
 {{#imports}}
-import { {{classname}} } from '{{filename}}';
+import type { {{classname}} } from '{{filename}}';
 {{/imports}}
 
 {{! Imports for the legacy search method signature }}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3102

### Changes included:

close https://github.com/algolia/algoliasearch-client-javascript/issues/1565
close https://github.com/algolia/algoliasearch-client-javascript/issues/1562

seems like tsup doesn't remove type imports if the statement doesn't include `type` in it, leading to javascript files with type imports... see https://www.npmjs.com/package/algoliasearch?activeTab=code in `/algoliasearch/dist/node.js` L53-L54 for example

also add https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax to enforce import types consistency