### PR TITLE
chore: reduce manual intervention on javascript clients

### DIFF
--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -144,7 +144,8 @@
       },
       {
         "name": "composition",
-        "output": "clients/algoliasearch-client-javascript/packages/composition"
+        "output": "clients/algoliasearch-client-javascript/packages/composition",
+        "isStandaloneClient": true
       },
       {
         "name": "ingestion",
@@ -176,7 +177,9 @@
       },
       {
         "name": "composition-full",
-        "output": "clients/algoliasearch-client-javascript/packages/client-composition"
+        "output": "clients/algoliasearch-client-javascript/packages/client-composition",
+        "isStandaloneClient": true,
+        "clientName": "composition"
       }
     ],
     "folder": "clients/algoliasearch-client-javascript",

--- a/config/clients.schema.json
+++ b/config/clients.schema.json
@@ -46,7 +46,9 @@
                     "search"
                   ]
                 },
-                "output": { "type": "string" }
+                "output": { "type": "string" },
+                "isStandaloneClient": { "type": "boolean", "description": "this property only matters for the javascript client, when `true`, your package will be built as a standalone client and not be part of `algoliasearch` directly. This is recommended for non stable APIs." },
+                "clientName": { "type": "string", "description": "when defined, the name of the generated instance of the client will be hardcoded, otherwise it defaults to the `spec` name, e.g. search -> searchClient" }
               },
               "required": ["name", "output"],
               "additionalProperties": false

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -174,7 +174,7 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
 
         String version = Helpers.getPackageJsonVersion(name);
 
-        if (version.contains("alpha") || version.contains("beta")) {
+        if (version.contains("alpha") || version.contains("beta") || (boolean) pkg.getOrDefault("isStandaloneClient", false) == true) {
           continue;
         }
 
@@ -193,9 +193,8 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
       additionalProperties.put("dependencies", dependencies);
 
       // Files used to generate the `lite` client
-      clientName = "lite" + Helpers.API_SUFFIX;
       additionalProperties.put("apiName", "search");
-      additionalProperties.put("clientName", clientName);
+      additionalProperties.put("clientName", "lite" + Helpers.API_SUFFIX);
       additionalProperties.put("algoliaAgent", "Lite");
     }
   }

--- a/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
@@ -145,7 +145,6 @@ public class AlgoliaCTSGenerator extends DefaultCodegen {
       // We can put whatever we want in the bundle, and it will be accessible in the template
       bundle.put("mode", mode);
       bundle.put("is" + Helpers.capitalize(Helpers.camelize(client)) + "Client", true);
-      bundle.put("isStandaloneClient", client.contains("search") || client.contains("composition") || client.contains("realtime"));
       bundle.put("isSearchClient", client.contains("search")); // just so algoliasearch is treated as a search client too
       bundle.put("client", Helpers.createClientName(importClientName, language) + "Client");
       bundle.put("clientPrefix", Helpers.createClientName(importClientName, language));

--- a/generators/src/main/java/com/algolia/codegen/cts/manager/JavascriptCTSManager.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/manager/JavascriptCTSManager.java
@@ -3,6 +3,7 @@ package com.algolia.codegen.cts.manager;
 import com.algolia.codegen.AlgoliaJavascriptGenerator;
 import com.algolia.codegen.exceptions.GeneratorException;
 import com.algolia.codegen.utils.*;
+import com.fasterxml.jackson.databind.*;
 import java.util.*;
 import org.openapitools.codegen.SupportingFile;
 
@@ -43,30 +44,32 @@ public class JavascriptCTSManager implements CTSManager {
 
   @Override
   public void addDataToBundle(Map<String, Object> bundle) throws GeneratorException {
+    Optional<Map<String, Object>> clientPkg = Helpers.getClientConfigList("javascript", "clients")
+      .stream()
+      .filter(pkg -> ((String) pkg.get("name")).contains(client))
+      .findFirst();
+    if (!clientPkg.isPresent()) {
+      throw new GeneratorException("Cannot find client " + client + " in config/clients.config.json for javascript");
+    }
+
+    boolean isStandaloneClient = (boolean) clientPkg.get().getOrDefault("isStandaloneClient", false);
+    bundle.put("isStandaloneClient", isStandaloneClient || client.contains("search"));
+
+    if (client.equals("algoliasearch")) {
+      bundle.put("clientName", "liteClient");
+      bundle.put("importPackage", "algoliasearch/lite");
+    } else if (isStandaloneClient) {
+      bundle.put("clientName", (String) clientPkg.get().getOrDefault("clientName", Helpers.camelize(client)) + Helpers.API_SUFFIX);
+
+      JsonNode packageJson = Helpers.readJsonFile(clientPkg.get().get("output") + "/package.json");
+      bundle.put("importPackage", packageJson.get("name").asText());
+    } else {
+      bundle.put("initMethod", "init" + Helpers.capitalize(Helpers.camelize(client)));
+      bundle.put("clientName", "algoliasearch");
+      bundle.put("importPackage", "algoliasearch");
+    }
+
     bundle.put("utilsPackageVersion", Helpers.getPackageJsonVersion("client-common"));
     bundle.put("algoliasearchVersion", Helpers.getPackageJsonVersion("algoliasearch"));
-    bundle.put("initMethod", "init" + Helpers.capitalize(Helpers.camelize(client)));
-
-    switch (client) {
-      case "composition":
-        bundle.put("clientName", "compositionClient");
-        bundle.put("importPackage", "@algolia/composition");
-        break;
-      case "composition-full":
-        bundle.put("clientName", "compositionClient");
-        bundle.put("importPackage", "@algolia/client-composition");
-        break;
-      case "realtime-personalization":
-        bundle.put("clientName", "realtimePersonalizationClient");
-        bundle.put("importPackage", "@algolia/client-realtime-personalization");
-        break;
-      case "algoliasearch":
-        bundle.put("clientName", "liteClient");
-        bundle.put("importPackage", "algoliasearch/lite");
-        break;
-      default:
-        bundle.put("clientName", "algoliasearch");
-        bundle.put("importPackage", "algoliasearch");
-    }
   }
 }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

### Changes included:

it requires manual intervention from an apic maintainer when someone wants to add a new client, because there's a bunch of condition for standalone clients to not be part of the `algoliasearch` package during the pre-release phase.

this pr adds a boolean to determine if the package should be included in `algoliasearch` or not (see composition), in order to eventually reduce the manual work required on that front.