### PR TITLE
docs(personalization): add rate limit information for personalization API

### DIFF
--- a/specs/personalization/paths/deleteUserProfile.yml
+++ b/specs/personalization/paths/deleteUserProfile.yml
@@ -14,6 +14,13 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
       content:
         application/json:
           schema:

--- a/specs/personalization/paths/getUserTokenProfile.yml
+++ b/specs/personalization/paths/getUserTokenProfile.yml
@@ -11,6 +11,13 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
       content:
         application/json:
           schema:

--- a/specs/personalization/paths/personalizationStrategy.yml
+++ b/specs/personalization/paths/personalizationStrategy.yml
@@ -9,6 +9,13 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
       content:
         application/json:
           schema:

--- a/specs/personalization/spec.yml
+++ b/specs/personalization/spec.yml
@@ -37,6 +37,18 @@ info:
     Successful responses return a `2xx` status. Client errors return a `4xx` status. Server errors are indicated by a `5xx` status.
     Error responses have a `message` property with more information.
 
+    ## Rate limiting
+
+    When making requests to the Personalization API, you are limited to 40 API calls per second per application.
+
+    The following headers provide information about your current limit:
+
+    - `x-ratelimit-limit`: The number of requests allowed every second.
+    - `x-ratelimit-remaining`: The number of requests remaining in the current
+    second period.
+    - `x-ratelimit-reset`: [Unix timestamp](https://www.unixtimestamp.com/) of
+    the next time period.
+
     ## Version
 
     The current version of the Personalization API is version 1, as indicated by the `/1/` in each endpoint's URL.


### PR DESCRIPTION
## 🧭 What and Why
Document the new rate limit for the personalization API.

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/PRED-3537

### Changes included:

- Section added in specs/personalization/spec.yml that details the rate limit and the related headers.

## 🧪 Test
N/A