### PR TITLE
fix(scripts): generate snippets.json files [skip-bc]

### DIFF
--- a/scripts/specs/__tests__/snippets.test.ts
+++ b/scripts/specs/__tests__/snippets.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseCodeSamples } from '../snippets.ts';
+import { generateSnippetsJSON } from '../snippets.ts';
 import type { CodeSamples } from '../types.ts';
 
 describe('init', () => {
   it('parses a multi line import', () => {
     expect(
       JSON.stringify(
-        parseCodeSamples({
+        generateSnippetsJSON({
           foo: {
             default: `
           // Initialize the client
@@ -56,7 +56,7 @@ var response = await client.CreateConfigAsync(
   it('parses a single line import', () => {
     expect(
       JSON.stringify(
-        parseCodeSamples({
+        generateSnippetsJSON({
           foo: {
             default: `
           // Initialize the client
@@ -105,7 +105,7 @@ describe('initialize', () => {
   it("doesn't stop at `client`", () => {
     expect(
       JSON.stringify(
-        parseCodeSamples({
+        generateSnippetsJSON({
           foo: {
             default: `
           // Initialize the client foo bar BAAAAAAAAAAAAAAAAAAAAAZ

--- a/scripts/specs/format.ts
+++ b/scripts/specs/format.ts
@@ -10,7 +10,7 @@ import { GENERATORS, run, toAbsolutePath } from '../common.ts';
 import { createSpinner } from '../spinners.ts';
 import type { Spec } from '../types.ts';
 
-import { getCodeSampleLabel, parseCodeSamples, transformGeneratedSnippetsToCodeSamples } from './snippets.ts';
+import { getCodeSampleLabel, transformGeneratedSnippetsToCodeSamples } from './snippets.ts';
 
 export async function lintCommon(useCache: boolean): Promise<void> {
   const spinner = createSpinner('linting common spec');
@@ -52,8 +52,6 @@ export async function bundleSpecsForDoc(bundledPath: string, clientName: string)
   const harRequests = await oas2har.oas2har(bundledSpec as any, { includeVendorExamples: true });
   const tagsDefinitions = bundledSpec.tags;
   const codeSamples = await transformGeneratedSnippetsToCodeSamples(clientName);
-
-  parseCodeSamples(JSON.parse(JSON.stringify(codeSamples)));
 
   for (const [pathKey, pathMethods] of Object.entries(bundledSpec.paths)) {
     for (const [method, specMethod] of Object.entries(pathMethods)) {

--- a/scripts/specs/snippets.ts
+++ b/scripts/specs/snippets.ts
@@ -19,7 +19,7 @@ export function getCodeSampleLabel(language: Language): OpenAPICodeSample['label
 }
 
 // Iterates over the result of `transformSnippetsToCodeSamples` in order to generate a JSON file for the doc to consume.
-export function parseCodeSamples(codeSamples: CodeSamples): CodeSamples {
+export function generateSnippetsJSON(codeSamples: CodeSamples): CodeSamples {
   for (const [language, operationWithSamples] of Object.entries(codeSamples)) {
     for (const [operation, samples] of Object.entries(operationWithSamples)) {
       if (operation === 'import') {
@@ -109,6 +109,12 @@ export async function transformGeneratedSnippetsToCodeSamples(clientName: string
       });
     }
   }
+
+  const jsonSnippets = generateSnippetsJSON(JSON.parse(JSON.stringify(codeSamples)));
+  await fsp.writeFile(
+    toAbsolutePath(`docs/bundled/${clientName}-snippets.json`),
+    JSON.stringify(jsonSnippets, null, 2),
+  );
 
   return codeSamples;
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3385

### Changes included:

https://github.com/algolia/api-clients-automation/pull/4227/files#diff-ef4366ac6fad81865865c07609a5388ce8c3e17f69292907304307dd3cd429beL70 removed the snippets file generation oopsie