### PR TITLE
fix(ruby): handle unknown attributes in index_exists

### DIFF
--- a/templates/ruby/search_helpers.mustache
+++ b/templates/ruby/search_helpers.mustache
@@ -396,10 +396,12 @@ end
 def index_exists?(index_name)
   begin
     get_settings(index_name)
-  rescue AlgoliaHttpError => e
-    return false if e.code == 404
+  rescue Exception => e
+    if e.is_a?(AlgoliaHttpError)
+      return false if e.code == 404
 
-    raise e
+      raise e
+    end
   end
 
   true


### PR DESCRIPTION
## 🧭 What and Why

This should fix the workaround in https://github.com/algolia/AlgoliaWeb/pull/23088, if we encounter a parsing error we know the index exist and can return true.
