### PR TITLE
fix(specs): different summaries for saveObject/addOrUpdate methods

### DIFF
--- a/specs/search/paths/objects/object.yml
+++ b/specs/search/paths/objects/object.yml
@@ -43,6 +43,7 @@ get:
       $ref: '../../../common/responses/MethodNotAllowed.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
+
 put:
   tags:
     - Records
@@ -78,6 +79,7 @@ put:
       $ref: '../../../common/responses/MethodNotAllowed.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
+
 delete:
   tags:
     - Records
@@ -90,6 +92,7 @@ delete:
 
     To delete more than one record, use the [`batch` operation](#tag/Records/operation/batch).
     To delete records matching a query, use the [`deleteByQuery` operation](#tag/Records/operation/deleteBy).
+
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ObjectID'

--- a/specs/search/paths/objects/object.yml
+++ b/specs/search/paths/objects/object.yml
@@ -43,7 +43,6 @@ get:
       $ref: '../../../common/responses/MethodNotAllowed.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
-
 put:
   tags:
     - Records
@@ -55,6 +54,7 @@ put:
     If a record with the specified object ID exists, the existing record is replaced.
     Otherwise, a new record is added to the index.
 
+    If you want to use auto-generated object IDs, use the [`saveObject` operation](#tag/Records/operation/saveObject).
     To update _some_ attributes of an existing record, use the [`partial` operation](#tag/Records/operation/partialUpdateObject) instead.
     To add, update, or replace multiple records, use the [`batch` operation](#tag/Records/operation/batch).
   parameters:
@@ -78,7 +78,6 @@ put:
       $ref: '../../../common/responses/MethodNotAllowed.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
-
 delete:
   tags:
     - Records
@@ -91,7 +90,6 @@ delete:
 
     To delete more than one record, use the [`batch` operation](#tag/Records/operation/batch).
     To delete records matching a query, use the [`deleteByQuery` operation](#tag/Records/operation/deleteBy).
-
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
     - $ref: '../../../common/parameters.yml#/ObjectID'

--- a/specs/search/paths/objects/objects.yml
+++ b/specs/search/paths/objects/objects.yml
@@ -5,7 +5,7 @@ post:
   x-acl:
     - addObject
   description: |
-    Adds a record to an index or replace it.
+    Adds a record to an index or replaces it.
 
     - If the record doesn't have an object ID, a new record with an auto-generated object ID is added to your index.
     - If a record with the specified object ID exists, the existing record is replaced.
@@ -16,7 +16,7 @@ post:
     To add, update, or replace multiple records, use the [`batch` operation](#tag/Records/operation/batch).
 
     This operation is subject to [indexing rate limits](https://support.algolia.com/hc/en-us/articles/4406975251089-Is-there-a-rate-limit-for-indexing-on-Algolia).
-  summary: Add or replace a record
+  summary: Add a new record (with auto-generated object ID)
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'
   requestBody:


### PR DESCRIPTION
## 🧭 What and Why

Better distinguish the `saveObject` and `addOrUpdateObject` methods with distinct summaries.

🎟 JIRA Ticket:

### Changes included:

- List changes

## 🧪 Test
