### PR TITLE
feat(php): add `setMaxRetries`

### DIFF
--- a/playground/php/src/search.php
+++ b/playground/php/src/search.php
@@ -15,6 +15,9 @@ $config = SearchConfig::create(
     $env['ALGOLIA_ADMIN_KEY']
 );
 
+$config->setMaxRetries(200);
+var_dump($config->getDefaultMaxRetries());
+
 //$config->setFullHosts(
 //    [
 //       'http://localhost:6677',

--- a/templates/php/client_config.mustache
+++ b/templates/php/client_config.mustache
@@ -48,6 +48,20 @@ class {{configClassname}} extends {{#hasRegionalHost}}ConfigWithRegion{{/hasRegi
         return $this->config['waitTaskTimeBeforeRetry'];
     }
 
+    /**
+     * Sets the max retries value used in the Search helpers (e.g. replaceAllobjects)
+     *
+     * @param number $maxRetries the user agent of the api client
+     *
+     * @return $this
+     */
+    public function setMaxRetries($maxRetries)
+    {
+        $this->config['defaultMaxRetries'] = $maxRetries;
+
+        return $this;
+    }
+
     public function getDefaultMaxRetries()
     {
         return $this->config['defaultMaxRetries'];


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CR-7898 https://algolia.atlassian.net/browse/DI-3473

### Changes included:

it is not possible to override the default value `maxRetries` value of the php client, and no parameters are provided at the `replaceAllObjects` level, this allows to configure it

alternatively, it could be a parameter on every method but seems redundant?