### PR TITLE
feat(specs): default authMode to WithinHeaders for Composition Client

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -154,10 +154,9 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
     additionalProperties.put("apiName", CLIENT);
     additionalProperties.put("clientName", clientName);
     additionalProperties.put("algoliaAgent", Helpers.capitalize(CLIENT));
+    additionalProperties.put("is" + Helpers.capitalize(CLIENT) + "Client", true);
     additionalProperties.put("isSearchClient", CLIENT.equals("search") || isAlgoliasearchClient);
-    additionalProperties.put("isIngestionClient", CLIENT.equals("ingestion"));
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
-    additionalProperties.put("isAlgoliaCompositionClient", isAlgoliaCompositionClient);
     additionalProperties.put("packageVersion", Helpers.getPackageJsonVersion(packageName));
     additionalProperties.put("packageName", packageName);
     additionalProperties.put("npmPackageName", isAlgoliasearchClient ? packageName : "@algolia/" + packageName);

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -91,9 +91,9 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
     {{#isSearchClient}}
     {{> client/api/helpers}}
     {{/isSearchClient}}
-    {{#isAlgoliaCompositionClient}}
+    {{#isCompositionClient}}
     {{> client/api/compositionHelpers}}
-    {{/isAlgoliaCompositionClient}}
+    {{/isCompositionClient}}
     {{#operation}}
     {{> client/api/operation/jsdoc}}
     {{nickname}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}( {{> client/api/operation/parameters}} ) : Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}> {

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -9,9 +9,9 @@ import {
   serializeQueryParameters,
   createIterablePromise,
   {{/isSearchClient}}
-  {{#isAlgoliaCompositionClient}}
+  {{#isCompositionClient}}
   createIterablePromise,
-  {{/isAlgoliaCompositionClient}}
+  {{/isCompositionClient}}
 } from '@algolia/client-common';
 import type {
   CreateClientOptions,
@@ -42,9 +42,9 @@ import type {
     WaitForAppTaskOptions,
     WaitForTaskOptions,
   {{/isSearchClient}}
-  {{#isAlgoliaCompositionClient}}
+  {{#isCompositionClient}}
     WaitForCompositionTaskOptions,
-  {{/isAlgoliaCompositionClient}}
+  {{/isCompositionClient}}
   {{#operation}}
     {{#vendorExtensions}}
       {{#x-create-wrapping-object}}

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -12,7 +12,7 @@
     logger: createNullLogger(),
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
-    authMode: 'Within{{#isAlgoliaCompositionClient}}Headers{{/isAlgoliaCompositionClient}}{{^isAlgoliaCompositionClient}}QueryParameters{{/isAlgoliaCompositionClient}}',
+    authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{^isCompositionClient}}QueryParameters{{/isCompositionClient}}',
     responsesCache: createMemoryCache(),
     requestsCache: createMemoryCache({ serializable: false }),
     hostsCache: createFallbackableCache({

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -12,7 +12,7 @@
     logger: createNullLogger(),
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
-    authMode: 'WithinQueryParameters',
+    authMode: 'Within{{#isAlgoliaCompositionClient}}Headers{{/isAlgoliaCompositionClient}}{{^isAlgoliaCompositionClient}}QueryParameters{{/isAlgoliaCompositionClient}}',
     responsesCache: createMemoryCache(),
     requestsCache: createMemoryCache({ serializable: false }),
     hostsCache: createFallbackableCache({

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -184,7 +184,7 @@ export type ReplaceAllObjectsOptions = {
 }
 {{/isAlgoliasearchClient}}
 {{/isSearchClient}}
-{{#isAlgoliaCompositionClient}}
+{{#isCompositionClient}}
 export type WaitForCompositionTaskOptions = {
   /**
    * The maximum number of retries. 50 by default.
@@ -206,6 +206,6 @@ export type WaitForCompositionTaskOptions = {
    */
   compositionID: string;
 };
-{{/isAlgoliaCompositionClient}}
+{{/isCompositionClient}}
 
 {{/apiInfo.apis.0}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [EMERCH-1759](https://algolia.atlassian.net/browse/EMERCH-1759)

### Changes included:

- default authMode to WithinHeaders for Composition Client
- standardize variable name

## 🧪 Test


[EMERCH-1759]: https://algolia.atlassian.net/browse/EMERCH-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ