### PR TITLE
fix(java): saveObjects always passing waitForTasks as false

### DIFF
--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -690,7 +690,7 @@ public <T> List<BatchResponse> saveObjects(String indexName, Iterable<T> objects
  *     the transporter requestOptions. (optional)
  */
 public <T> List<BatchResponse> saveObjects(String indexName, Iterable<T> objects, boolean waitForTasks, RequestOptions requestOptions) {
-  return saveObjects(indexName, objects, false, 1000, requestOptions);
+  return saveObjects(indexName, objects, waitForTasks, 1000, requestOptions);
 }
 
 /**


### PR DESCRIPTION
## 🧭 What and Why

The `com.algolia.api.SearchClient#saveObjects(String, Iterable, boolean, RequestOptions)` method takes the `waitForTasks` parameter, but it is ignored and always set to `false`.

🎟 JIRA Ticket:

### Changes included:

- Fixed the method by passing the `waitForTasks` parameter instead of hardcoding `false`

## 🧪 Test