### PR TITLE
docs: enrich samples with parameters and responses

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -25,6 +25,7 @@
     "@actions/core": "1.11.1",
     "@actions/exec": "1.1.1",
     "@actions/io": "1.1.3",
+    "@apidevtools/json-schema-ref-parser": "^11.7.2",
     "@har-sdk/oas": "2.10.0",
     "@octokit/rest": "21.0.2",
     "@types/express": "5.0.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -25,7 +25,7 @@
     "@actions/core": "1.11.1",
     "@actions/exec": "1.1.1",
     "@actions/io": "1.1.3",
-    "@apidevtools/json-schema-ref-parser": "^11.7.2",
+    "@apidevtools/json-schema-ref-parser": "11.7.2",
     "@har-sdk/oas": "2.10.0",
     "@octokit/rest": "21.0.2",
     "@types/express": "5.0.0",

--- a/scripts/specs/__tests__/snippets.test.ts
+++ b/scripts/specs/__tests__/snippets.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { transformCodeSamplesToGuideMethods } from '../snippets.js';
-import { SnippetSamples } from '../types.js';
+import { parseCodeSamples } from '../snippets.js';
+import { CodeSamples } from '../types.js';
 
 describe('init', () => {
   it('parses a multi line import', () => {
     expect(
-      JSON.parse(
-        transformCodeSamplesToGuideMethods({
+      JSON.stringify(
+        parseCodeSamples({
           csharp: {
             foo: {
               default: `
@@ -42,48 +42,28 @@ var response = await client.CreateConfigAsync(
           `,
             },
           },
-        } as unknown as SnippetSamples),
+        } as unknown as CodeSamples),
+        null,
+        2,
       ),
     ).toMatchInlineSnapshot(`
-      {
+      "{
         "csharp": {
           "foo": {
-            "default": "var response = await client.CreateConfigAsync(
-        new ConfigurationWithIndex
-        {
-          IndexName = "<YOUR_INDEX_NAME>",
-          SourceIndices = new List<SourceIndex>
-          {
-            new SourceIndex
-            {
-              IndexName = "<YOUR_INDEX_NAME>",
-              Facets = new List<Facet> { new Facet { Attribute = "test" } },
-              Generate = new List<List<string>>
-              {
-                new List<string> { "facetA", "facetB" },
-                new List<string> { "facetC" },
-              },
-            },
-          },
-          Languages = new Languages(new List<string> { "french" }),
-          Exclude = new List<string> { "test" },
-        }
-      );",
+            "default": "var response = await client.CreateConfigAsync(\\n  new ConfigurationWithIndex\\n  {\\n    IndexName = \\"<YOUR_INDEX_NAME>\\",\\n    SourceIndices = new List<SourceIndex>\\n    {\\n      new SourceIndex\\n      {\\n        IndexName = \\"<YOUR_INDEX_NAME>\\",\\n        Facets = new List<Facet> { new Facet { Attribute = \\"test\\" } },\\n        Generate = new List<List<string>>\\n        {\\n          new List<string> { \\"facetA\\", \\"facetB\\" },\\n          new List<string> { \\"facetC\\" },\\n        },\\n      },\\n    },\\n    Languages = new Languages(new List<string> { \\"french\\" }),\\n    Exclude = new List<string> { \\"test\\" },\\n  }\\n);"
           },
           "init": {
-            "default": "var client = new QuerySuggestionsClient(
-        new QuerySuggestionsConfig("YOUR_APP_ID", "YOUR_API_KEY", "YOUR_APP_ID_REGION")
-      );",
-          },
-        },
-      }
+            "default": "var client = new QuerySuggestionsClient(\\n  new QuerySuggestionsConfig(\\"YOUR_APP_ID\\", \\"YOUR_API_KEY\\", \\"YOUR_APP_ID_REGION\\")\\n);"
+          }
+        }
+      }"
     `);
   });
 
   it('parses a single line import', () => {
     expect(
-      JSON.parse(
-        transformCodeSamplesToGuideMethods({
+      JSON.stringify(
+        parseCodeSamples({
           csharp: {
             foo: {
               default: `
@@ -116,39 +96,21 @@ var response = await client.CreateConfigAsync(
           `,
             },
           },
-        } as unknown as SnippetSamples),
+        } as unknown as CodeSamples),
+        null,
+        2,
       ),
     ).toMatchInlineSnapshot(`
-      {
+      "{
         "csharp": {
           "foo": {
-            "default": "var response = await client.CreateConfigAsync(
-        new ConfigurationWithIndex
-        {
-          IndexName = "<YOUR_INDEX_NAME>",
-          SourceIndices = new List<SourceIndex>
-          {
-            new SourceIndex
-            {
-              IndexName = "<YOUR_INDEX_NAME>",
-              Facets = new List<Facet> { new Facet { Attribute = "test" } },
-              Generate = new List<List<string>>
-              {
-                new List<string> { "facetA", "facetB" },
-                new List<string> { "facetC" },
-              },
-            },
-          },
-          Languages = new Languages(new List<string> { "french" }),
-          Exclude = new List<string> { "test" },
-        }
-      );",
+            "default": "var response = await client.CreateConfigAsync(\\n  new ConfigurationWithIndex\\n  {\\n    IndexName = \\"<YOUR_INDEX_NAME>\\",\\n    SourceIndices = new List<SourceIndex>\\n    {\\n      new SourceIndex\\n      {\\n        IndexName = \\"<YOUR_INDEX_NAME>\\",\\n        Facets = new List<Facet> { new Facet { Attribute = \\"test\\" } },\\n        Generate = new List<List<string>>\\n        {\\n          new List<string> { \\"facetA\\", \\"facetB\\" },\\n          new List<string> { \\"facetC\\" },\\n        },\\n      },\\n    },\\n    Languages = new Languages(new List<string> { \\"french\\" }),\\n    Exclude = new List<string> { \\"test\\" },\\n  }\\n);"
           },
           "init": {
-            "default": "var client = new QuerySuggestionsClient(new Client("YOUR_APP_ID", "YOUR_API_KEY", "YOUR_APP_ID_REGION"));",
-          },
-        },
-      }
+            "default": "var client = new QuerySuggestionsClient(new Client(\\"YOUR_APP_ID\\", \\"YOUR_API_KEY\\", \\"YOUR_APP_ID_REGION\\"));"
+          }
+        }
+      }"
     `);
   });
 });
@@ -156,8 +118,8 @@ var response = await client.CreateConfigAsync(
 describe('initialize', () => {
   it("doesn't stop at `client`", () => {
     expect(
-      JSON.parse(
-        transformCodeSamplesToGuideMethods({
+      JSON.stringify(
+        parseCodeSamples({
           csharp: {
             foo: {
               default: `
@@ -192,41 +154,21 @@ var response = await client.CreateConfigAsync(
           `,
             },
           },
-        } as unknown as SnippetSamples),
+        } as unknown as CodeSamples),
+        null,
+        2,
       ),
     ).toMatchInlineSnapshot(`
-      {
+      "{
         "csharp": {
           "foo": {
-            "default": "var response = await client.CreateConfigAsync(
-        new ConfigurationWithIndex
-        {
-          IndexName = "<YOUR_INDEX_NAME>",
-          SourceIndices = new List<SourceIndex>
-          {
-            new SourceIndex
-            {
-              IndexName = "<YOUR_INDEX_NAME>",
-              Facets = new List<Facet> { new Facet { Attribute = "test" } },
-              Generate = new List<List<string>>
-              {
-                new List<string> { "facetA", "facetB" },
-                new List<string> { "facetC" },
-              },
-            },
-          },
-          Languages = new Languages(new List<string> { "french" }),
-          Exclude = new List<string> { "test" },
-        }
-      );",
+            "default": "var response = await client.CreateConfigAsync(\\n  new ConfigurationWithIndex\\n  {\\n    IndexName = \\"<YOUR_INDEX_NAME>\\",\\n    SourceIndices = new List<SourceIndex>\\n    {\\n      new SourceIndex\\n      {\\n        IndexName = \\"<YOUR_INDEX_NAME>\\",\\n        Facets = new List<Facet> { new Facet { Attribute = \\"test\\" } },\\n        Generate = new List<List<string>>\\n        {\\n          new List<string> { \\"facetA\\", \\"facetB\\" },\\n          new List<string> { \\"facetC\\" },\\n        },\\n      },\\n    },\\n    Languages = new Languages(new List<string> { \\"french\\" }),\\n    Exclude = new List<string> { \\"test\\" },\\n  }\\n);"
           },
           "init": {
-            "default": "var client = new QuerySuggestionsClient(
-        new QuerySuggestionsConfig("YOUR_APP_ID", "YOUR_API_KEY", "YOUR_APP_ID_REGION")
-      );",
-          },
-        },
-      }
+            "default": "var client = new QuerySuggestionsClient(\\n  new QuerySuggestionsConfig(\\"YOUR_APP_ID\\", \\"YOUR_API_KEY\\", \\"YOUR_APP_ID_REGION\\")\\n);"
+          }
+        }
+      }"
     `);
   });
 });

--- a/scripts/specs/format.ts
+++ b/scripts/specs/format.ts
@@ -52,7 +52,7 @@ export async function bundleSpecsForDoc(bundledPath: string, clientName: string)
   const tagsDefinitions = bundledSpec.tags;
   const codeSamples = await transformGeneratedSnippetsToCodeSamples(clientName);
 
-  await bundleCodeSamplesForDoc(JSON.parse(JSON.stringify(codeSamples)), clientName);
+  await bundleCodeSamplesForDoc(bundledSpec, JSON.parse(JSON.stringify(codeSamples)), clientName);
 
   for (const [pathKey, pathMethods] of Object.entries(bundledSpec.paths)) {
     for (const [method, specMethod] of Object.entries(pathMethods)) {

--- a/scripts/specs/index.ts
+++ b/scripts/specs/index.ts
@@ -3,11 +3,11 @@ import fsp from 'fs/promises';
 import yaml from 'js-yaml';
 
 import { Cache } from '../cache.js';
-import { run, toAbsolutePath } from '../common.js';
+import { exists, run, toAbsolutePath } from '../common.js';
 import { createSpinner } from '../spinners.js';
 import type { Spec } from '../types.js';
 
-import { lintCommon, transformBundle } from './format.js';
+import { bundleSpecsForClient, bundleSpecsForDoc, lintCommon } from './format.js';
 import type { BaseBuildSpecsOptions } from './types.js';
 
 const ALGOLIASEARCH_LITE_OPERATIONS = ['search', 'customPost', 'getRecommendations'];
@@ -53,12 +53,7 @@ async function buildLiteSpec({
   // remove unused components for the outputted light spec
   await run(`yarn openapi bundle ${bundledPath} -o ${bundledPath} --ext yml --remove-unused-components`);
 
-  await transformBundle({
-    bundledPath,
-    clientName: spec,
-    // Lite does not need documentation because it's just a subset
-    docs: false,
-  });
+  await bundleSpecsForClient(bundledPath, spec);
 }
 
 /**
@@ -70,15 +65,15 @@ async function buildSpec({
   docs,
   useCache,
 }: BaseBuildSpecsOptions & { spec: string }): Promise<void> {
-  const isAlgoliasearch = spec === 'algoliasearch';
+  const isLiteSpec = spec === 'algoliasearch';
 
-  if (docs && isAlgoliasearch) {
+  if (docs && isLiteSpec) {
     return;
   }
 
   // In case of lite we use a the `search` spec as a base because only its bundled form exists.
-  const specBase = isAlgoliasearch ? 'search' : spec;
-  const deps = isAlgoliasearch ? ['search', 'recommend'] : [spec];
+  const specBase = isLiteSpec ? 'search' : spec;
+  const deps = isLiteSpec ? ['search', 'recommend'] : [spec];
   const logSuffix = docs ? 'doc spec' : 'spec';
   const cache = new Cache({
     folder: toAbsolutePath('specs/'),
@@ -105,16 +100,16 @@ async function buildSpec({
   await run(`yarn specs:fix ${specBase}`);
 
   // Then bundle the file
-  const bundledPath = `specs/bundled/${spec}.${docs ? 'doc.' : ''}${outputFormat}`;
+  const bundledPath = toAbsolutePath(`specs/bundled/${spec}.${docs ? 'doc.' : ''}${outputFormat}`);
   await run(`yarn openapi bundle specs/${specBase}/spec.yml -o ${bundledPath} --ext ${outputFormat}`);
 
+  if (!(await exists(bundledPath))) {
+    throw new Error(`Bundled file not found ${bundledPath}.`);
+  }
+
   // Add the correct tags to be able to generate the proper client
-  if (!isAlgoliasearch) {
-    await transformBundle({
-      bundledPath: toAbsolutePath(bundledPath),
-      clientName: spec,
-      docs,
-    });
+  if (!isLiteSpec) {
+    docs ? await bundleSpecsForDoc(bundledPath, spec) : await bundleSpecsForClient(bundledPath, spec);
   } else {
     await buildLiteSpec({
       spec,

--- a/scripts/specs/snippets.ts
+++ b/scripts/specs/snippets.ts
@@ -3,9 +3,9 @@ import fsp from 'fs/promises';
 import { GENERATORS, capitalize, createClientName, exists, toAbsolutePath } from '../common.js';
 import type { Language } from '../types.js';
 
-import type { CodeSamples, SnippetForMethod, SnippetSamples } from './types.js';
+import type { CodeSamples, OpenAPICodeSample, SampleForOperation } from './types.js';
 
-export function getCodeSampleLabel(language: Language): CodeSamples['label'] {
+export function getCodeSampleLabel(language: Language): OpenAPICodeSample['label'] {
   switch (language) {
     case 'csharp':
       return 'C#';
@@ -14,14 +14,14 @@ export function getCodeSampleLabel(language: Language): CodeSamples['label'] {
     case 'php':
       return 'PHP';
     default:
-      return capitalize(language) as CodeSamples['label'];
+      return capitalize(language) as OpenAPICodeSample['label'];
   }
 }
 
-// Iterates over the snippet samples and sanitize the data to only keep the method part in order to use it in the guides.
-export function transformCodeSamplesToGuideMethods(snippetSamples: SnippetSamples): string {
-  for (const [language, operationWithSample] of Object.entries(snippetSamples)) {
-    for (const [operation, samples] of Object.entries(operationWithSample)) {
+// Iterates over the result of `transformSnippetsToCodeSamples` in order to generate a JSON file for the doc to consume.
+export async function bundleCodeSamplesForDoc(codeSamples: CodeSamples, clientName: string): Promise<void> {
+  for (const [language, operationWithSamples] of Object.entries(codeSamples)) {
+    for (const [operation, samples] of Object.entries(operationWithSamples)) {
       if (operation === 'import') {
         continue;
       }
@@ -37,25 +37,25 @@ export function transformCodeSamplesToGuideMethods(snippetSamples: SnippetSample
         const initLine = sampleMatch[1];
         const callLine = sampleMatch[3];
 
-        if (!('init' in snippetSamples[language])) {
-          snippetSamples[language].init = {
+        if (!('init' in codeSamples[language])) {
+          codeSamples[language].init = {
             default: initLine.trim(),
           };
         }
 
-        snippetSamples[language][operation][sampleName] = callLine.trim();
+        codeSamples[language][operation][sampleName] = callLine.trim();
       }
     }
   }
 
-  return JSON.stringify(snippetSamples, null, 2);
+  await fsp.writeFile(toAbsolutePath(`docs/bundled/${clientName}-snippets.json`), JSON.stringify(codeSamples, null, 2));
 }
 
-// For a given `clientName`, reads the matching snippet file for every available clients and builds an hashmap of snippets per operationId per language.
-export async function transformSnippetsToCodeSamples(clientName: string): Promise<SnippetSamples> {
-  const snippetSamples = Object.values(GENERATORS).reduce(
+// Reads the generated `docs/snippets/` file for every languages of the given `clientName` and builds an hashmap of snippets per operationId per language.
+export async function transformGeneratedSnippetsToCodeSamples(clientName: string): Promise<CodeSamples> {
+  const codeSamples = Object.values(GENERATORS).reduce<CodeSamples>(
     (prev, curr) => ({ ...prev, [curr.language]: {} }),
-    {} as SnippetSamples,
+    {} as CodeSamples,
   );
 
   for (const gen of Object.values(GENERATORS)) {
@@ -76,7 +76,7 @@ export async function transformSnippetsToCodeSamples(clientName: string): Promis
 
     const importMatch = snippetFileContent.match(/>IMPORT\n([\s\S]*?)\n.*IMPORT</);
     if (importMatch) {
-      snippetSamples[gen.language].import = {
+      codeSamples[gen.language].import = {
         default: importMatch[1].trim(),
       };
     }
@@ -91,13 +91,13 @@ export async function transformSnippetsToCodeSamples(clientName: string): Promis
       const operationId = match[1];
       const testName = match[2] || 'default';
 
-      if (!snippetSamples[gen.language][operationId]) {
-        snippetSamples[gen.language][operationId] = {};
+      if (!codeSamples[gen.language][operationId]) {
+        codeSamples[gen.language][operationId] = {};
       }
 
-      const snippetForMethod: SnippetForMethod = snippetSamples[gen.language][operationId];
+      const sampleForOperation: SampleForOperation = codeSamples[gen.language][operationId];
 
-      snippetForMethod[testName] = '';
+      sampleForOperation[testName] = '';
 
       const indent = lines[0].length - lines[0].trim().length;
       // skip first and last lines because they contain the SEPARATOR or operationId
@@ -105,10 +105,10 @@ export async function transformSnippetsToCodeSamples(clientName: string): Promis
         // best effort to determine how far the snippet is indented so we
         // can have every snippets in the documentation on the far left
         // without impacting the formatting
-        snippetForMethod[testName] += `${line.slice(indent).replaceAll(/\t/g, '  ')}\n`;
+        sampleForOperation[testName] += `${line.slice(indent).replaceAll(/\t/g, '  ')}\n`;
       });
     }
   }
 
-  return snippetSamples;
+  return codeSamples;
 }

--- a/scripts/specs/snippets.ts
+++ b/scripts/specs/snippets.ts
@@ -19,8 +19,7 @@ export function getCodeSampleLabel(language: Language): OpenAPICodeSample['label
   }
 }
 
-// Iterates over the result of `transformSnippetsToCodeSamples` in order to generate a JSON file for the doc to consume.
-export async function bundleCodeSamplesForDoc(spec: Spec, codeSamples: CodeSamples, clientName: string): Promise<void> {
+export function parseCodeSamples(codeSamples: CodeSamples): CodeSamples {
   // first we build the end JSON file with our given code samples
   for (const [language, operationWithSamples] of Object.entries(codeSamples)) {
     for (const [operation, samples] of Object.entries(operationWithSamples)) {
@@ -49,6 +48,13 @@ export async function bundleCodeSamplesForDoc(spec: Spec, codeSamples: CodeSampl
       }
     }
   }
+
+  return codeSamples;
+}
+
+// Iterates over the result of `transformSnippetsToCodeSamples` in order to generate a JSON file for the doc to consume.
+export async function bundleCodeSamplesForDoc(spec: Spec, codeSamples: CodeSamples, clientName: string): Promise<void> {
+  codeSamples = parseCodeSamples(codeSamples);
 
   const codeSamplesWithParameters = { ...codeSamples } as CodeSamplesWithAPIDefinition;
   const dereferencedSpec = (await $RefParser.dereference(spec, {

--- a/scripts/specs/types.ts
+++ b/scripts/specs/types.ts
@@ -6,10 +6,10 @@ export type BaseBuildSpecsOptions = {
   useCache: boolean;
 };
 
-export type SnippetForMethod = Record<string, string>;
-export type SnippetSamples = Record<Language, Record<string, SnippetForMethod>>;
+export type SampleForOperation = Record<string, string>;
+export type CodeSamples = Record<Language, Record<string, SampleForOperation>>;
 
-export type CodeSamples = {
+export type OpenAPICodeSample = {
   lang:
     | 'c'
     | 'c++'

--- a/scripts/specs/types.ts
+++ b/scripts/specs/types.ts
@@ -6,12 +6,19 @@ export type BaseBuildSpecsOptions = {
   useCache: boolean;
 };
 
+export type SampleForOperationWithAPIDefinition = SampleForOperation & {
+  parameters: Array<Record<string, any>>;
+  responses: Record<string, Record<string, any>>;
+};
+export type CodeSamplesWithAPIDefinition = Record<Language, Record<string, SampleForOperationWithAPIDefinition>>;
+
 export type SampleForOperation = Record<string, string>;
 export type CodeSamples = Record<Language, Record<string, SampleForOperation>>;
 
 export type OpenAPICodeSample = {
   lang:
     | 'c'
+    | 'cURL'
     | 'c++'
     | 'coffeescript'
     | 'csharp'
@@ -38,6 +45,7 @@ export type OpenAPICodeSample = {
     | 'typescript';
   label:
     | 'C'
+    | 'curl'
     | 'C#'
     | 'C++'
     | 'CoffeeScript'

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,6 +1,6 @@
 import type config from '../config/clients.config.json';
 
-import type { CodeSamples } from './specs/types.js';
+import type { OpenAPICodeSample } from './specs/types.js';
 
 /**
  * Config.
@@ -46,6 +46,8 @@ export type Spec = {
   paths: Path;
   components: {
     schemas: Record<string, any>;
+    parameters: Record<string, any>;
+    responses: Record<string, any>;
     securitySchemes: Partial<{ appId?: Record<string, any>; apiKey?: Record<string, any> }>;
   };
 };
@@ -77,11 +79,17 @@ type Method = 'delete' | 'get' | 'options' | 'patch' | 'post' | 'put';
 /**
  * Paths of a spec.
  */
-type Path = Record<
-  Method,
-  Record<string, any> & {
-    operationId: string;
-    'x-codeSamples': CodeSamples[];
-    summary: string;
-  }
->;
+export type Path = Record<string, Record<Method, Operation>>;
+
+export type Operation = {
+  operationId: string;
+  'x-codeSamples': OpenAPICodeSample[];
+  summary: string;
+  requestBody?: {
+    required: boolean;
+    description: string;
+    content?: { 'application/json'?: { schema?: { properties?: Record<string, any> } } };
+  };
+  parameters: Array<Record<string, any>>;
+  responses: Record<string, Record<string, any>>;
+} & Record<string, unknown>;


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3226

### Changes included:

this pr aims at enriching the generated snippets files with the parameters and responses of each operation

----

review disclaimer:

- the first commit (https://github.com/algolia/api-clients-automation/pull/4140/commits/8bff73601c5fff1c51c22d2012bd9629102d4d3d) only contains some renaming and type fixes, no behavioral changes
- the subsequent commits however contains the logic that enriches the JSON files

----

observations:

- it could be nice to handle multiple snippets in the API ref directly, so we could just provide a dereferenced JSON version of it and avoid this logic
- our snippet files follow the `language.operationID` schema, which forces us to duplicate every parameters and responses here. Doing `operationID.language` would allow us to have `parameters` and `responses` at the root, so less duplication