### PR TITLE
fix(javascript): allow import from dist

### DIFF
--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -41,7 +41,7 @@
         "default": "./dist/builds/browser.umd.js"
       }
     },
-    "./src/*": "./src/*.ts"
+    "./dist/builds/*": "./dist/builds/*.js"
   },
   "jsdelivr": "./dist/builds/browser.umd.js",
   "unpkg": "./dist/builds/browser.umd.js",
@@ -101,7 +101,9 @@
         "import": "./dist/lite/builds/browser.js",
         "default": "./dist/lite/builds/browser.umd.js"
       }
-    }
+    },
+    "./dist/*": "./dist/*.js",
+    "./dist/lite/builds/*": "./dist/lite/builds/*.js"
   },
   "jsdelivr": "./dist/algoliasearch.umd.js",
   "unpkg": "./dist/algoliasearch.umd.js",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3141

### Changes included:

It's impossible to import from the dist right now because it's not defined in the exports