### PR TITLE
chore(scripts): change dist folder and bump

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [5.14.1](https://github.com/algolia/algoliasearch-client-javascript/compare/5.14.0...5.14.1)
+## [5.14.2](https://github.com/algolia/algoliasearch-client-javascript/compare/5.14.0...5.14.2)
 
 - [b97a88beb](https://github.com/algolia/api-clients-automation/commit/b97a88beb) fix(javascript): add support for private package publish ([#4106](https://github.com/algolia/api-clients-automation/pull/4106)) by [@shortcuts](https://github.com/shortcuts/)
 - [36d583e35](https://github.com/algolia/api-clients-automation/commit/36d583e35) fix(specs): make the searchParams compatible with v4 ([#4108](https://github.com/algolia/api-clients-automation/pull/4108)) by [@millotp](https://github.com/millotp/)

--- a/clients/algoliasearch-client-javascript/README.md
+++ b/clients/algoliasearch-client-javascript/README.md
@@ -38,11 +38,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add algoliasearch@5.14.1
+yarn add algoliasearch@5.14.2
 # or
-npm install algoliasearch@5.14.1
+npm install algoliasearch@5.14.2
 # or
-pnpm add algoliasearch@5.14.1
+pnpm add algoliasearch@5.14.2
 ```
 
 ### Without a package manager
@@ -51,10 +51,10 @@ Add the following JavaScript snippet to the <head> of your website:
 
 ```html
 // for the full client
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.1/dist/algoliasearch.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.2/dist/algoliasearch.umd.js"></script>
 
 // for the lite client
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.1/dist/lite/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.2/dist/lite/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --scope '@algolia/client-composition' --include-dependencies",
     "clean": "lerna run clean",
-    "release:publish": "tsc --project scripts/tsconfig.json && node scripts/dist/scripts/publish.js",
+    "release:publish": "tsc --project scripts/tsconfig.json && node scripts/dist/publish.js",
     "test": "lerna run test $*",
     "test:size": "bundlesize",
     "test:bundle": "lerna run test:bundle --verbose --include-dependencies"

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/README.md
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/README.md
@@ -38,11 +38,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add algoliasearch@5.14.1
+yarn add algoliasearch@5.14.2
 # or
-npm install algoliasearch@5.14.1
+npm install algoliasearch@5.14.2
 # or
-pnpm add algoliasearch@5.14.1
+pnpm add algoliasearch@5.14.2
 ```
 
 ### Without a package manager
@@ -51,10 +51,10 @@ Add the following JavaScript snippet to the <head> of your website:
 
 ```html
 // for the full client
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.1/dist/algoliasearch.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.2/dist/algoliasearch.umd.js"></script>
 
 // for the lite client
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.1/dist/lite/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@5.14.2/dist/lite/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/lite/src/liteClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/lite/src/liteClient.ts
@@ -24,7 +24,7 @@ import type {
 import type { SearchForFacetValuesResponse } from '../model/searchForFacetValuesResponse';
 import type { SearchResponse } from '../model/searchResponse';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -73,22 +73,22 @@
     "lite.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-abtesting": "5.14.1",
-    "@algolia/client-analytics": "5.14.1",
-    "@algolia/client-common": "5.14.1",
-    "@algolia/client-insights": "5.14.1",
-    "@algolia/client-personalization": "5.14.1",
-    "@algolia/client-query-suggestions": "5.14.1",
-    "@algolia/client-search": "5.14.1",
-    "@algolia/ingestion": "1.14.1",
-    "@algolia/monitoring": "1.14.1",
-    "@algolia/recommend": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-abtesting": "5.14.2",
+    "@algolia/client-analytics": "5.14.2",
+    "@algolia/client-common": "5.14.2",
+    "@algolia/client-insights": "5.14.2",
+    "@algolia/client-personalization": "5.14.2",
+    "@algolia/client-query-suggestions": "5.14.2",
+    "@algolia/client-search": "5.14.2",
+    "@algolia/ingestion": "1.14.2",
+    "@algolia/monitoring": "1.14.2",
+    "@algolia/recommend": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
-    "@algolia/requester-testing": "5.14.1",
+    "@algolia/requester-testing": "5.14.2",
     "@arethetypeswrong/cli": "0.17.0",
     "@types/node": "22.9.0",
     "jsdom": "25.0.1",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-abtesting@5.14.1
+yarn add @algolia/client-abtesting@5.14.2
 # or
-npm install @algolia/client-abtesting@5.14.1
+npm install @algolia/client-abtesting@5.14.2
 # or
-pnpm add @algolia/client-abtesting@5.14.1
+pnpm add @algolia/client-abtesting@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-abtesting@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-abtesting@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-abtesting@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/src/abtestingClient.ts
@@ -31,7 +31,7 @@ import type {
   StopABTestProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 export const REGIONS = ['de', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-analytics@5.14.1
+yarn add @algolia/client-analytics@5.14.2
 # or
-npm install @algolia/client-analytics@5.14.1
+npm install @algolia/client-analytics@5.14.2
 # or
-pnpm add @algolia/client-analytics@5.14.1
+pnpm add @algolia/client-analytics@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-analytics@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-analytics@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-analytics@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/src/analyticsClient.ts
@@ -58,7 +58,7 @@ import type {
   GetUsersCountProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 export const REGIONS = ['de', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": {
     "type": "git",

--- a/clients/algoliasearch-client-javascript/packages/client-composition/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-composition/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-composition@0.0.1-alpha.2
+yarn add @algolia/client-composition@0.0.1-alpha.3
 # or
-npm install @algolia/client-composition@0.0.1-alpha.2
+npm install @algolia/client-composition@0.0.1-alpha.3
 # or
-pnpm add @algolia/client-composition@0.0.1-alpha.2
+pnpm add @algolia/client-composition@0.0.1-alpha.3
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-composition@0.0.1-alpha.2
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-composition@0.0.1-alpha.2/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-composition@0.0.1-alpha.3/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-composition/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-composition/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-composition/src/compositionClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-composition/src/compositionClient.ts
@@ -41,7 +41,7 @@ import type {
   WaitForCompositionTaskOptions,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '0.0.1-alpha.2';
+export const apiClientVersion = '0.0.1-alpha.3';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/client-insights/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-insights@5.14.1
+yarn add @algolia/client-insights@5.14.2
 # or
-npm install @algolia/client-insights@5.14.1
+npm install @algolia/client-insights@5.14.2
 # or
-pnpm add @algolia/client-insights@5.14.1
+pnpm add @algolia/client-insights@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-insights@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-insights@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-insights@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/src/insightsClient.ts
@@ -21,7 +21,7 @@ import type {
   DeleteUserTokenProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 export const REGIONS = ['de', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-personalization@5.14.1
+yarn add @algolia/client-personalization@5.14.2
 # or
-npm install @algolia/client-personalization@5.14.1
+npm install @algolia/client-personalization@5.14.2
 # or
-pnpm add @algolia/client-personalization@5.14.1
+pnpm add @algolia/client-personalization@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-personalization@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-personalization@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-personalization@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/src/personalizationClient.ts
@@ -25,7 +25,7 @@ import type {
   GetUserTokenProfileProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 export const REGIONS = ['eu', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-query-suggestions@5.14.1
+yarn add @algolia/client-query-suggestions@5.14.2
 # or
-npm install @algolia/client-query-suggestions@5.14.1
+npm install @algolia/client-query-suggestions@5.14.2
 # or
-pnpm add @algolia/client-query-suggestions@5.14.1
+pnpm add @algolia/client-query-suggestions@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-query-suggestions@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-query-suggestions@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-query-suggestions@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/src/querySuggestionsClient.ts
@@ -30,7 +30,7 @@ import type {
   UpdateConfigProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 export const REGIONS = ['eu', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/client-search/README.md
+++ b/clients/algoliasearch-client-javascript/packages/client-search/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/client-search@5.14.1
+yarn add @algolia/client-search@5.14.2
 # or
-npm install @algolia/client-search@5.14.1
+npm install @algolia/client-search@5.14.2
 # or
-pnpm add @algolia/client-search@5.14.1
+pnpm add @algolia/client-search@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/client-search@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/client-search@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/client-search@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-search/src/searchClient.ts
@@ -143,7 +143,7 @@ import type {
 
 import type { BatchRequest } from '../model/batchRequest';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/ingestion/README.md
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/ingestion@1.14.1
+yarn add @algolia/ingestion@1.14.2
 # or
-npm install @algolia/ingestion@1.14.1
+npm install @algolia/ingestion@1.14.2
 # or
-pnpm add @algolia/ingestion@1.14.1
+pnpm add @algolia/ingestion@1.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/ingestion@1.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/ingestion@1.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/ingestion@1.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.1",
+  "version": "1.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/src/ingestionClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/src/ingestionClient.ts
@@ -117,7 +117,7 @@ import type { SubscriptionTrigger } from '../model/subscriptionTrigger';
 import type { TaskCreateTrigger } from '../model/taskCreateTrigger';
 import type { Trigger } from '../model/trigger';
 
-export const apiClientVersion = '1.14.1';
+export const apiClientVersion = '1.14.2';
 
 export const REGIONS = ['eu', 'us'] as const;
 export type Region = (typeof REGIONS)[number];

--- a/clients/algoliasearch-client-javascript/packages/logger-console/package.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/logger-console",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Promise-based log library using console log.",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "vitest": "2.1.4"
   },
   "dependencies": {
-    "@algolia/client-common": "5.14.1"
+    "@algolia/client-common": "5.14.2"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/clients/algoliasearch-client-javascript/packages/monitoring/README.md
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/monitoring@1.14.1
+yarn add @algolia/monitoring@1.14.2
 # or
-npm install @algolia/monitoring@1.14.1
+npm install @algolia/monitoring@1.14.2
 # or
-pnpm add @algolia/monitoring@1.14.1
+pnpm add @algolia/monitoring@1.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/monitoring@1.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/monitoring@1.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/monitoring@1.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.1",
+  "version": "1.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/monitoring/src/monitoringClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/src/monitoringClient.ts
@@ -31,7 +31,7 @@ import type {
   GetReachabilityProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '1.14.1';
+export const apiClientVersion = '1.14.2';
 
 function getDefaultHosts(): Host[] {
   return [{ url: 'status.algolia.com', accept: 'readWrite', protocol: 'https' }];

--- a/clients/algoliasearch-client-javascript/packages/recommend/README.md
+++ b/clients/algoliasearch-client-javascript/packages/recommend/README.md
@@ -41,11 +41,11 @@ All of our clients comes with type definition, and are available for both browse
 ### With a package manager
 
 ```bash
-yarn add @algolia/recommend@5.14.1
+yarn add @algolia/recommend@5.14.2
 # or
-npm install @algolia/recommend@5.14.1
+npm install @algolia/recommend@5.14.2
 # or
-pnpm add @algolia/recommend@5.14.1
+pnpm add @algolia/recommend@5.14.2
 ```
 
 ### Without a package manager
@@ -53,7 +53,7 @@ pnpm add @algolia/recommend@5.14.1
 Add the following JavaScript snippet to the <head> of your website:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@algolia/recommend@5.14.1/dist/builds/browser.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@algolia/recommend@5.14.2/dist/builds/browser.umd.js"></script>
 ```
 
 ### Usage

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.14.1",
+  "version": "5.14.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -48,10 +48,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/recommend/src/recommendClient.ts
+++ b/clients/algoliasearch-client-javascript/packages/recommend/src/recommendClient.ts
@@ -34,7 +34,7 @@ import type {
   SearchRecommendRulesProps,
 } from '../model/clientMethodProps';
 
-export const apiClientVersion = '5.14.1';
+export const apiClientVersion = '5.14.2';
 
 function getDefaultHosts(appId: string): Host[] {
   return (

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Promise-based request library for browser using xhr.",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "test:bundle": "publint . && attw --pack . --ignore-rules cjs-resolves-to-esm"
   },
   "dependencies": {
-    "@algolia/client-common": "5.14.1"
+    "@algolia/client-common": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Promise-based request library using Fetch.",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.14.1"
+    "@algolia/client-common": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Promise-based request library for node using the native http module.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.14.1"
+    "@algolia/client-common": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-testing",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "private": true,
   "description": "A package that contains the echo requester of the algoliasearch JavaScript requesters, for testing purposes",
   "repository": {
@@ -42,10 +42,10 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.14.1",
-    "@algolia/requester-browser-xhr": "5.14.1",
-    "@algolia/requester-fetch": "5.14.1",
-    "@algolia/requester-node-http": "5.14.1"
+    "@algolia/client-common": "5.14.2",
+    "@algolia/requester-browser-xhr": "5.14.2",
+    "@algolia/requester-fetch": "5.14.2",
+    "@algolia/requester-node-http": "5.14.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.0",

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@algolia/client-abtesting@npm:5.14.1, @algolia/client-abtesting@workspace:packages/client-abtesting":
+"@algolia/client-abtesting@npm:5.14.2, @algolia/client-abtesting@workspace:packages/client-abtesting":
   version: 0.0.0-use.local
   resolution: "@algolia/client-abtesting@workspace:packages/client-abtesting"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -22,14 +22,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-analytics@npm:5.14.1, @algolia/client-analytics@workspace:packages/client-analytics":
+"@algolia/client-analytics@npm:5.14.2, @algolia/client-analytics@workspace:packages/client-analytics":
   version: 0.0.0-use.local
   resolution: "@algolia/client-analytics@workspace:packages/client-analytics"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -39,7 +39,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-common@npm:5.14.1, @algolia/client-common@workspace:packages/client-common":
+"@algolia/client-common@npm:5.14.2, @algolia/client-common@workspace:packages/client-common":
   version: 0.0.0-use.local
   resolution: "@algolia/client-common@workspace:packages/client-common"
   dependencies:
@@ -58,10 +58,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/client-composition@workspace:packages/client-composition"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -71,14 +71,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-insights@npm:5.14.1, @algolia/client-insights@workspace:packages/client-insights":
+"@algolia/client-insights@npm:5.14.2, @algolia/client-insights@workspace:packages/client-insights":
   version: 0.0.0-use.local
   resolution: "@algolia/client-insights@workspace:packages/client-insights"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -88,14 +88,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-personalization@npm:5.14.1, @algolia/client-personalization@workspace:packages/client-personalization":
+"@algolia/client-personalization@npm:5.14.2, @algolia/client-personalization@workspace:packages/client-personalization":
   version: 0.0.0-use.local
   resolution: "@algolia/client-personalization@workspace:packages/client-personalization"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -105,14 +105,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-query-suggestions@npm:5.14.1, @algolia/client-query-suggestions@workspace:packages/client-query-suggestions":
+"@algolia/client-query-suggestions@npm:5.14.2, @algolia/client-query-suggestions@workspace:packages/client-query-suggestions":
   version: 0.0.0-use.local
   resolution: "@algolia/client-query-suggestions@workspace:packages/client-query-suggestions"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -122,14 +122,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-search@npm:5.14.1, @algolia/client-search@workspace:packages/client-search":
+"@algolia/client-search@npm:5.14.2, @algolia/client-search@workspace:packages/client-search":
   version: 0.0.0-use.local
   resolution: "@algolia/client-search@workspace:packages/client-search"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -139,14 +139,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/ingestion@npm:1.14.1, @algolia/ingestion@workspace:packages/ingestion":
+"@algolia/ingestion@npm:1.14.2, @algolia/ingestion@workspace:packages/ingestion":
   version: 0.0.0-use.local
   resolution: "@algolia/ingestion@workspace:packages/ingestion"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -160,7 +160,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/logger-console@workspace:packages/logger-console"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     jsdom: "npm:25.0.1"
@@ -172,14 +172,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/monitoring@npm:1.14.1, @algolia/monitoring@workspace:packages/monitoring":
+"@algolia/monitoring@npm:1.14.2, @algolia/monitoring@workspace:packages/monitoring":
   version: 0.0.0-use.local
   resolution: "@algolia/monitoring@workspace:packages/monitoring"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -189,14 +189,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/recommend@npm:5.14.1, @algolia/recommend@workspace:packages/recommend":
+"@algolia/recommend@npm:5.14.2, @algolia/recommend@workspace:packages/recommend":
   version: 0.0.0-use.local
   resolution: "@algolia/recommend@workspace:packages/recommend"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -206,11 +206,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-browser-xhr@npm:5.14.1, @algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr":
+"@algolia/requester-browser-xhr@npm:5.14.2, @algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     jsdom: "npm:25.0.1"
@@ -222,11 +222,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-fetch@npm:5.14.1, @algolia/requester-fetch@workspace:packages/requester-fetch":
+"@algolia/requester-fetch@npm:5.14.2, @algolia/requester-fetch@workspace:packages/requester-fetch":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-fetch@workspace:packages/requester-fetch"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     cross-fetch: "npm:4.0.0"
@@ -238,11 +238,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-node-http@npm:5.14.1, @algolia/requester-node-http@workspace:packages/requester-node-http":
+"@algolia/requester-node-http@npm:5.14.2, @algolia/requester-node-http@workspace:packages/requester-node-http":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-node-http@workspace:packages/requester-node-http"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     nock: "npm:13.5.6"
@@ -253,14 +253,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-testing@npm:5.14.1, @algolia/requester-testing@workspace:packages/requester-testing":
+"@algolia/requester-testing@npm:5.14.2, @algolia/requester-testing@workspace:packages/requester-testing":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-testing@workspace:packages/requester-testing"
   dependencies:
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     publint: "npm:0.2.12"
@@ -2322,20 +2322,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "algoliasearch@workspace:packages/algoliasearch"
   dependencies:
-    "@algolia/client-abtesting": "npm:5.14.1"
-    "@algolia/client-analytics": "npm:5.14.1"
-    "@algolia/client-common": "npm:5.14.1"
-    "@algolia/client-insights": "npm:5.14.1"
-    "@algolia/client-personalization": "npm:5.14.1"
-    "@algolia/client-query-suggestions": "npm:5.14.1"
-    "@algolia/client-search": "npm:5.14.1"
-    "@algolia/ingestion": "npm:1.14.1"
-    "@algolia/monitoring": "npm:1.14.1"
-    "@algolia/recommend": "npm:5.14.1"
-    "@algolia/requester-browser-xhr": "npm:5.14.1"
-    "@algolia/requester-fetch": "npm:5.14.1"
-    "@algolia/requester-node-http": "npm:5.14.1"
-    "@algolia/requester-testing": "npm:5.14.1"
+    "@algolia/client-abtesting": "npm:5.14.2"
+    "@algolia/client-analytics": "npm:5.14.2"
+    "@algolia/client-common": "npm:5.14.2"
+    "@algolia/client-insights": "npm:5.14.2"
+    "@algolia/client-personalization": "npm:5.14.2"
+    "@algolia/client-query-suggestions": "npm:5.14.2"
+    "@algolia/client-search": "npm:5.14.2"
+    "@algolia/ingestion": "npm:1.14.2"
+    "@algolia/monitoring": "npm:1.14.2"
+    "@algolia/recommend": "npm:5.14.2"
+    "@algolia/requester-browser-xhr": "npm:5.14.2"
+    "@algolia/requester-fetch": "npm:5.14.2"
+    "@algolia/requester-node-http": "npm:5.14.2"
+    "@algolia/requester-testing": "npm:5.14.2"
     "@arethetypeswrong/cli": "npm:0.17.0"
     "@types/node": "npm:22.9.0"
     jsdom: "npm:25.0.1"

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -169,7 +169,7 @@
     ],
     "folder": "clients/algoliasearch-client-javascript",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.14.1",
+    "packageVersion": "5.14.2",
     "modelFolder": "model",
     "apiFolder": "src",
     "tests": {


### PR DESCRIPTION
## 🧭 What and Why

The js release failed because tsc changed the output dir for some reason.
I tried releasing manually and failed so I had to bump all version a patch up and release on top of the buggy version.
This is very dirty and I have learned a lesson not to release on a friday night