### PR TITLE
fix(scripts): cleanup guides gen before generation

### DIFF
--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -10,7 +10,7 @@ import clientsConfig from '../config/clients.config.json' with { type: 'json' };
 import releaseConfig from '../config/release.config.json' with { type: 'json' };
 
 import { Cache } from './cache.ts';
-import { getDockerImage } from './config.ts';
+import { getDockerImage, getTestOutputFolder } from './config.ts';
 import { generateOpenapitools } from './pre-gen/index.ts';
 import { getGitAuthor } from './release/common.ts';
 import { buildSpecs } from './specs/index.ts';
@@ -293,6 +293,12 @@ export async function setupAndGen(
   await buildCustomGenerators();
 
   for (const gen of generators) {
+    if (mode === 'guides') {
+      await run(`rm -rf ${path.join('docs', mode, gen.language, getTestOutputFolder(gen.language))}`, {
+        language: gen.language,
+      });
+    }
+
     const spinner = createSpinner(`generating ${mode} for ${gen.key}`);
     await fn(gen);
     spinner.succeed();

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { callGenerator, exists, isWSL, run, setupAndGen, toAbsolutePath } from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
@@ -6,10 +5,6 @@ import type { Generator } from '../types.ts';
 
 export async function docsGenerateMany(generators: Generator[], scope: 'guides' | 'snippets'): Promise<void> {
   await setupAndGen(generators, scope, async (gen) => {
-    await run(`rm -rf ${path.join('docs', scope, gen.language, getTestOutputFolder(gen.language))}`, {
-      language: gen.language,
-    });
-
     if (getTestOutputFolder(gen.language)) {
       await callGenerator(gen);
     }

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { callGenerator, exists, isWSL, run, setupAndGen, toAbsolutePath } from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
@@ -5,6 +6,10 @@ import type { Generator } from '../types.ts';
 
 export async function docsGenerateMany(generators: Generator[], scope: 'guides' | 'snippets'): Promise<void> {
   await setupAndGen(generators, scope, async (gen) => {
+    await run(`rm -rf ${path.join('docs', scope, gen.language, getTestOutputFolder(gen.language))}`, {
+      language: gen.language,
+    });
+
     if (getTestOutputFolder(gen.language)) {
       await callGenerator(gen);
     }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

if we rename of remove existing guides/snippets they won't be deleted, this should take care of it