### PR TITLE
chore(scripts): only warn about breaking changes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -597,7 +597,7 @@ jobs:
         run: |
           {
             echo 'BREAKING_CHANGES_SECTION<<EOF'
-            echo "# 💥 Breaking changes detected !!""
+            echo "# 💥 Breaking changes detected !!"
             echo "Either this PR or a previous PR not released yet introduced breaking changes, be careful when merging."
             echo "You can find the details in the `client java@17` CI job."
             echo 'EOF'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -595,7 +595,8 @@ jobs:
           {
             echo 'BREAKING_CHANGES_SECTION<<EOF'
             echo "# 💥 Breaking changes detected !!""
-            echo "either this PR or a previous PR not released yet introduced breaking changes, be careful when merging."
+            echo "Either this PR or a previous PR not released yet introduced breaking changes, be careful when merging."
+            echo "You can find the details in the `client java@17` CI job."
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -355,7 +355,7 @@ jobs:
         run: yarn cli build playground ${{ matrix.client.language }}
 
       - name: Run Java 'algoliasearch' public API validation
-        if: ${{ github.base_ref == 'main' && matrix.client.language == 'java' && matrix.client.isMainVersion && !contains(format('{0} {1}', github.event.pull_request.title, github.event.head_commit.message), '[skip-bc]') }}
+        if: ${{ github.base_ref == 'main' && matrix.client.language == 'java' && matrix.client.isMainVersion }}
         run: |
           cd ${{ matrix.client.path }}
           exit_code=0
@@ -367,7 +367,9 @@ jobs:
             cat $FILE
           fi
 
-          exit $exit_code
+          if [[ $exit_code -ne 0 ]]; then
+            echo "hasBreakingChanges=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Remove previous CTS output
         run: rm -rf ${{ matrix.client.testsToDelete }} || true
@@ -586,12 +588,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
 
+      - name: Check for breaking changes
+        id: breakingChanges
+        if: ${{ needs.client_gen.outputs.hasBreakingChanges == 'true' }}
+        run: |
+          {
+            echo 'BREAKING_CHANGES_SECTION<<EOF'
+            echo "# 💥 Breaking changes detected !!""
+            echo "either this PR or a previous PR not released yet introduced breaking changes, be careful when merging."
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: update generation comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ steps.pushGeneratedCode.outputs.GENERATED_COMMIT == '' }}
         with:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           message: |
+            ${{ steps.breakingChanges.outputs.BENCHMARK_SECTION }}
             ### No code generated
 
             _If you believe code should've been generated, please, [report the issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=bug%2Ctriage&projects=&template=Bug_report.yml&title=%5Bbug%5D%3A+)._
@@ -604,6 +618,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           message: |
+            ${{ steps.breakingChanges.outputs.BENCHMARK_SECTION }}
             ### ✔️ Code generated!
 
             |  Name | Link |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -609,7 +609,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           message: |
-            ${{ steps.breakingChanges.outputs.BENCHMARK_SECTION }}
+            ${{ steps.breakingChanges.outputs.BREAKING_CHANGES_SECTION }}
             ### No code generated
 
             _If you believe code should've been generated, please, [report the issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=bug%2Ctriage&projects=&template=Bug_report.yml&title=%5Bbug%5D%3A+)._
@@ -622,7 +622,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN != '' && secrets.ALGOLIA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           message: |
-            ${{ steps.breakingChanges.outputs.BENCHMARK_SECTION }}
+            ${{ steps.breakingChanges.outputs.BREAKING_CHANGES_SECTION }}
             ### ✔️ Code generated!
 
             |  Name | Link |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -319,6 +319,8 @@ jobs:
       ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
       ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
       MONITORING_API_KEY: ${{ secrets.MONITORING_API_KEY }}
+    outputs:
+      hasBreakingChanges: ${{ steps.breakingChanges.outputs.hasBreakingChanges }}
     name: client ${{ matrix.client.language }}@${{ matrix.client.version }}
     steps:
       - uses: actions/checkout@v4
@@ -355,6 +357,7 @@ jobs:
         run: yarn cli build playground ${{ matrix.client.language }}
 
       - name: Run Java 'algoliasearch' public API validation
+        id: breakingChanges
         if: ${{ github.base_ref == 'main' && matrix.client.language == 'java' && matrix.client.isMainVersion }}
         run: |
           cd ${{ matrix.client.path }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -599,7 +599,7 @@ jobs:
             echo 'BREAKING_CHANGES_SECTION<<EOF'
             echo "# 💥 Breaking changes detected !!"
             echo "Either this PR or a previous PR not released yet introduced breaking changes, be careful when merging."
-            echo "You can find the details in the `client java@17` CI job."
+            echo "You can find the details in the 'client java@17' CI job."
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -436,7 +436,7 @@ jobs:
       !contains(needs.*.result, 'failure')
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
-    name: client kotlin${{ needs.setup.outputs.RUN_MACOS_KOTLIN_BUILD == 'true' && format('@{0}', fromJSON(needs.setup.outputs.KOTLIN_DATA).version) || '' }} macos
+    name: client kotlin${{ format('@{0}', fromJSON(needs.setup.outputs.KOTLIN_DATA).version) }} macos
     steps:
       - uses: actions/checkout@v4
 
@@ -486,7 +486,7 @@ jobs:
       MONITORING_API_KEY: ${{ secrets.MONITORING_API_KEY }}
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
-    name: client swift${{ needs.setup.outputs.RUN_MACOS_SWIFT_CTS == 'true' && format('@{0}', fromJSON(needs.setup.outputs.SWIFT_DATA).version) || '' }} macos
+    name: client swift${{ format('@{0}', fromJSON(needs.setup.outputs.SWIFT_DATA).version) }} macos
     steps:
       - uses: actions/checkout@v4
         if: ${{ env.ALGOLIA_APPLICATION_ID != '' }}

--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -303,14 +303,12 @@ program
   )
   .option('-d, --dry-run', 'does not push anything to GitHub')
   .option('-vh, --versions-history', 'only generates the versions-history policy', false)
-  .option('-b --breaking', 'allow breaking change on the CI', false)
-  .action(async ({ verbose, releaseType, dryRun, versionsHistory, breaking }) => {
+  .action(async ({ verbose, releaseType, dryRun, versionsHistory }) => {
     setVerbose(Boolean(verbose));
 
     await createReleasePR({
       releaseType,
       dryRun,
-      breaking,
       versionsHistory,
     });
   });

--- a/scripts/release/createReleasePR.ts
+++ b/scripts/release/createReleasePR.ts
@@ -341,12 +341,10 @@ async function prepareGitEnvironment(dryRun: boolean): Promise<void> {
 export async function createReleasePR({
   releaseType,
   dryRun,
-  breaking,
   versionsHistory,
 }: {
   releaseType?: semver.ReleaseType;
   dryRun?: boolean;
-  breaking?: boolean;
   versionsHistory?: boolean;
 }): Promise<void> {
   await prepareGitEnvironment(dryRun || versionsHistory || false);
@@ -418,7 +416,7 @@ export async function createReleasePR({
 
   setVerbose(true);
   console.log(`Pushing updated changes to: ${headBranch}`);
-  const commitMessage = `${generationCommitText.commitPrepareReleaseMessage}${breaking ? ' [skip-bc]' : ''}`;
+  const commitMessage = generationCommitText.commitPrepareReleaseMessage;
   await run('git add .');
   await run(`CI=true git commit -m "${commitMessage}"`);
 


### PR DESCRIPTION
## 🧭 What and Why

It's very annoying to add `[skip-bc]` to all PR because we slowed down our release cycle.
Now it will only be a warning in the sticky comment.