### PR TITLE
feat(specs): remove predictive profiles from advanced perso [PRED-3403]

### DIFF
--- a/specs/ai-personalization/common/schemas/Configuration.yml
+++ b/specs/ai-personalization/common/schemas/Configuration.yml
@@ -49,12 +49,11 @@ personalizationReRanking:
 
 profileType:
   type: string
-  enum: [basic, predictive]
+  enum: [basic]
   description: |
     The type of user profiles to generate.
 
     Basic profiles are based on past behaviors, ensuring search results align with previous interests.
-    Predictive profiles are AI-powered profiles that predict and adapt to users' interests, ensuring search results align with evolving preferences.
 
 eventType:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

As per the ticket, we don't want to display references to predictive profiles whilst they're still in beta.

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/PRED-3403%5D

### Changes included:

- Remove predictive profiles reference

## 🧪 Test

n/a
