### PR TITLE
fix(ruby): provide default ttl

### DIFF
--- a/clients/algoliasearch-client-ruby/lib/algolia.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia.rb
@@ -5,6 +5,7 @@
 # Common files
 require "algolia/api_client"
 require "algolia/api_error"
+require "algolia/defaults"
 require "algolia/error"
 require "algolia/version"
 require "algolia/configuration"

--- a/clients/algoliasearch-client-ruby/lib/algolia/defaults.rb
+++ b/clients/algoliasearch-client-ruby/lib/algolia/defaults.rb
@@ -1,0 +1,5 @@
+module Algolia
+  module Defaults
+    TTL = 300
+  end
+end

--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -119,6 +119,7 @@ export const patterns = [
   'clients/algoliasearch-client-ruby/lib/algolia/**',
   '!clients/algoliasearch-client-ruby/lib/algolia/api_client.rb',
   '!clients/algoliasearch-client-ruby/lib/algolia/api_error.rb',
+  '!clients/algoliasearch-client-ruby/lib/algolia/defaults.rb',
   '!clients/algoliasearch-client-ruby/lib/algolia/error.rb',
   '!clients/algoliasearch-client-ruby/lib/algolia/configuration.rb',
   '!clients/algoliasearch-client-ruby/lib/algolia/logger_helper.rb',


### PR DESCRIPTION
## 🧭 What and Why

closes https://github.com/algolia/algoliasearch-client-ruby/pull/504

The client is referencing an file that doesn't exists anymore