### PR TITLE
guides: dart -- add dynamic snippet

### DIFF
--- a/templates/dart/guides/search/saveObjectsMovies.mustache
+++ b/templates/dart/guides/search/saveObjectsMovies.mustache
@@ -20,7 +20,7 @@ void main() async {
       );
     }
 
-  try {
+    try {
       // push data to algolia
       await client.batch(
         indexName: 'movies_index',

--- a/templates/dart/guides/search/saveObjectsMovies.mustache
+++ b/templates/dart/guides/search/saveObjectsMovies.mustache
@@ -11,10 +11,26 @@ void main() async {
       Uri.parse('https://dashboard.algolia.com/sample_datasets/movie.json'));
 
   if (datasetRequest.statusCode == 200) {
-    final movies = jsonDecode(datasetRequest.body);
+    final moviesData = jsonDecode(datasetRequest.body);
+    final batchRequests = <BatchRequest>[];
 
-    // push data to algolia
-    {{#dynamicSnippet}}saveObjectsMovies{{/dynamicSnippet}}
+    for (final movie in moviesData) {
+      batchRequests.add(
+        BatchRequest(action: Action.fromJson('addObject'), body: movie),
+      );
+    }
+
+  // push data to algolia
+  try {
+      // push data to algolia
+      await client.batch(
+        indexName: 'movies_index',
+        batchWriteParams: BatchWriteParams(requests: batchRequests),
+      );
+      print("Successfully indexed records!");
+    } catch (e) {
+      print("Error: ${e.toString()}");
+    }
   } else {
     throw Exception('Failed to load data');
   }

--- a/templates/dart/guides/search/saveObjectsMovies.mustache
+++ b/templates/dart/guides/search/saveObjectsMovies.mustache
@@ -21,6 +21,8 @@ void main() async {
       );
     }
 
+    {{#dynamicSnippet}}saveObjectsMovies{{/dynamicSnippet}}
+
     try {
       // push data to algolia
       await client.batch(

--- a/templates/dart/guides/search/saveObjectsMovies.mustache
+++ b/templates/dart/guides/search/saveObjectsMovies.mustache
@@ -11,28 +11,10 @@ void main() async {
       Uri.parse('https://dashboard.algolia.com/sample_datasets/movie.json'));
 
   if (datasetRequest.statusCode == 200) {
-    final moviesData = jsonDecode(datasetRequest.body);
+    final movies = jsonDecode(datasetRequest.body);
 
-    final batchRequests = <BatchRequest>[];
-
-    for (final movie in moviesData) {
-      batchRequests.add(
-        BatchRequest(action: Action.fromJson('addObject'), body: movie),
-      );
-    }
-
+    // push data to algolia
     {{#dynamicSnippet}}saveObjectsMovies{{/dynamicSnippet}}
-
-    try {
-      // push data to algolia
-      await client.batch(
-        indexName: 'movies_index',
-        batchWriteParams: BatchWriteParams(requests: batchRequests),
-      );
-      print("Successfully indexed records!");
-    } catch (e) {
-      print("Error: ${e.toString()}");
-    }
   } else {
     throw Exception('Failed to load data');
   }

--- a/templates/dart/guides/search/saveObjectsMovies.mustache
+++ b/templates/dart/guides/search/saveObjectsMovies.mustache
@@ -20,7 +20,6 @@ void main() async {
       );
     }
 
-  // push data to algolia
   try {
       // push data to algolia
       await client.batch(

--- a/templates/dart/tests/client/method.mustache
+++ b/templates/dart/tests/client/method.mustache
@@ -1,17 +1,1 @@
-try {
-  {{#hasResponse}}final res = {{/hasResponse}}await client.{{method}}(
-      {{#parametersWithDataType}}
-      {{> tests/request_param}}
-      {{/parametersWithDataType}}
-  );
-  {{#testResponse}}
-  {{^match.isPrimitive}}
-  expectBody(res, """{{{match.value}}}""");
-  {{/match.isPrimitive}}
-  {{#match.isPrimitive}}
-  expect(res, {{#match}}{{> tests/param_value}}{{/match}});
-  {{/match.isPrimitive}}
-  {{/testResponse}}
-} on InterceptionException catch (_) {
-  // Ignore InterceptionException
-}
+{{> tests/method}}

--- a/templates/dart/tests/method.mustache
+++ b/templates/dart/tests/method.mustache
@@ -13,6 +13,6 @@ try {
   {{/match.isPrimitive}}
   {{/testResponse}}
   print('successfully indexed records!');
-} on InterceptionException catch (_) {
-  // Ignore InterceptionException
+} catch(e) {
+ print('Error: $e');
 }

--- a/templates/dart/tests/method.mustache
+++ b/templates/dart/tests/method.mustache
@@ -1,0 +1,17 @@
+try {
+  {{#hasResponse}}final res = {{/hasResponse}}await client.{{method}}(
+      {{#parametersWithDataType}}
+      {{> tests/request_param}}
+      {{/parametersWithDataType}}
+  );
+  {{#testResponse}}
+  {{^match.isPrimitive}}
+  expectBody(res, """{{{match.value}}}""");
+  {{/match.isPrimitive}}
+  {{#match.isPrimitive}}
+  expect(res, {{#match}}{{> tests/param_value}}{{/match}});
+  {{/match.isPrimitive}}
+  {{/testResponse}}
+} on InterceptionException catch (_) {
+  // Ignore InterceptionException
+}

--- a/templates/dart/tests/method.mustache
+++ b/templates/dart/tests/method.mustache
@@ -12,7 +12,6 @@ try {
   expect(res, {{#match}}{{> tests/param_value}}{{/match}});
   {{/match.isPrimitive}}
   {{/testResponse}}
-  print('successfully indexed records!');
-} catch(e) {
- print('Error: $e');
+} on InterceptionException catch (_) {
+  // Ignore InterceptionException
 }

--- a/templates/dart/tests/method.mustache
+++ b/templates/dart/tests/method.mustache
@@ -12,6 +12,7 @@ try {
   expect(res, {{#match}}{{> tests/param_value}}{{/match}});
   {{/match.isPrimitive}}
   {{/testResponse}}
+  print('successfully indexed records!');
 } on InterceptionException catch (_) {
   // Ignore InterceptionException
 }


### PR DESCRIPTION
Small updates -- I intended to use the dynamic snippet like we do for the other clients, bit since `saveObjects()` is not available on the Dart client, this PR just turned into a little cleanup exercise.