### PR TITLE
fix(specs): support synonyms type in camel case [skip-bc]

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavaGenerator.java
@@ -131,8 +131,7 @@ public class AlgoliaJavaGenerator extends JavaClientCodegen {
     }
 
     if (!value.matches("[A-Z0-9_]+")) {
-      // convert camelCase77String to CAMEL_CASE_77_STRING
-      return value.replaceAll("-", "_").replaceAll("(.+?)([A-Z]|[0-9])", "$1_$2").toUpperCase(Locale.ROOT);
+      return Helpers.toScreamingSnakeCase(value);
     }
 
     return value;

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -161,4 +161,28 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     // always default to None in the client, to let the server handle the default value.
     return "None";
   }
+
+  public static String toEnum(String value) {
+    // we only convert the full lowercase enums as they have a fallback to camelCase enums with the
+    // same name so no BC is introduced
+    if (!value.toLowerCase().equals(value)) {
+      // special edge case for onewaysynonym because there's no way to distinguish the two at the
+      // generation level
+      if (value.equals("'oneWaySynonym'")) {
+        return Helpers.toSnakeCase(value);
+      }
+      return value;
+    }
+    return Helpers.toScreamingSnakeCase(value);
+  }
+
+  @Override
+  public String toEnumVariableName(String value, String datatype) {
+    return super.toEnumVariableName(toEnum(value), datatype);
+  }
+
+  @Override
+  public String toEnumVarName(String value, String datatype) {
+    return super.toEnumVarName(toEnum(value), datatype);
+  }
 }

--- a/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
@@ -43,7 +43,12 @@ public class Helpers {
 
   // convert camelCase77String to CAMEL_CASE_77_STRING
   public static String toScreamingSnakeCase(String camelCase) {
-    return camelCase.replaceAll("-", "_").replaceAll("(.+?)([A-Z]|[0-9])", "$1_$2").toUpperCase(Locale.ROOT);
+    return camelCase
+      .replaceAll("-", "_")
+      .replaceAll("/", "_")
+      .replaceAll("(?<=.)([A-Z]+|\\d+)", "_$1")
+      .replaceAll("__", "_")
+      .toUpperCase(Locale.ROOT);
   }
 
   /**

--- a/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/Helpers.java
@@ -41,6 +41,11 @@ public class Helpers {
     return camel;
   }
 
+  // convert camelCase77String to CAMEL_CASE_77_STRING
+  public static String toScreamingSnakeCase(String camelCase) {
+    return camelCase.replaceAll("-", "_").replaceAll("(.+?)([A-Z]|[0-9])", "$1_$2").toUpperCase(Locale.ROOT);
+  }
+
   /**
    * Will add the boolean `vendorExtensions.x-is-custom-request` to operations if they should not
    * escape '/' in the path variable

--- a/specs/search/paths/synonyms/common/parameters.yml
+++ b/specs/search/paths/synonyms/common/parameters.yml
@@ -30,6 +30,9 @@ SynonymType:
     - altcorrection1
     - altcorrection2
     - placeholder
+    - oneWaySynonym
+    - altCorrection1
+    - altCorrection2
 
 ObjectID:
   name: objectID


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3108

### Changes included:

see https://github.com/algolia/AlgoliaWeb/pull/22442#discussion_r1816448163 and https://github.com/algolia/AlgoliaWeb/pull/22442#discussion_r1816451248 for context

the API accepts both casing, and the search is case insensitive, the camel case is the more obvious one and was supported in the previous major