### PR TITLE
fix(specs): add missing recordType collection

### DIFF
--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -138,7 +138,7 @@ DestinationIndexName:
 RecordType:
   type: string
   description: Record type for ecommerce sources.
-  enum: [product, variant]
+  enum: [product, variant, collection]
 
 AttributesToExclude:
   type: array


### PR DESCRIPTION
## 🧭 What and Why

The `recordType` `collection` is used for destinations used by shopify.