### PR TITLE
fix(swift): don't overwrite decimal encoding/decoding methods

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Core/Helpers/Extensions.swift
+++ b/clients/algoliasearch-client-swift/Sources/Core/Helpers/Extensions.swift
@@ -161,18 +161,6 @@ public extension KeyedEncodingContainerProtocol {
             try self.encodeMap(pairs)
         }
     }
-
-    mutating func encode(_ value: Decimal, forKey key: Self.Key) throws {
-        var mutableValue = value
-        let stringValue = NSDecimalString(&mutableValue, Locale(identifier: "en_US"))
-        try self.encode(stringValue, forKey: key)
-    }
-
-    mutating func encodeIfPresent(_ value: Decimal?, forKey key: Self.Key) throws {
-        if let value {
-            try self.encode(value, forKey: key)
-        }
-    }
 }
 
 public extension KeyedDecodingContainerProtocol {
@@ -212,34 +200,6 @@ public extension KeyedDecodingContainerProtocol {
         }
 
         return map
-    }
-
-    func decode(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal {
-        let stringValue = try decode(String.self, forKey: key)
-        guard let decimalValue = Decimal(string: stringValue) else {
-            let context = DecodingError.Context(
-                codingPath: [key],
-                debugDescription: "The key \(key) couldn't be converted to a Decimal value"
-            )
-            throw DecodingError.typeMismatch(type, context)
-        }
-
-        return decimalValue
-    }
-
-    func decodeIfPresent(_ type: Decimal.Type, forKey key: Self.Key) throws -> Decimal? {
-        guard let stringValue = try decodeIfPresent(String.self, forKey: key) else {
-            return nil
-        }
-        guard let decimalValue = Decimal(string: stringValue) else {
-            let context = DecodingError.Context(
-                codingPath: [key],
-                debugDescription: "The key \(key) couldn't be converted to a Decimal value"
-            )
-            throw DecodingError.typeMismatch(type, context)
-        }
-
-        return decimalValue
     }
 }
 


### PR DESCRIPTION
## 🧭 What and Why

fixes algolia/algoliasearch-client-swift#876

OpenAPI Generator overrides the default decoding/encoding methods for Decimal to be able to decode/encode from strings, in order to avoid losing precision
If users work with Decimal, it will override the default behavior for them
Also, we don't use the Decimal type in our specs, so it shouldn't be an issue for us

⚠️ For the future, here are some more details:
- OpenAPI Generator [uses a string to avoid losing precision](https://github.com/OpenAPITools/openapi-generator/pull/13589), because using a Double as an intermediary container WILL LOSE some
- When writing a spec, you can use a Decimal by specifying `{ "type": "string", "format": "decimal" }`, but we should avoid that and prefer a number type directly

### Changes included:

- remove Decimal encoding/decoding methods
