### PR TITLE
docs(java): fix typo on README

### DIFF
--- a/clients/algoliasearch-client-java/README.md
+++ b/clients/algoliasearch-client-java/README.md
@@ -56,7 +56,7 @@ import com.algolia.model.search.*;
 SearchClient client = new SearchClient("YOUR_APP_ID", "YOUR_API_KEY");
 
 // Add a new record to your Algolia index
-client.saveObject("<YOUR_INDEX_NAME>", Map.of("objectID", "id", "test", "val"));
+var response = client.saveObject("<YOUR_INDEX_NAME>", Map.of("objectID", "id", "test", "val"));
 
 // Poll the task status to know when it has been indexed
 client.waitForTask("<YOUR_INDEX_NAME>", response.getTaskID());


### PR DESCRIPTION
## 🧭 What and Why

The `README.md` has a typo in the Getting Started code snippet. The variable `response` is used but never declared in the example. I declare the variables like we did on https://www.algolia.com/doc/libraries/java/v4/#test-your-installation code snippet.

### Changes included:

- Declare the `response` var in the code snippet.
