### PR TITLE
fix(specs): make `action` optional for tasks [skip-bc]

### DIFF
--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -35,7 +35,6 @@ Task:
     - sourceID
     - destinationID
     - enabled
-    - action
     - createdAt
 
 TaskV1:
@@ -74,7 +73,6 @@ TaskV1:
     - destinationID
     - trigger
     - enabled
-    - action
     - createdAt
 
 Trigger:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3142

### Changes included:

for `push`, the `action` is empty since it has no effect in this context