### PR TITLE
fix(javascript): add support for private package publish

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -15,12 +15,10 @@
   },
   "devDependencies": {
     "@types/node": "22.9.0",
-    "@types/semver": "7.5.8",
     "bundlesize": "0.18.2",
     "execa": "9.5.1",
     "lerna": "8.1.9",
     "rollup": "4.25.0",
-    "semver": "7.6.3",
     "typescript": "5.6.3"
   },
   "engines": {

--- a/clients/algoliasearch-client-javascript/scripts/publish.ts
+++ b/clients/algoliasearch-client-javascript/scripts/publish.ts
@@ -1,16 +1,17 @@
 import { execaCommand } from 'execa';
-import semver from 'semver';
-
-import packageJSON from '../packages/algoliasearch/package.json' with { type: 'json' };
 
 async function publish(): Promise<void> {
-  // Get tag like `alpha`, `beta`, ...
-  const tag = semver.prerelease(packageJSON.version)?.[0];
-
+  // publish the stable public packages
   await execaCommand(
-    `yarn lerna exec --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access public ${
-      tag ? `--tag ${tag}` : ''
-    }`,
+    `yarn lerna exec --ignore '@algolia/client-composition' --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access public`,
+    {
+      shell: 'bash',
+    },
+  );
+
+  // publish the prereleases private packages
+  await execaCommand(
+    `yarn lerna exec --scope '@algolia/client-composition' --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access private --tag alpha`,
     {
       shell: 'bash',
     },

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -2133,13 +2133,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:7.5.8":
-  version: 7.5.8
-  resolution: "@types/semver@npm:7.5.8"
-  checksum: 10/3496808818ddb36deabfe4974fd343a78101fa242c4690044ccdc3b95dcf8785b494f5d628f2f47f38a702f8db9c53c67f47d7818f2be1b79f2efb09692e1178
-  languageName: node
-  linkType: hard
-
 "@vitest/expect@npm:2.1.4":
   version: 2.1.4
   resolution: "@vitest/expect@npm:2.1.4"
@@ -2317,12 +2310,10 @@ __metadata:
   resolution: "algoliasearch-client-javascript@workspace:."
   dependencies:
     "@types/node": "npm:22.9.0"
-    "@types/semver": "npm:7.5.8"
     bundlesize: "npm:0.18.2"
     execa: "npm:9.5.1"
     lerna: "npm:8.1.9"
     rollup: "npm:4.25.0"
-    semver: "npm:7.6.3"
     typescript: "npm:5.6.3"
   languageName: unknown
   linkType: soft
@@ -7719,7 +7710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.6.3, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

the release script for js failed on the composition package, I assume it is because we went from a private to a public package with manual interventions

this pr updates the public script to support (in a non programmatically way) the private and alpha releases