### PR TITLE
chore: remove gh auth login

### DIFF
--- a/scripts/ci/codegen/pushToRepository.ts
+++ b/scripts/ci/codegen/pushToRepository.ts
@@ -2,7 +2,6 @@ import fsp from 'fs/promises';
 import path, { resolve } from 'path';
 
 import {
-  CI,
   configureGitHubAuthor,
   ensureGitHubToken,
   exists,
@@ -91,6 +90,8 @@ async function pushToRepository(repository: string, config: RepositoryConfigurat
     .filter(Boolean);
 
   if (!process.env.FORCE && !lastCommitMessage.startsWith(commitStartRelease)) {
+    console.warn('FORCE not provided or not a commit release, skipping');
+
     return;
   }
 
@@ -169,10 +170,6 @@ async function pushToRepository(repository: string, config: RepositoryConfigurat
 if (import.meta.url.endsWith(process.argv[1])) {
   setVerbose(false);
   const repositories = process.argv.slice(2) as Array<string>;
-
-  if (CI) {
-    await run(`echo ${ensureGitHubToken()} | gh auth login --with-token`);
-  }
 
   await Promise.allSettled(
     Object.entries(pushToRepositoryConfiguration).map(([name, config]) => {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

idk why I added the auth step, as per https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows it's not required, the token is enough to login, and as per https://cli.github.com/manual/gh_help_environment, gh_token and github_token works