### PR TITLE
fix(specs): fix batchWriteParams example

### DIFF
--- a/specs/common/schemas/Batch.yml
+++ b/specs/common/schemas/Batch.yml
@@ -25,6 +25,20 @@ batchWriteParams:
           - body
   required:
     - requests
+  example:
+    batch:
+      requests:
+        - action: addObject
+          body:
+            name: Betty Jane McCamey
+            company: Vita Foods Inc.
+            email: betty@mccamey.com
+        - action: addObject
+          body:
+            name: Gayla geimer
+            company: Ortman McCain Co.
+            email: gayla@geimer.com
+
 action:
   type: string
   enum:

--- a/specs/common/schemas/Batch.yml
+++ b/specs/common/schemas/Batch.yml
@@ -26,18 +26,17 @@ batchWriteParams:
   required:
     - requests
   example:
-    batch:
-      requests:
-        - action: addObject
-          body:
-            name: Betty Jane McCamey
-            company: Vita Foods Inc.
-            email: betty@mccamey.com
-        - action: addObject
-          body:
-            name: Gayla geimer
-            company: Ortman McCain Co.
-            email: gayla@geimer.com
+    requests:
+      - action: addObject
+        body:
+          name: Betty Jane McCamey
+          company: Vita Foods Inc.
+          email: betty@mccamey.com
+      - action: addObject
+        body:
+          name: Gayla geimer
+          company: Ortman McCain Co.
+          email: gayla@geimer.com
 
 action:
   type: string

--- a/specs/common/schemas/Batch.yml
+++ b/specs/common/schemas/Batch.yml
@@ -25,22 +25,6 @@ batchWriteParams:
           - body
   required:
     - requests
-  example:
-    batch:
-      summary: Batch indexing request
-      value:
-        requests:
-          - action: addObject
-            body:
-              name: Betty Jane McCamey
-              company: Vita Foods Inc.
-              email: betty@mccamey.com
-          - action: addObject
-            body:
-              name: Gayla geimer
-              company: Ortman McCain Co.
-              email: gayla@geimer.com
-
 action:
   type: string
   enum:


### PR DESCRIPTION
## 🧭 What and Why

The example for `batchWriteParams` was wrongly constructed. The object in `example` is used as is (summary/value fields are for the `examples` field which is different. 

🎟 JIRA Ticket: N/A

### Changes included:

- Fix the `example` property of the `batchWriteParams` schema

## 🧪 Test

N/A