### PR TITLE
fix(python): expose `user_agent` on the config

### DIFF
--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -36,3 +36,10 @@ class BaseConfig:
         if self.headers is None:
             self.headers = {}
         self.headers["x-algolia-api-key"] = api_key
+
+    def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
+        """adds a segment to the default user agent, and update the headers sent with each requests as well"""
+        self.user_agent = self.user_agent.add(segment, version)
+
+        if self.headers is not None:
+            self.headers["user-agent"] = self.user_agent.get()

--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -2,6 +2,7 @@ from os import environ
 from typing import Dict, Optional
 
 from algoliasearch.http.hosts import HostsCollection
+from algoliasearch.http.user_agent import UserAgent
 
 
 class BaseConfig:
@@ -26,6 +27,8 @@ class BaseConfig:
         self.headers: Optional[Dict[str, str]] = None
         self.proxies: Optional[Dict[str, str]] = None
         self.hosts: Optional[HostsCollection] = None
+
+        self.user_agent: UserAgent = UserAgent()
 
     def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""

--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -28,7 +28,7 @@ class BaseConfig:
         self.proxies: Optional[Dict[str, str]] = None
         self.hosts: Optional[HostsCollection] = None
 
-        self.user_agent: UserAgent = UserAgent()
+        self._user_agent: UserAgent = UserAgent()
 
     def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""
@@ -39,7 +39,7 @@ class BaseConfig:
 
     def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
         """adds a segment to the default user agent, and update the headers sent with each requests as well"""
-        self.user_agent = self.user_agent.add(segment, version)
+        self._user_agent = self._user_agent.add(segment, version)
 
         if self.headers is not None:
-            self.headers["user-agent"] = self.user_agent.get()
+            self.headers["user-agent"] = self._user_agent.get()

--- a/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
@@ -19,6 +19,10 @@ class UserAgent:
     def get(self) -> str:
         return self.value
 
-    def add(self, segment: str, version: Optional[str] = __version__) -> Self:
-        self.value += "; {} ({})".format(segment, __version__ if version is None else version)
+    def add(self, segment: str, version: Optional[str] = None) -> Self:
+        self.value += "; {}".format(segment)
+
+        if version is not None:
+            self.value += " ({})".format(version)
+
         return self

--- a/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
@@ -20,5 +20,7 @@ class UserAgent:
         return self.value
 
     def add(self, segment: str, version: Optional[str] = __version__) -> Self:
-        self.value += "; {} ({})".format(segment, __version__ if version is None else version)
+        self.value += "; {} ({})".format(
+            segment, __version__ if version is None else version
+        )
         return self

--- a/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
@@ -20,7 +20,5 @@ class UserAgent:
         return self.value
 
     def add(self, segment: str, version: Optional[str] = __version__) -> Self:
-        self.value += "; {} ({})".format(
-            segment, __version__ if version is None else version
-        )
+        self.value += "; {} ({})".format(segment, __version__ if version is None else version)
         return self

--- a/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/user_agent.py
@@ -20,5 +20,5 @@ class UserAgent:
         return self.value
 
     def add(self, segment: str, version: Optional[str] = __version__) -> Self:
-        self.value += "; {} ({})".format(segment, version)
+        self.value += "; {} ({})".format(segment, __version__ if version is None else version)
         return self

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -15,6 +15,7 @@ def main():
     )
     client._config.user_agent.add("playground")
 
+    print("user_agent", client._config.user_agent.get())
     print("client initialized", client)
 
     try:

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -13,6 +13,8 @@ def main():
     client = SearchClientSync(
         environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
     )
+    client._config.user_agent.add("playground")
+
     print("client initialized", client)
 
     try:

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -13,7 +13,7 @@ def main():
     client = SearchClientSync(
         environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
     )
-    client._config.user_agent.add("playground")
+    client.add_user_agent("playground")
 
     print("user_agent", client._config.user_agent.get())
     print("client initialized", client)

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -14,6 +14,7 @@ def main():
         environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
     )
     client.add_user_agent("playground")
+    client.add_user_agent("bar", "baz")
 
     print("user_agent", client._config._user_agent.get())
     print("client initialized", client)

--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -15,7 +15,7 @@ def main():
     )
     client.add_user_agent("playground")
 
-    print("user_agent", client._config.user_agent.get())
+    print("user_agent", client._config._user_agent.get())
     print("client initialized", client)
 
     try:

--- a/playground/python/poetry.lock
+++ b/playground/python/poetry.lock
@@ -139,7 +139,7 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "algoliasearch"
-version = "4.9.1"
+version = "4.9.2"
 description = "A fully-featured and blazing-fast Python API client to interact with Algolia."
 optional = false
 python-versions = ">= 3.8.1"
@@ -147,7 +147,7 @@ files = []
 develop = true
 
 [package.dependencies]
-aiohttp = ">= 3.9.2"
+aiohttp = ">= 3.10.11"
 async-timeout = ">= 4.0.3"
 pydantic = ">= 2"
 python-dateutil = ">= 2.8.2"

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -102,6 +102,10 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         """Sets a new API key to authenticate requests."""
         self._transporter.config.set_client_api_key(api_key)
 
+    {{^isSyncClient}}async {{/isSyncClient}}def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
+        """adds a segment to the default user agent, and update the headers sent with each requests as well"""
+        self._transporter.config.add_user_agent(segment, version)
+
     {{#isSearchClient}}
 {{> search_helpers}}
     {{/isSearchClient}}

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -98,11 +98,11 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         return self._transporter.close()
     {{/isSyncClient}}
     
-    def set_client_api_key(self, api_key: str) -> None:
+    {{^isSyncClient}}async {{/isSyncClient}}def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""
         self._transporter.config.set_client_api_key(api_key)
 
-    def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
+    {{^isSyncClient}}async {{/isSyncClient}}def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
         """adds a segment to the default user agent, and update the headers sent with each requests as well"""
         self._transporter.config.add_user_agent(segment, version)
 

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -98,11 +98,11 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         return self._transporter.close()
     {{/isSyncClient}}
     
-    {{^isSyncClient}}async {{/isSyncClient}}def set_client_api_key(self, api_key: str) -> None:
+    def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""
         self._transporter.config.set_client_api_key(api_key)
 
-    {{^isSyncClient}}async {{/isSyncClient}}def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
+    def add_user_agent(self, segment: str, version: Optional[str] = None) -> None:
         """adds a segment to the default user agent, and update the headers sent with each requests as well"""
         self._transporter.config.add_user_agent(segment, version)
 

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -8,13 +8,15 @@ from algoliasearch.http.hosts import (
 )
 from algoliasearch.http.user_agent import UserAgent
 from algoliasearch.http.base_config import BaseConfig
+from algoliasearch import __version__
 
 
 class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
     def __init__(self, app_id: Optional[str], api_key: Optional[str]{{#hasRegionalHost}}, region: {{#fallbackToAliasHost}}Optional[str] = None{{/fallbackToAliasHost}}{{^fallbackToAliasHost}}str = ""{{/fallbackToAliasHost}}{{/hasRegionalHost}}) -> None:
         super().__init__(app_id, api_key)
 
-        self._user_agent = UserAgent().add("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}")
+        self._user_agent = UserAgent()
+        self.add_user_agent("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}", __version__)
 
         if app_id is None or not app_id:
              raise ValueError("`app_id` is missing.")

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -14,7 +14,7 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
     def __init__(self, app_id: Optional[str], api_key: Optional[str]{{#hasRegionalHost}}, region: {{#fallbackToAliasHost}}Optional[str] = None{{/fallbackToAliasHost}}{{^fallbackToAliasHost}}str = ""{{/fallbackToAliasHost}}{{/hasRegionalHost}}) -> None:
         super().__init__(app_id, api_key)
 
-        self.user_agent = UserAgent().add("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}")
+        self._user_agent = UserAgent().add("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}")
 
         if app_id is None or not app_id:
              raise ValueError("`app_id` is missing.")
@@ -25,7 +25,7 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
         self.headers = {
              "x-algolia-application-id": app_id,
              "x-algolia-api-key": api_key,
-             "user-agent": self.user_agent.get(),
+             "user-agent": self._user_agent.get(),
              "content-type": "application/json",
          }
 

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -14,7 +14,7 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
     def __init__(self, app_id: Optional[str], api_key: Optional[str]{{#hasRegionalHost}}, region: {{#fallbackToAliasHost}}Optional[str] = None{{/fallbackToAliasHost}}{{^fallbackToAliasHost}}str = ""{{/fallbackToAliasHost}}{{/hasRegionalHost}}) -> None:
         super().__init__(app_id, api_key)
 
-        user_agent = UserAgent().add("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}")
+        self.user_agent = UserAgent().add("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}")
 
         if app_id is None or not app_id:
              raise ValueError("`app_id` is missing.")
@@ -25,7 +25,7 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
         self.headers = {
              "x-algolia-application-id": app_id,
              "x-algolia-api-key": api_key,
-             "user-agent": user_agent.get(),
+             "user-agent": self.user_agent.get(),
              "content-type": "application/json",
          }
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

there's no easy way to just get the user agent or just add segments to it, rather than keeping it local to the config we could just expose it so it's easier to play with