### PR TITLE
chore(ci): always run all clients

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -161,7 +161,7 @@ jobs:
           type: minimal
 
       - name: Building specs
-        run: yarn cli build specs ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX).toRun }}
+        run: yarn cli build specs
 
       - name: Store bundled specs
         uses: actions/upload-artifact@v4
@@ -210,7 +210,7 @@ jobs:
           version: ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).version }}
 
       - name: Generate clients
-        run: yarn cli generate javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli generate javascript
 
       - name: Update `yarn.lock` for JavaScript
         run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
@@ -219,13 +219,13 @@ jobs:
         run: cd clients/algoliasearch-client-javascript && yarn build
 
       - name: Build the playground
-        run: yarn cli build playground javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli build playground javascript
 
       - name: Build the browser playground
         run: yarn workspace javascript-playground-browser build
 
       - name: Run common and requester tests
-        run: cd clients/algoliasearch-client-javascript && yarn test ${{ !contains(fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun, 'algoliasearch') && '--ignore algoliasearch' || '' }}
+        run: cd clients/algoliasearch-client-javascript && yarn test
 
       - name: Test JavaScript bundle size
         if: ${{ startsWith(github.head_ref, 'chore/prepare-release-') }}
@@ -239,7 +239,7 @@ jobs:
         run: rm -rf ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).testsToDelete }}
 
       - name: Generate CTS
-        run: yarn cli cts generate javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli cts generate javascript
 
         # JavaScript test deps (needs to be cached because they are huge and inefficient)
       - name: Get yarn js test cache directory path
@@ -260,32 +260,32 @@ jobs:
           key: node-modules-tests-${{ hashFiles('tests/output/javascript/yarn.lock') }}
 
       - name: Run unit CTS
-        run: yarn cli cts run javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }} --no-e2e
+        run: yarn cli cts run javascript --no-e2e
 
       - name: Run e2e CTS
         id: cts-e2e
         continue-on-error: true
         if: ${{ !github.event.pull_request.head.repo.fork && !contains(format('{0} {1}', github.event.pull_request.title, github.event.head_commit.message), '[skip-e2e]') }}
-        run: yarn cli cts run javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }} --no-client --no-requests
+        run: yarn cli cts run javascript --no-client --no-requests
 
       - name: Retry e2e CTS
         if: ${{ steps.cts-e2e.outcome == 'failure' }}
-        run: yarn cli cts run javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }} --no-client --no-requests
+        run: yarn cli cts run javascript --no-client --no-requests
 
       - name: Run benchmarks
-        run: yarn cli cts run javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }} --benchmark --no-client --no-requests --no-e2e
+        run: yarn cli cts run javascript --benchmark --no-client --no-requests --no-e2e
 
       - name: Generate code snippets
-        run: yarn cli snippets javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli snippets javascript
 
       - name: Build the snippets to check validity
-        run: yarn cli build snippets javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli build snippets javascript
 
       - name: Generate code guides
-        run: yarn cli guides javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli guides javascript
 
       - name: Build the guides to check validity
-        run: yarn cli build guides javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).toRun }}
+        run: yarn cli build guides javascript
 
       - name: Zip artifact before storing
         run: zip -r -y clients-javascript.zip clients/algoliasearch-client-javascript ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).testsToStore }} ${{ fromJSON(needs.setup.outputs.JAVASCRIPT_DATA).guidesToStore }} -x "**/node_modules**" "**/.yarn/cache/**" "**/.yarn/install-state.gz" "**/build/**" "**/dist/**" "**/.gradle/**" "**/bin/**" "**/.nx/**"
@@ -334,7 +334,7 @@ jobs:
           version: ${{ matrix.client.version }}
 
       - name: Generate clients
-        run: yarn cli generate ${{ matrix.client.language }} ${{ matrix.client.toRun }}
+        run: yarn cli generate ${{ matrix.client.language }}
 
       # no need to build the clients here, it will be done in the Run CTS step anyway.
 
@@ -375,33 +375,33 @@ jobs:
         run: rm -rf ${{ matrix.client.testsToDelete }} || true
 
       - name: Generate CTS
-        run: yarn cli cts generate ${{ matrix.client.language }} ${{ matrix.client.toRun }} --language-version ${{ matrix.client.version }}
+        run: yarn cli cts generate ${{ matrix.client.language }} --language-version ${{ matrix.client.version }}
 
       - name: Run unit CTS
-        run: yarn cli cts run ${{ matrix.client.language }} ${{ matrix.client.toRun }} --no-e2e
+        run: yarn cli cts run ${{ matrix.client.language }} --no-e2e
 
       - name: Run e2e CTS
         id: cts-e2e
         continue-on-error: true
         if: ${{ !github.event.pull_request.head.repo.fork && !contains(format('{0} {1}', github.event.pull_request.title, github.event.head_commit.message), '[skip-e2e]') }}
-        run: yarn cli cts run ${{ matrix.client.language }} ${{ matrix.client.toRun }} --no-client --no-requests
+        run: yarn cli cts run ${{ matrix.client.language }} --no-client --no-requests
 
       - name: Retry e2e CTS
         if: ${{ steps.cts-e2e.outcome == 'failure' }}
-        run: yarn cli cts run ${{ matrix.client.language }} ${{ matrix.client.toRun }} --no-client --no-requests
+        run: yarn cli cts run ${{ matrix.client.language }} --no-client --no-requests
 
       - name: Run benchmarks
         if: ${{ matrix.client.isMainVersion }}
-        run: yarn cli cts run ${{ matrix.client.language }} ${{ matrix.client.toRun }} --benchmark --no-client --no-requests --no-e2e
+        run: yarn cli cts run ${{ matrix.client.language }} --benchmark --no-client --no-requests --no-e2e
 
       - name: Generate code snippets
-        run: yarn cli snippets ${{ matrix.client.language }} ${{ matrix.client.toRun }}
+        run: yarn cli snippets ${{ matrix.client.language }}
 
       - name: Build the snippets to check validity
         run: yarn cli build snippets ${{ matrix.client.language }}
 
       - name: Generate code guides
-        run: yarn cli guides ${{ matrix.client.language }} ${{ matrix.client.toRun }}
+        run: yarn cli guides ${{ matrix.client.language }}
 
       - name: Build the guides to check validity
         run: yarn cli build guides ${{ matrix.client.language }}
@@ -449,7 +449,7 @@ jobs:
           version: ${{ fromJSON(needs.setup.outputs.KOTLIN_DATA).version }}
 
       - name: Generate clients
-        run: yarn cli generate kotlin ${{ fromJSON(needs.setup.outputs.KOTLIN_DATA).toRun }}
+        run: yarn cli generate kotlin
 
       - name: Build clients for macOS
         id: build
@@ -501,7 +501,7 @@ jobs:
           version: ${{ fromJSON(needs.setup.outputs.SWIFT_DATA).version }}
 
       - name: Generate clients
-        run: yarn cli generate swift ${{ fromJSON(needs.setup.outputs.SWIFT_DATA).toRun }}
+        run: yarn cli generate swift
 
       - name: Build clients
         run: yarn cli build clients swift
@@ -545,7 +545,7 @@ jobs:
           type: minimal
 
       - name: Generate documentation specs with code snippets
-        run: yarn cli build specs ${{ fromJSON(needs.setup.outputs.SPECS_MATRIX).toRun }} --docs
+        run: yarn cli build specs --docs
 
       - name: Read benchmark results
         id: benchmark

--- a/scripts/ci/githubActions/types.ts
+++ b/scripts/ci/githubActions/types.ts
@@ -16,10 +16,6 @@ export type ClientMatrix = {
      */
     path: string;
     /**
-     * The list of clients to run in the CI.
-     */
-    toRun: string;
-    /**
      * The client language.
      */
     language: string;

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -10,7 +10,7 @@ import clientsConfig from '../config/clients.config.json' with { type: 'json' };
 import releaseConfig from '../config/release.config.json' with { type: 'json' };
 
 import { Cache } from './cache.ts';
-import { getClientsConfigField, getDockerImage } from './config.ts';
+import { getDockerImage } from './config.ts';
 import { generateOpenapitools } from './pre-gen/index.ts';
 import { getGitAuthor } from './release/common.ts';
 import { buildSpecs } from './specs/index.ts';
@@ -295,15 +295,6 @@ export async function setupAndGen(
   await buildCustomGenerators();
 
   for (const gen of generators) {
-    if (mode === 'guides') {
-      await run(
-        `rm -rf ${path.join('docs', mode, gen.language, getClientsConfigField(gen.language, ['snippets', 'outputFolder']))}`,
-        {
-          language: gen.language,
-        },
-      );
-    }
-
     const spinner = createSpinner(`generating ${mode} for ${gen.key}`);
     await fn(gen);
     spinner.succeed();


### PR DESCRIPTION
## 🧭 What and Why

The improvements thanks to only running client that has changes is dwarfed by swift being so slow, we don't need this anymore.
And it's causing issues with guides because they are not in 1 folder by client