### PR TITLE
fix(specs): add a linter to assert that type is present

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -54,6 +54,7 @@ module.exports = {
             'automation-custom/no-big-int': 'error',
             'automation-custom/no-final-dot': 'error',
             'automation-custom/single-quote-ref': 'error',
+            'automation-custom/has-type': 'error',
           },
           overrides: [
             {

--- a/eslint/src/index.ts
+++ b/eslint/src/index.ts
@@ -1,4 +1,5 @@
 import { endWithDot } from './rules/endWithDot.js';
+import { hasType } from './rules/hasType.js';
 import { noBigInt } from './rules/noBigInt.js';
 import { noFinalDot } from './rules/noFinalDot.js';
 import { noNewLine } from './rules/noNewLine.js';
@@ -10,6 +11,7 @@ import { validInlineTitle } from './rules/validInlineTitle.js';
 
 const rules = {
   'end-with-dot': endWithDot,
+  'has-type': hasType,
   'no-big-int': noBigInt,
   'no-final-dot': noFinalDot,
   'no-new-line': noNewLine,

--- a/eslint/src/rules/hasType.ts
+++ b/eslint/src/rules/hasType.ts
@@ -1,0 +1,47 @@
+import { createRule } from 'eslint-plugin-yml/lib/utils';
+
+import { isPairWithKey } from '../utils.js';
+
+export const hasType = createRule('hasType', {
+  meta: {
+    docs: {
+      description: '`type` must be specified with `properties` or `items`',
+      categories: null,
+      extensionRule: false,
+      layout: false,
+    },
+    messages: {
+      hasType: '`type` must be specified with `properties` or `items`',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  create(context) {
+    if (!context.getSourceCode().parserServices?.isYAML) {
+      return {};
+    }
+
+    return {
+      YAMLPair(node): void {
+        if (isPairWithKey(node.parent.parent, 'properties')) {
+          return; // allow everything in properties
+        }
+
+        const hasType = !!node.parent.pairs.find((pair) => isPairWithKey(pair, 'type'));
+        if (isPairWithKey(node, 'properties') && !hasType) {
+          return context.report({
+            node: node as any,
+            messageId: 'hasType',
+          });
+        }
+
+        if (isPairWithKey(node, 'items') && !hasType) {
+          return context.report({
+            node: node as any,
+            messageId: 'hasType',
+          });
+        }
+      },
+    };
+  },
+});

--- a/eslint/src/rules/hasType.ts
+++ b/eslint/src/rules/hasType.ts
@@ -1,6 +1,6 @@
 import { createRule } from 'eslint-plugin-yml/lib/utils';
 
-import { isPairWithKey } from '../utils.js';
+import { isPairWithKey, isPairWithValue } from '../utils.js';
 
 export const hasType = createRule('hasType', {
   meta: {
@@ -27,15 +27,15 @@ export const hasType = createRule('hasType', {
           return; // allow everything in properties
         }
 
-        const hasType = !!node.parent.pairs.find((pair) => isPairWithKey(pair, 'type'));
-        if (isPairWithKey(node, 'properties') && !hasType) {
+        const type = node.parent.pairs.find((pair) => isPairWithKey(pair, 'type'));
+        if (isPairWithKey(node, 'properties') && (!type || !isPairWithValue(type, 'object'))) {
           return context.report({
             node: node as any,
             messageId: 'hasType',
           });
         }
 
-        if (isPairWithKey(node, 'items') && !hasType) {
+        if (isPairWithKey(node, 'items') && (!type || !isPairWithValue(type, 'array'))) {
           return context.report({
             node: node as any,
             messageId: 'hasType',

--- a/eslint/src/rules/noBigInt.ts
+++ b/eslint/src/rules/noBigInt.ts
@@ -34,7 +34,11 @@ export const noBigInt = createRule('noBigInt', {
 
         // check the format next to the type
         node.parent.pairs.find((pair) => {
-          if (isPairWithKey(pair, 'format') && isScalar(pair.value) && (pair.value.value === 'int32' || pair.value.value === 'int64')) {
+          if (
+            isPairWithKey(pair, 'format') &&
+            isScalar(pair.value) &&
+            (pair.value.value === 'int32' || pair.value.value === 'int64')
+          ) {
             context.report({
               node: pair.value as any,
               messageId: 'noBigInt',

--- a/eslint/src/rules/outOfLineRule.ts
+++ b/eslint/src/rules/outOfLineRule.ts
@@ -1,4 +1,4 @@
-import { RuleModule } from 'eslint-plugin-yml/lib/types.js';
+import type { RuleModule } from 'eslint-plugin-yml/lib/types.js';
 import { createRule } from 'eslint-plugin-yml/lib/utils';
 
 import { isNullable, isPairWithKey } from '../utils.js';

--- a/eslint/src/utils.ts
+++ b/eslint/src/utils.ts
@@ -26,6 +26,13 @@ export function isPairWithKey(node: AST.YAMLNode | null, key: string): node is A
   return isScalar(node.key) && node.key.value === key;
 }
 
+export function isPairWithValue(node: AST.YAMLNode | null, value: string): node is AST.YAMLPair {
+  if (node === null || node.type !== 'YAMLPair' || node.value === null) {
+    return false;
+  }
+  return isScalar(node.value) && node.value.value === value;
+}
+
 export function isNullable(node: AST.YAMLNode | null): boolean {
   return (
     isSequence(node) &&

--- a/eslint/tests/hasType.test.ts
+++ b/eslint/tests/hasType.test.ts
@@ -33,6 +33,16 @@ simple:
       },
       {
         code: `
+wrongType:
+  type: string
+  properties:
+    noType:
+      type: string
+    `,
+        errors: [{ messageId: 'hasType' }],
+      },
+      {
+        code: `
 array:
   items:
     type: string

--- a/eslint/tests/hasType.test.ts
+++ b/eslint/tests/hasType.test.ts
@@ -1,0 +1,47 @@
+import { runClassic } from 'eslint-vitest-rule-tester';
+import yamlParser from 'yaml-eslint-parser';
+
+import { hasType } from '../src/rules/hasType.js';
+
+runClassic(
+  'has-type',
+  hasType,
+  {
+    valid: [
+      `
+simple:
+  type: object
+  properties:
+    prop1:
+    `,
+      `
+withArray:
+  type: array
+  items:
+    type: string
+  `,
+    ],
+    invalid: [
+      {
+        code: `
+simple:
+  properties:
+    noType:
+      type: string
+    `,
+        errors: [{ messageId: 'hasType' }],
+      },
+      {
+        code: `
+array:
+  items:
+    type: string
+    `,
+        errors: [{ messageId: 'hasType' }],
+      },
+    ],
+  },
+  {
+    parser: yamlParser,
+  },
+);

--- a/eslint/tests/noBigInt.test.ts
+++ b/eslint/tests/noBigInt.test.ts
@@ -2,12 +2,12 @@ import { runClassic } from 'eslint-vitest-rule-tester';
 import yamlParser from 'yaml-eslint-parser';
 import { noBigInt } from '../src/rules/noBigInt.js';
 
-
 runClassic(
   'no-big-int',
   noBigInt,
   {
-    valid: [`
+    valid: [
+      `
 type: object
 properties:
   id:
@@ -16,11 +16,13 @@ properties:
   url:
     type: string
     format: uri
-`, `
+`,
+      `
 prop:
   type: integer
   format: int32
-`],
+`,
+    ],
     invalid: [
       {
         code: `

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postinstall": "husky && yarn workspace eslint-plugin-automation-custom build",
     "playground:browser": "yarn workspace javascript-browser-playground start",
     "scripts:build": "yarn workspace scripts build:actions",
-    "scripts:lint": "yarn workspace scripts lint",
+    "scripts:lint": "yarn cli format javascript scripts && yarn cli format javascript eslint",
     "scripts:test": "yarn workspace scripts test",
     "specs:fix": "eslint --ext=yml $0 --fix",
     "specs:lint": "eslint --ext=yml $0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,7 +6,6 @@
     "build:actions": "cd ci/actions/restore-artifacts && esbuild --bundle --format=cjs --minify --platform=node --outfile=builddir/index.cjs --log-level=error src/index.ts",
     "createGitHubReleases": "yarn runScript ci/codegen/createGitHubReleases.ts",
     "createMatrix": "yarn runScript ci/githubActions/createMatrix.ts",
-    "lint": "yarn start format javascript scripts",
     "lint:deadcode": "knip",
     "pre-commit": "node ./ci/husky/pre-commit.mjs",
     "pushGeneratedCode": "yarn runScript ci/codegen/pushGeneratedCode.ts",

--- a/specs/crawler/common/schemas/configuration.yml
+++ b/specs/crawler/common/schemas/configuration.yml
@@ -285,6 +285,7 @@ requestOptions:
       $ref: '#/headers'
 
 waitTime:
+  type: object
   description: Timeout for the HTTP request.
   properties:
     min:

--- a/specs/monitoring/common/schemas/Server.yml
+++ b/specs/monitoring/common/schemas/Server.yml
@@ -1,4 +1,5 @@
 title: server
+type: object
 additionalProperties: false
 properties:
   name:


### PR DESCRIPTION
## 🧭 What and Why

Following #4392, we can use a custom linter to verify that type is present and matches what we expect.