### PR TITLE
fix(javascript): allow async param on createIterablePromise

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "vitest --run",
+    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "devDependencies": {

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "devDependencies": {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/cache/browser-local-storage-cache.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/cache/browser-local-storage-cache.test.ts
@@ -91,7 +91,7 @@ describe('browser local storage cache', () => {
 
     await cache.clear();
 
-    const defaultValue = (): Promise<void> => Promise.resolve({ bar: 2 });
+    const defaultValue = (): Promise<{ bar: number }> => Promise.resolve({ bar: 2 });
 
     expect(localStorage.length).toBe(0);
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/create-iterable-promise.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/create-iterable-promise.test.ts
@@ -53,6 +53,26 @@ describe('createIterablePromise', () => {
       await expect(promise).resolves.toEqual(3);
       expect(calls).toBe(3);
     });
+
+    test('allow async function', async () => {
+      createIterablePromise({
+        func: () => {
+          return Promise.resolve({
+            hits: [],
+            cursor: '',
+          });
+        },
+        validate: async () => {
+          return await Promise.resolve(true);
+        },
+        aggregator: async (res) => {
+          return await Promise.resolve(res);
+        },
+        timeout: async () => {
+          return await Promise.resolve(1000);
+        },
+      });
+    });
   });
 
   describe('aggregator', () => {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/createIterablePromise.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/createIterablePromise.ts
@@ -20,22 +20,25 @@ export function createIterablePromise<TResponse>({
   const retry = (previousResponse?: TResponse): Promise<TResponse> => {
     return new Promise<TResponse>((resolve, reject) => {
       func(previousResponse)
-        .then((response) => {
+        .then(async (response) => {
           if (aggregator) {
-            aggregator(response);
+            await aggregator(response);
           }
 
-          if (validate(response)) {
+          if (await validate(response)) {
             return resolve(response);
           }
 
-          if (error && error.validate(response)) {
-            return reject(new Error(error.message(response)));
+          if (error && (await error.validate(response))) {
+            return reject(new Error(await error.message(response)));
           }
 
-          return setTimeout(() => {
-            retry(response).then(resolve).catch(reject);
-          }, timeout());
+          return setTimeout(
+            () => {
+              retry(response).then(resolve).catch(reject);
+            },
+            await timeout(),
+          );
         })
         .catch((err) => {
           reject(err);

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/createIterablePromise.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/createIterablePromise.ts
@@ -2,7 +2,7 @@ export type IterableOptions<TResponse> = Partial<{
   /**
    * The function that runs right after the API call has been resolved, allows you to do anything with the response before `validate`.
    */
-  aggregator: (response: TResponse) => void;
+  aggregator: (response: TResponse) => unknown | PromiseLike<unknown>;
 
   /**
    * The `validate` condition to throw an error and its message.
@@ -11,18 +11,18 @@ export type IterableOptions<TResponse> = Partial<{
     /**
      * The function to validate the error condition.
      */
-    validate: (response: TResponse) => boolean;
+    validate: (response: TResponse) => boolean | PromiseLike<boolean>;
 
     /**
      * The error message to throw.
      */
-    message: (response: TResponse) => string;
+    message: (response: TResponse) => string | PromiseLike<string>;
   };
 
   /**
    * The function to decide how long to wait between iterations.
    */
-  timeout: () => number;
+  timeout: () => number | PromiseLike<number>;
 }>;
 
 export type CreateIterablePromise<TResponse> = IterableOptions<TResponse> & {
@@ -36,5 +36,5 @@ export type CreateIterablePromise<TResponse> = IterableOptions<TResponse> & {
   /**
    * The validator function. It receive the resolved return of the API call.
    */
-  validate: (response: TResponse) => boolean;
+  validate: (response: TResponse) => boolean | PromiseLike<boolean>;
 };

--- a/clients/algoliasearch-client-javascript/packages/client-common/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["dist", "node_modules", "src/__tests__"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/logger-console/package.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "tsc --noEmit__tests__/* && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "devDependencies": {

--- a/clients/algoliasearch-client-javascript/packages/logger-console/package.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "vitest --run",
+    "test": "tsc --noEmit__tests__/* && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "devDependencies": {

--- a/clients/algoliasearch-client-javascript/packages/logger-console/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src", "index.ts"],
-  "exclude": ["dist", "node_modules", "src/__tests__"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:bundle": "publint . && attw --pack . --ignore-rules cjs-resolves-to-esm"
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "vitest --run",
+    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
     "test:bundle": "publint . && attw --pack . --ignore-rules cjs-resolves-to-esm"
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/__tests__/browser-xhr-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/src/__tests__/browser-xhr-requester.test.ts
@@ -114,7 +114,7 @@ describe('timeout handling', () => {
 
   afterAll(
     () =>
-      new Promise((done) => {
+      new Promise<void>((done) => {
         done();
       }),
   );

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["dist", "node_modules", "src/__tests__"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "vitest --run",
+    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/src/__tests__/fetch-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/src/__tests__/fetch-requester.test.ts
@@ -108,7 +108,7 @@ describe('timeout handling', () => {
 
   afterAll(
     () =>
-      new Promise((done) => {
+      new Promise<void>((done) => {
         done();
       }),
   );

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["dist", "node_modules", "src/__tests__"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "vitest --run",
+    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "yarn clean && yarn tsup",
     "clean": "rm -rf ./dist || true",
-    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
@@ -164,7 +164,7 @@ describe('timeout handling', () => {
 
   afterAll(
     () =>
-      new Promise((done) => {
+      new Promise<void>((done) => {
         done();
       }),
   );

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/tsconfig.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node", "vitest/globals"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["dist", "node_modules", "src/__tests__"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/playground/javascript/node/ingestion.ts
+++ b/playground/javascript/node/ingestion.ts
@@ -1,4 +1,4 @@
-import { ApiError, createIterablePromise } from '@algolia/client-common';
+import { ApiError } from '@algolia/client-common';
 import { ingestionClient } from '@algolia/ingestion';
 
 const appId = process.env.ALGOLIA_APPLICATION_ID || '**** APP_ID *****';

--- a/playground/javascript/node/ingestion.ts
+++ b/playground/javascript/node/ingestion.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@algolia/client-common';
+import { ApiError, createIterablePromise } from '@algolia/client-common';
 import { ingestionClient } from '@algolia/ingestion';
 
 const appId = process.env.ALGOLIA_APPLICATION_ID || '**** APP_ID *****';

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn tsup && yarn rollup -c rollup.config.js",
     "clean": "rm -rf ./dist || true",
     {{#isAlgoliasearchClient}}
-    "test": "tsc --noEmit && vitest --run",
+    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
     {{/isAlgoliasearchClient}}
     "test:bundle": "publint . && attw --pack ."
   },

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn tsup && yarn rollup -c rollup.config.js",
     "clean": "rm -rf ./dist || true",
     {{#isAlgoliasearchClient}}
-    "test": "vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     {{/isAlgoliasearchClient}}
     "test:bundle": "publint . && attw --pack ."
   },

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn tsup && yarn rollup -c rollup.config.js",
     "clean": "rm -rf ./dist || true",
     {{#isAlgoliasearchClient}}
-    "test": "tsc --noEmit src/__tests__/**/*.ts && vitest --run",
+    "test": "tsc --noEmit && vitest --run",
     {{/isAlgoliasearchClient}}
     "test:bundle": "publint . && attw --pack ."
   },

--- a/templates/javascript/clients/package.mustache
+++ b/templates/javascript/clients/package.mustache
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn tsup && yarn rollup -c rollup.config.js",
     "clean": "rm -rf ./dist || true",
     {{#isAlgoliasearchClient}}
-    "test": "tsc --noEmit && vitest --run",
+    "test": "tsc -p __tests__/tsconfig.json && vitest --run",
     {{/isAlgoliasearchClient}}
     "test:bundle": "publint . && attw --pack ."
   },


### PR DESCRIPTION
## 🧭 What and Why

Allow all params of `createIterablePromise` to return `PromiseLike` and call them with await, if people want to use `await` inside their fonctions.

This is not a breaking change and stays compatible with before.