### PR TITLE
fix(specs): `saveRule` response type

### DIFF
--- a/specs/search/paths/rules/common/schemas.yml
+++ b/specs/search/paths/rules/common/schemas.yml
@@ -289,18 +289,3 @@ automaticFacetFilter:
         If false, multiple occurences are combined with the logical `AND` operation.
   required:
     - facet
-
-updatedRuleResponse:
-  type: object
-  additionalProperties: false
-  properties:
-    objectID:
-      $ref: '../../../../common/parameters.yml#/ruleID'
-    updatedAt:
-      $ref: '../../../../common/responses/common.yml#/updatedAt'
-    taskID:
-      $ref: '../../../../common/responses/common.yml#/taskID'
-  required:
-    - objectID
-    - updatedAt
-    - taskID

--- a/specs/search/paths/rules/rule.yml
+++ b/specs/search/paths/rules/rule.yml
@@ -52,11 +52,7 @@ put:
           $ref: 'common/schemas.yml#/rule'
   responses:
     '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            $ref: 'common/schemas.yml#/updatedRuleResponse'
+      $ref: '../../../common/responses/UpdatedAt.yml'
     '400':
       $ref: '../../../common/responses/BadRequest.yml'
     '402':


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3246

### Changes included:

seems like a wrong type leftover from 2 years ago but no objectID fields are returned from the response, it actually returns `{"updatedAt":"2024-11-26T16:07:56.523Z","taskID":588516396000}`