### PR TITLE
feat(clients): expose waitForTasks to batch helpers

### DIFF
--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -317,14 +317,15 @@ async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, bat
  * @param saveObjects - The `saveObjects` object.
  * @param saveObjects.indexName - The `indexName` to save `objects` in.
  * @param saveObjects.objects - The array of `objects` to store in the given Algolia `indexName`.
+ * @param chunkedBatch.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `batch` method and merged with the transporter requestOptions.
  */
 async saveObjects(
-  { indexName, objects }: SaveObjectsOptions,
+  { indexName, objects, waitForTasks }: SaveObjectsOptions,
   requestOptions?: RequestOptions
 ): Promise<BatchResponse[]> {
   return await this.chunkedBatch(
-    { indexName, objects, action: 'addObject' },
+    { indexName, objects, action: 'addObject', waitForTasks },
     requestOptions
   );
 },
@@ -336,10 +337,11 @@ async saveObjects(
  * @param deleteObjects - The `deleteObjects` object.
  * @param deleteObjects.indexName - The `indexName` to delete `objectIDs` from.
  * @param deleteObjects.objectIDs - The objectIDs to delete.
+ * @param chunkedBatch.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `batch` method and merged with the transporter requestOptions.
  */
 async deleteObjects(
-  { indexName, objectIDs }: DeleteObjectsOptions,
+  { indexName, objectIDs, waitForTasks }: DeleteObjectsOptions,
   requestOptions?: RequestOptions
 ): Promise<BatchResponse[]> {
   return await this.chunkedBatch(
@@ -347,6 +349,7 @@ async deleteObjects(
       indexName,
       objects: objectIDs.map((objectID) => ({ objectID })),
       action: 'deleteObject',
+      waitForTasks,
     },
     requestOptions
   );

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -132,7 +132,7 @@ export type SearchClientNodeHelpers = {
 }
 {{/isSearchClient}}
 
-export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName'> & {
+export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'waitForTasks'> & {
   /**
    * The objectIDs to delete.
    */
@@ -151,7 +151,7 @@ export type PartialUpdateObjectsOptions = Pick<
 
 export type SaveObjectsOptions = Pick<
   ChunkedBatchOptions,
-  'indexName' | 'objects'
+  'indexName' | 'objects' | 'waitForTasks'
 >;
 
 export type ChunkedBatchOptions = ReplaceAllObjectsOptions & {

--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -256,23 +256,25 @@
         self,
         index_name: str,
         objects: List[Dict[str, Any]],
+        wait_for_tasks: bool = false,
         request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> List[BatchResponse]:
         """
         Helper: Saves the given array of objects in the given index. The `chunked_batch` helper is used under the hood, which creates a `batch` requests with at most 1000 objects in it.
         """
-        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.ADDOBJECT, request_options=request_options)
+        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=objects, action=Action.ADDOBJECT, wait_for_tasks=wait_for_tasks, request_options=request_options)
 
     {{^isSyncClient}}async {{/isSyncClient}}def delete_objects(
         self,
         index_name: str,
         object_ids: List[str],
+        wait_for_tasks: bool = false,
         request_options: Optional[Union[dict, RequestOptions]] = None,
     ) -> List[BatchResponse]:
         """
         Helper: Deletes every records for the given objectIDs. The `chunked_batch` helper is used under the hood, which creates a `batch` requests with at most 1000 objectIDs in it.
         """
-        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=[{"objectID": id} for id in object_ids], action=Action.DELETEOBJECT, request_options=request_options)
+        return {{^isSyncClient}}await {{/isSyncClient}}self.chunked_batch(index_name=index_name, objects=[{"objectID": id} for id in object_ids], action=Action.DELETEOBJECT, wait_for_tasks=wait_for_tasks, request_options=request_options)
 
     {{^isSyncClient}}async {{/isSyncClient}}def partial_update_objects(
         self,


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

follow up of https://github.com/algolia/api-clients-automation/pull/3565
closes https://github.com/algolia/algoliasearch-client-javascript/issues/1567#issuecomment-2437416341

forward `waitForTasks` option to the `saveObjects` and `deleteObjects` methods to ease the usage