### PR TITLE
fix(clients): lock version

### DIFF
--- a/clients/algoliasearch-client-ruby/algolia.gemspec
+++ b/clients/algoliasearch-client-ruby/algolia.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'net-http-persistent'
 
-  s.add_development_dependency 'bundler'
+  s.add_development_dependency 'bundler', '>= 2.4.10'
   s.add_development_dependency 'rake'
 end

--- a/playground/ruby/Gemfile.lock
+++ b/playground/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../clients/algoliasearch-client-ruby
   specs:
-    algolia (3.5.1)
+    algolia (3.10.0)
       base64 (>= 0.2.0, < 1)
       faraday (>= 1.0.1, < 3.0)
       faraday-net_http_persistent (>= 0.15, < 3)
@@ -12,21 +12,23 @@ GEM
   specs:
     base64 (0.2.0)
     connection_pool (2.4.1)
-    dotenv (3.1.2)
-    faraday (2.11.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    dotenv (3.1.4)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-net_http (3.3.0)
-      net-http
-    faraday-net_http_persistent (2.1.0)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-net_http_persistent (2.3.0)
       faraday (~> 2.5)
-      net-http-persistent (~> 4.0)
-    logger (1.6.1)
-    net-http (0.4.1)
+      net-http-persistent (>= 4.0.4, < 5)
+    json (2.9.0)
+    logger (1.6.2)
+    net-http (0.6.0)
       uri
-    net-http-persistent (4.0.4)
+    net-http-persistent (4.0.5)
       connection_pool (~> 2.2)
-    uri (0.13.1)
+    uri (1.0.2)
 
 PLATFORMS
   aarch64-linux
@@ -37,4 +39,4 @@ DEPENDENCIES
   dotenv
 
 BUNDLED WITH
-   2.4.10
+   2.5.23

--- a/renovate.json
+++ b/renovate.json
@@ -209,6 +209,16 @@
     },
     {
       "customType": "regex",
+      "description": "Update ruby version on CI",
+      "fileMatch": "clients/algoliasearch-client-ruby/.github/workflows/release.yml",
+      "matchStrings": [
+        "ruby-version: (?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "ruby-version",
+      "depNameTemplate": "ruby"
+    },
+    {
+      "customType": "regex",
       "description": "Update .swift-version",
       "fileMatch": ".swift-version",
       "matchStrings": [


### PR DESCRIPTION
## 🧭 What and Why

The dart release is failing because the lock file is outdated compared to the ruby and bundler version.