### PR TITLE
feat(javascript): prepare composition for stable release

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-composition/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-composition/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1-alpha.21",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -51,8 +51,8 @@
   "dependencies": {
     "@algolia/client-common": "5.23.4",
     "@algolia/requester-browser-xhr": "5.23.4",
-    "@algolia/requester-fetch": "5.23.4",
-    "@algolia/requester-node-http": "5.23.4"
+    "@algolia/requester-node-http": "5.23.4",
+    "@algolia/requester-fetch": "5.23.4"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.4",

--- a/clients/algoliasearch-client-javascript/packages/composition/package.json
+++ b/clients/algoliasearch-client-javascript/packages/composition/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1-beta.13",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -51,8 +51,8 @@
   "dependencies": {
     "@algolia/client-common": "5.23.4",
     "@algolia/requester-browser-xhr": "5.23.4",
-    "@algolia/requester-fetch": "5.23.4",
-    "@algolia/requester-node-http": "5.23.4"
+    "@algolia/requester-node-http": "5.23.4",
+    "@algolia/requester-fetch": "5.23.4"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.17.4",


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-3729

### Changes included:

This should be enough for the next release to be the 1.0.0 of the JavaScript composition clients.