### PR TITLE
fix(javascript): set latest version on prereleases

### DIFF
--- a/clients/algoliasearch-client-javascript/scripts/publish.ts
+++ b/clients/algoliasearch-client-javascript/scripts/publish.ts
@@ -11,7 +11,7 @@ async function publish(): Promise<void> {
 
   // publish the prereleases private packages
   await execaCommand(
-    `yarn lerna exec --scope '@algolia/client-composition' --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access private --tag alpha`,
+    `yarn lerna exec --scope '@algolia/client-composition' --no-bail -- npm_config_registry=https://registry.npmjs.org/ npm publish --access private --tag alpha --tag latest`,
     {
       shell: 'bash',
     },


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

the published alpha version isn't set as the latest available, meaning that npm shows the .1 everytime (cf screenshot)

we now set the latest tag explicitly, which seems to be enough https://www.npmjs.com/package/@algolia/client-composition?activeTab=versions

![image](https://github.com/user-attachments/assets/961ef37e-e4d4-41a9-a460-bb8a4de29be3)