### PR TITLE
chore(deps): upgrade openapi-generator to v7.10.0

### DIFF
--- a/generators/build.gradle
+++ b/generators/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.openapitools:openapi-generator:7.8.0'
+    compileOnly 'org.openapitools:openapi-generator:7.10.0'
 }
 
 tasks.withType(JavaCompile) {

--- a/scripts/pre-gen/generateOpenapitools.ts
+++ b/scripts/pre-gen/generateOpenapitools.ts
@@ -43,7 +43,7 @@ export async function generateOpenapitools(
     JSON.stringify(
       {
         'generator-cli': {
-          version: '7.8.0',
+          version: '7.10.0',
           generators,
         },
       },

--- a/specs/common/schemas/HighlightResult.yml
+++ b/specs/common/schemas/HighlightResult.yml
@@ -43,6 +43,7 @@ highlightResultArray:
 highlightResultMap:
   type: object
   description: Surround words that match the query with HTML tags for highlighting.
+  x-is-free-form: false # openapi-generator thinks this is a free-form object since https://github.com/OpenAPITools/openapi-generator/pull/19605
   additionalProperties:
     x-additionalPropertiesName: attribute
     $ref: '#/highlightResult'

--- a/specs/common/schemas/SnippetResult.yml
+++ b/specs/common/schemas/SnippetResult.yml
@@ -16,6 +16,7 @@ snippetResultOption:
 snippetResultMap:
   type: object
   description: Snippets that show the context around a matching search query.
+  x-is-free-form: false # openapi-generator thinks this is a free-form object since https://github.com/OpenAPITools/openapi-generator/pull/19605
   additionalProperties:
     x-additionalPropertiesName: attribute
     $ref: '#/snippetResult'


### PR DESCRIPTION
## 🧭 What and Why

With 7.10.0, there are a lot fewer bug, and we can actually fix them in the spec directly thanks to a bypass.