### PR TITLE
fix(clients): implement Is on custom errors [skip-e2e]

### DIFF
--- a/clients/algoliasearch-client-go/algolia/errs/net_err.go
+++ b/clients/algoliasearch-client-go/algolia/errs/net_err.go
@@ -21,3 +21,9 @@ func NetError(err net.Error, msg string) net.Error {
 func (e *netError) Error() string   { return e.msg }
 func (e *netError) Timeout() bool   { return e.isTimeout }
 func (e *netError) Temporary() bool { return e.isTemporary }
+
+func (e netError) Is(target error) bool {
+	_, ok := target.(*netError)
+
+	return ok
+}

--- a/clients/algoliasearch-client-go/algolia/errs/no_more_host_to_try_err.go
+++ b/clients/algoliasearch-client-go/algolia/errs/no_more_host_to_try_err.go
@@ -27,3 +27,10 @@ func (e *NoMoreHostToTryError) Error() string {
 	}
 	return "all hosts have been contacted unsuccessfully, it can either be a server or a network error or wrong appID/key credentials were used. You can use 'ExposeIntermediateNetworkErrors: true' in the config to investigate."
 }
+
+
+func (n NoMoreHostToTryError) Is(target error) bool {
+	_, ok := target.(*NoMoreHostToTryError)
+
+	return ok
+}

--- a/clients/algoliasearch-client-go/algolia/errs/wait_err.go
+++ b/clients/algoliasearch-client-go/algolia/errs/wait_err.go
@@ -14,14 +14,32 @@ func (e WaitError) Error() string {
 	return e.msg
 }
 
+func (e WaitError) Is(target error) bool {
+	_, ok := target.(*WaitError)
+
+	return ok
+}
+
 type WaitKeyUpdateError struct{}
 
 func (e WaitKeyUpdateError) Error() string {
 	return "`apiKey` is required when waiting for an `update` operation."
 }
 
+func (e WaitKeyUpdateError) Is(target error) bool {
+	_, ok := target.(*WaitKeyUpdateError)
+
+	return ok
+}
+
 type WaitKeyOperationError struct{}
 
 func (e WaitKeyOperationError) Error() string {
 	return "`operation` must be one of `add`, `update` or `delete`."
+}
+
+func (e WaitKeyOperationError) Is(target error) bool {
+	_, ok := target.(*WaitKeyOperationError)
+
+	return ok
 }

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -390,3 +390,9 @@ func (o *APIError) UnmarshalJSON(bytes []byte) error {
 
 	return nil
 }
+
+func (a APIError) Is(target error) bool {
+  _, ok := target.(*APIError)
+
+  return ok
+}


### PR DESCRIPTION
## 🧭 What and Why

This allow users to use `errors.Is` on our custom errors