### PR TITLE
feat(specs): add the owner attributes to ingestion resources

### DIFF
--- a/specs/ingestion/common/schemas/authentication.yml
+++ b/specs/ingestion/common/schemas/authentication.yml
@@ -11,6 +11,8 @@ Authentication:
       $ref: './common.yml#/name'
     platform:
       $ref: '#/Platform'
+    owner:
+      $ref: './common.yml#/owner'
     input:
       $ref: '#/AuthInputPartial'
     createdAt:

--- a/specs/ingestion/common/schemas/common.yml
+++ b/specs/ingestion/common/schemas/common.yml
@@ -82,6 +82,12 @@ name:
   type: string
   description: Descriptive name for the resource.
 
+owner:
+  oneOf:
+    - type: string
+      description: Owner of the resource.
+    - type: 'null'
+
 Window:
   type: object
   additionalProperties: false

--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -9,6 +9,8 @@ Destination:
       $ref: '#/DestinationType'
     name:
       $ref: './common.yml#/name'
+    owner:
+      $ref: './common.yml#/owner'
     input:
       $ref: '#/DestinationInput'
     createdAt:

--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -8,6 +8,8 @@ Source:
       $ref: '#/SourceType'
     name:
       type: string
+    owner:
+      $ref: './common.yml#/owner'
     input:
       $ref: '#/SourceInput'
     authenticationID:

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -14,6 +14,8 @@ Task:
       $ref: '#/LastRun'
     nextRun:
       $ref: '#/NextRun'
+    owner:
+      $ref: './common.yml#/owner'
     input:
       $ref: '#/TaskInput'
     enabled:

--- a/specs/ingestion/common/schemas/transformation.yml
+++ b/specs/ingestion/common/schemas/transformation.yml
@@ -12,6 +12,8 @@ Transformation:
       $ref: '#/Name'
     description:
       $ref: '#/Description'
+    owner:
+      $ref: './common.yml#/owner'
     createdAt:
       $ref: './common.yml#/createdAt'
     updatedAt:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [DI-3653](https://algolia.atlassian.net/browse/DI-3653)

The `owner` attributes on ingestion resources is used to hide resources for internal use.


[DI-3653]: https://algolia.atlassian.net/browse/DI-3653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ