### PR TITLE
docs(partialUpdate): add note about multiple operations

### DIFF
--- a/specs/search/paths/objects/partialUpdate.yml
+++ b/specs/search/paths/objects/partialUpdate.yml
@@ -31,6 +31,8 @@ post:
     - _operation: the operation to apply on the attribute
     - value: the right-hand side argument to the operation, for example, increment or decrement step, value to add or remove.
 
+    When updating multiple attributes or using multiple operations targeting the same record, you should use a single partial update for faster processing.
+
     This operation is subject to [indexing rate limits](https://support.algolia.com/hc/en-us/articles/4406975251089-Is-there-a-rate-limit-for-indexing-on-Algolia).
   parameters:
     - $ref: '../../../common/parameters.yml#/IndexName'


### PR DESCRIPTION
## 🧭 What and Why

Add a small note on `partialUpdate` regarding aggregating multiple updates to the same record a single partial update.

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CR-7983?focusedCommentId=535411

### Changes included:

- Additional note on `partialUpdate`
