### PR TITLE
fix(specs): message is not required in WatchResponse

### DIFF
--- a/specs/ingestion/common/schemas/common.yml
+++ b/specs/ingestion/common/schemas/common.yml
@@ -123,4 +123,4 @@ WatchResponse:
       description: a message describing the outcome of a validate run.
       type: string
   required:
-    - message
+    - runID


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CR-8231](https://algolia.atlassian.net/browse/CR-8231)

The `message` is not returned by the `push task` endpoint when `watcher=false`.
However the runID should be always returned.

[CR-8231]: https://algolia.atlassian.net/browse/CR-8231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ