### PR TITLE
feat(specs): add missing message attribute to GetObjectsResponse [skip-bc]

### DIFF
--- a/specs/search/paths/objects/getObjects.yml
+++ b/specs/search/paths/objects/getObjects.yml
@@ -61,6 +61,10 @@ post:
             type: object
             additionalProperties: false
             properties:
+              message:
+                type: string
+                description: An optional status message.
+                example: Index INDEX_NAME does not exist.
               results:
                 type: array
                 description: Retrieved records.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: just trying to make a small contribution :)

### Changes included:

Add missing `message` attribute to `GetObjectsResponse`

<img width="502" alt="Screenshot 2024-10-24 at 18 18 25" src="https://github.com/user-attachments/assets/5044d5c1-6714-4d64-9eb2-41ad8e42c06b">

