### PR TITLE
fix(specs): remove SFCC source type

### DIFF
--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -105,7 +105,6 @@ SourceType:
     - ga4BigqueryExport
     - json
     - shopify
-    - sfcc
     - push
 
 SourceCommercetools:


### PR DESCRIPTION
## 🧭 What and Why

SFCC is no longer supported in the ingestion API.