### PR TITLE
fix(specs): `nb_api_calls` in `getLogs` response is optional

### DIFF
--- a/specs/search/paths/advanced/getLogs.yml
+++ b/specs/search/paths/advanced/getLogs.yml
@@ -152,7 +152,6 @@ get:
                     - ip
                     - query_headers
                     - sha1
-                    - nb_api_calls
                     - processing_time_ms
     '400':
       $ref: '../../../common/responses/BadRequest.yml'


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

closes https://github.com/algolia/api-clients-automation/issues/4139

this parameter isn't required in the response, I also checked previous major versions and it was already optional