### PR TITLE
fix(clients): correctly deserialize SearchResult

### DIFF
--- a/playground/java/src/main/java/com/algolia/playground/Search.java
+++ b/playground/java/src/main/java/com/algolia/playground/Search.java
@@ -6,7 +6,6 @@ import com.algolia.model.search.*;
 import io.github.cdimascio.dotenv.Dotenv;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 class Actor extends Hit {
 
@@ -47,6 +46,7 @@ public class Search {
 
     singleSearch(client, indexName, query);
     multiSearch(indexName, query, client);
+    multiSearchHits(indexName, query, client);
     client.close();
   }
 
@@ -73,13 +73,27 @@ public class Search {
     searchMethodParams.setRequests(requests);
 
     var responses = client.search(searchMethodParams, Actor.class);
-    var results = responses.getResults();
     System.out.println("-> Multi Index Search:");
-    for (var result : results) {
-      var response = (SearchResponse) result;
-      for (var hit : response.getHits()) {
-        var record = (Map) hit;
-        System.out.println("> " + record.get("name"));
+    for (var result : responses.getResults()) {
+      for (var hit : ((SearchResponse<Actor>) result).getHits()) {
+        System.out.println("> " + hit.name);
+      }
+    }
+  }
+
+  private static void multiSearchHits(String indexName, String query, SearchClient client) {
+    var searchQuery = new SearchForHits()
+      .setIndexName(indexName)
+      .setQuery(query)
+      .addAttributesToSnippet("title")
+      .addAttributesToSnippet("alternative_titles");
+    List<SearchForHits> requests = List.of(searchQuery);
+    // with searchForHits, all the types are known, no need to cast
+    var responses = client.searchForHits(requests, Actor.class);
+    System.out.println("-> Multi Index SearchForHits:");
+    for (var result : responses) {
+      for (var hit : result.getHits()) {
+        System.out.println("> " + hit.name);
       }
     }
   }

--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -15,6 +15,8 @@ post:
 
     - Different indices for different purposes, such as, one index for products, another one for marketing content.
     - Multiple searches to the same index—for example, with different filters.
+
+    Use the helper `searchForHits` or `searchForFacets` to get the results in a more convenient format, if you already know the return type you want.
   requestBody:
     required: true
     description: Muli-search request body. Results are returned in the same order as the requests.

--- a/templates/java/oneof_interface.mustache
+++ b/templates/java/oneof_interface.mustache
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.annotation.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.algolia.exceptions.AlgoliaRuntimeException;
 import com.algolia.utils.CompoundType;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.BeanProperty;
 
 import java.io.IOException;
 import java.util.List;
@@ -87,9 +89,25 @@ public interface {{classname}}{{#vendorExtensions.x-has-child-generic}}<T>{{/ven
     {{/isModel}}
     {{/composedSchemas.oneOf}}
 
-    class Deserializer{{#vendorExtensions.x-has-child-generic}}<T>{{/vendorExtensions.x-has-child-generic}} extends JsonDeserializer<{{classname}}{{#vendorExtensions.x-has-child-generic}}<T>{{/vendorExtensions.x-has-child-generic}}> {
+    class Deserializer{{#vendorExtensions.x-has-child-generic}}<T>{{/vendorExtensions.x-has-child-generic}} extends JsonDeserializer<{{classname}}{{#vendorExtensions.x-has-child-generic}}<T>{{/vendorExtensions.x-has-child-generic}}>{{#vendorExtensions.x-has-child-generic}} implements ContextualDeserializer{{/vendorExtensions.x-has-child-generic}} {
 
         private static final Logger LOGGER = Logger.getLogger(Deserializer.class.getName());
+
+        {{#vendorExtensions.x-has-child-generic}}
+        private JavaType returnType;
+
+        public Deserializer() {}
+
+        private Deserializer(JavaType returnType) {
+          this.returnType = returnType;
+        }
+
+        @Override
+        public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
+          JavaType contextualType = ctxt.getContextualType().containedType(0);
+          return new Deserializer(contextualType);
+        }
+        {{/vendorExtensions.x-has-child-generic}}
 
         @Override
         public {{classname}}{{#vendorExtensions.x-has-child-generic}}<T>{{/vendorExtensions.x-has-child-generic}} deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
@@ -97,9 +115,19 @@ public interface {{classname}}{{#vendorExtensions.x-has-child-generic}}<T>{{/ven
             {{#composedSchemas.oneOf}}
             // deserialize {{{datatypeWithEnum}}}
             if (tree.{{#isModel}}isObject(){{#vendorExtensions.x-discriminator-fields}} && tree.has("{{{.}}}"){{/vendorExtensions.x-discriminator-fields}}{{/isModel}}{{#isEnumRef}}isTextual(){{/isEnumRef}}{{#isArray}}isArray(){{/isArray}}{{#isInteger}}isInt(){{/isInteger}}{{#isLong}}isLong(){{/isLong}}{{#isDouble}}isDouble(){{/isDouble}}{{#isBoolean}}isBoolean(){{/isBoolean}}{{#isString}}isTextual(){{/isString}}{{^isEnumRef}}{{^isModel}}{{^isArray}}{{^isInteger}}{{^isLong}}{{^isDouble}}{{^isBoolean}}{{^isString}}isObject(){{/isString}}{{/isBoolean}}{{/isDouble}}{{/isLong}}{{/isInteger}}{{/isArray}}{{/isModel}}{{/isEnumRef}}){
-                try(JsonParser parser = tree.traverse(jp.getCodec())) {  
+                try(JsonParser parser = tree.traverse(jp.getCodec())) {
                     {{#isModel}}
-                    return parser.readValueAs({{#vendorExtensions.x-has-child-generic}}new TypeReference<{{datatypeWithEnum}}<T>>() {}{{/vendorExtensions.x-has-child-generic}}{{^vendorExtensions.x-has-child-generic}}{{{datatypeWithEnum}}}.class{{/vendorExtensions.x-has-child-generic}});
+                    {{#vendorExtensions.x-has-child-generic}}
+                    // For generic types, the innerType is erased by Java, we need to use the contextual type.
+                    JavaType innerType = ctxt.getTypeFactory().constructParametricType({{dataType}}.class, returnType);
+                    if (parser.getCurrentToken() == null) {
+                      parser.nextToken();
+                    }
+                    return ctxt.readValue(parser, innerType);
+                    {{/vendorExtensions.x-has-child-generic}}
+                    {{^vendorExtensions.x-has-child-generic}}
+                    return parser.readValueAs({{{datatypeWithEnum}}}.class);
+                    {{/vendorExtensions.x-has-child-generic}}
                     {{/isModel}}
                     {{#isEnumRef}}
                     return parser.readValueAs({{{datatypeWithEnum}}}.class);


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CR-7011](https://algolia.atlassian.net/browse/CR-7011) [CR-8307](https://algolia.atlassian.net/browse/CR-8307)

The `SearchResult` deserialization is not working in java because the generic type `T` is getting erased by java, we need to use all the information about the type to deserialize it into the proper type.