### PR TITLE
fix(specs): userData is any type

### DIFF
--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -768,7 +768,6 @@ hitsPerPage:
     - Pagination
 
 userData:
-  type: object
   example:
     settingID: f2a7b51e3503acc6a39b3784ffb84300
     pluginVersion: 1.6.0

--- a/templates/kotlin/json_object_serializer.mustache
+++ b/templates/kotlin/json_object_serializer.mustache
@@ -2,7 +2,7 @@ internal object {{classname}}Serializer : KSerializer<{{classname}}> {
 
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor("{{classname}}") {
         {{#vars}}
-        element<{{{datatypeWithEnum}}}>("{{{vendorExtensions.x-base-name-literal}}}"{{^required}}, isOptional = true{{/required}})
+        element<{{#isAnyType}}JsonElement{{/isAnyType}}{{^isAnyType}}{{{datatypeWithEnum}}}{{/isAnyType}}>("{{{vendorExtensions.x-base-name-literal}}}"{{^required}}, isOptional = true{{/required}})
         {{/vars}}
     }
 

--- a/tests/CTS/requests/search/setSettings.json
+++ b/tests/CTS/requests/search/setSettings.json
@@ -760,7 +760,15 @@
       "indexName": "theIndexName",
       "indexSettings": {
         "ranking": [
-          "desc(is_popular)", "typo", "geo", "words", "filters", "proximity", "attribute", "exact", "custom"
+          "desc(is_popular)",
+          "typo",
+          "geo",
+          "words",
+          "filters",
+          "proximity",
+          "attribute",
+          "exact",
+          "custom"
         ]
       }
     },
@@ -769,7 +777,15 @@
       "method": "PUT",
       "body": {
         "ranking": [
-          "desc(is_popular)", "typo", "geo", "words", "filters", "proximity", "attribute", "exact", "custom"
+          "desc(is_popular)",
+          "typo",
+          "geo",
+          "words",
+          "filters",
+          "proximity",
+          "attribute",
+          "exact",
+          "custom"
         ]
       }
     }


### PR DESCRIPTION
## 🧭 What and Why

fixes https://github.com/algolia/algoliasearch-client-go/issues/769

🎟 JIRA Ticket: [DI-3692](https://algolia.atlassian.net/browse/DI-3692)

The `userData` of the index settings can be anything since it's not serialized by the API, I tried with a string, an array, and a object and they are all accepted by the API.

I found out that we can generate the `any` type in all languages by just omitting the `type`, but this means its also nullable, not sure how to remove that.

[DI-3692]: https://algolia.atlassian.net/browse/DI-3692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ