### PR TITLE
fix(specs): do not cache searchCompositionRules

### DIFF
--- a/specs/composition/paths/rules/searchRules.yml
+++ b/specs/composition/paths/rules/searchRules.yml
@@ -2,8 +2,6 @@ post:
   tags:
     - Rules
   operationId: searchCompositionRules
-  x-use-read-transporter: true
-  x-cacheable: true
   x-acl:
     - settings
   summary: Search for composition rules


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

- remove `x-use-read-transporter` & `x-cacheable` that where set by default

## 🧪 Test
