### PR TITLE
fix(clients): no list indexes entry

### DIFF
--- a/specs/major-breaking-changes-rename.json
+++ b/specs/major-breaking-changes-rename.json
@@ -31,7 +31,6 @@
     "client.getTopUserIDs": "client.getTopUserIds",
     "client.getUserID": "client.getUserId",
     "client.listApiKeys": "client.listApiKeys",
-    "client.listIndexes": "client.listIndices",
     "client.listIndices": "client.listIndices",
     "client.listUserIDs": "client.listUserIds",
     "client.moveIndex": "client.operationIndex",


### PR DESCRIPTION
## 🧭 What and Why

Remove the separate entry for the old `client.list_indexes` method which was only used for Ruby. This is better handled as an exception when constructing [the table](https://deploy-preview-9638--algolia-docs.netlify.app/doc/libraries/ruby/v3/upgrade/) since the URL is the same `list-indices` but only the name is different and only for Ruby. 

🎟 JIRA Ticket:

### Changes included:

- Remove the `client.list_indexes` entry, since this is handled in https://github.com/algolia/doc/pull/9638

## 🧪 Test
