### PR TITLE
chore(swift): fix configuration protection level

### DIFF
--- a/templates/swift/client_configuration.mustache
+++ b/templates/swift/client_configuration.mustache
@@ -22,7 +22,7 @@ public struct {{#lambda.client-to-name}}{{{client}}}{{/lambda.client-to-name}}Cl
   public var hosts: [RetryableHost]
   public let compression: CompressionAlgorithm
 
-  init(appID: String,
+  public init(appID: String,
       apiKey: String,{{#hasRegionalHost}}
       region: Region{{#fallbackToAliasHost}}? = nil{{/fallbackToAliasHost}},{{/hasRegionalHost}}
       writeTimeout: TimeInterval = DefaultConfiguration.default.writeTimeout,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-3103]& fixes algolia/algoliasearch-client-swift#872

### Changes included:

- make the client configuration init public
