### PR TITLE
fix(dart): add readme for composition

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_composition/README.md
+++ b/clients/algoliasearch-client-dart/packages/client_composition/README.md
@@ -1,0 +1,40 @@
+<!-- centered logo -->
+<p align="center">
+  <a href="https://www.algolia.com">
+    <img alt="Algolia for Dart" src="https://raw.githubusercontent.com/algolia/algoliasearch-client-common/master/banners/dart.png" >
+  </a>
+</p>
+
+<!-- centered badges -->
+<p align="center">
+  <a href="https://pub.dartlang.org/packages/algolia_client_composition"><img src="https://img.shields.io/pub/v/algolia_client_composition.svg" alt="Latest version"></a>
+  <a href="https://pub.dev/packages/algolia_client_composition/publisher"><img src="https://img.shields.io/pub/publisher/algolia_client_composition.svg" alt="Publisher"></a>
+</p>
+
+<h3 align="center">
+  <strong>Algolia Composition API Client</strong>
+</h3>
+
+<p align="center">
+  The Algolia Composition API Client allows you to enrich your search queries by using compositions.
+</p>
+
+## 💡 Installation
+
+Add Algolia Composition API Client as a dependency in your project directly from pub.dev:
+
+#### For Dart projects:
+
+```shell
+dart pub add algolia_client_composition
+```
+
+#### For Flutter projects:
+
+```shell
+flutter pub add algolia_client_composition
+```
+
+## License
+
+Algolia API Client is an open-sourced software licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
## 🧭 What and Why

The release is failing because a Dart package needs a README.