### PR TITLE
feat(javascript): expose current apiKey on the client instance [skip-bc]

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -20,6 +20,10 @@ describe('api', () => {
     expect(client.appId).toEqual('APP_ID');
   });
 
+  test('exposes the `apiKey` currently in use at the root of the API', () => {
+    expect(client.apiKey).toEqual('API_KEY');
+  });
+
   test('provides a `clearCache` method', () => {
     expect(client.clearCache).not.toBeUndefined();
     expect(() => client.clearCache()).not.toThrow();

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -48,6 +48,11 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
     appId: appIdOption,
 
     /**
+      * The `apiKey` currently in use.
+      */
+    apiKey: apiKeyOption,
+
+    /**
      * Clears the cache of the transporter for the `requestsCache` and `responsesCache` properties.
      */
     clearCache(): Promise<void> {


### PR DESCRIPTION

## 🧭 What and Why

Expose the currently used api key. This is good for instantiating other information (like insights client) and is consistent with the appId being exposed.


### Changes included:

- add apiKey to the client template

## 🧪 Test

```js
const appId = "appId";
const apiKey = "apiKey";

const client = algoliasearch(appId, apiKey) // and other clients

expect(client. appId).toBe(appId)
expect(client.apiKey).toBe(apiKey)
```