### PR TITLE
fix(specs): make the updateAt non-null in ingestion

### DIFF
--- a/specs/ingestion/common/schemas/authentication.yml
+++ b/specs/ingestion/common/schemas/authentication.yml
@@ -25,6 +25,7 @@ Authentication:
     - name
     - input
     - createdAt
+    - updatedAt
 
 AuthenticationCreate:
   type: object

--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -27,6 +27,7 @@ Destination:
     - name
     - input
     - createdAt
+    - updatedAt
 
 DestinationCreate:
   type: object

--- a/specs/ingestion/common/schemas/source.yml
+++ b/specs/ingestion/common/schemas/source.yml
@@ -23,6 +23,7 @@ Source:
     - type
     - name
     - createdAt
+    - updatedAt
 
 SourceCreate:
   type: object

--- a/specs/ingestion/common/schemas/task.yml
+++ b/specs/ingestion/common/schemas/task.yml
@@ -44,6 +44,7 @@ Task:
     - destinationID
     - enabled
     - createdAt
+    - updatedAt
 
 TaskV1:
   type: object
@@ -86,6 +87,7 @@ TaskV1:
     - trigger
     - enabled
     - createdAt
+    - updatedAt
 
 Trigger:
   description: Trigger that runs the task.

--- a/specs/ingestion/common/schemas/transformation.yml
+++ b/specs/ingestion/common/schemas/transformation.yml
@@ -23,6 +23,7 @@ Transformation:
     - code
     - name
     - createdAt
+    - updatedAt
 
 Code:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

The `updatedAt` field is always returned