### PR TITLE
feat(specs): make response fields required for composition list endpoint

### DIFF
--- a/specs/composition-full/common/schemas/listCompositionsResponse.yml
+++ b/specs/composition-full/common/schemas/listCompositionsResponse.yml
@@ -24,8 +24,11 @@ listCompositionsResponse:
       description: Number of items.
       example: 200
   required:
+    - hitsPerPage
     - items
+    - nbHits
     - nbPages
+    - page
 
 composition:
   type: object


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CMP-424

### Changes included:

- List changes

Follow up of https://github.com/algolia/api-clients-automation/pull/4819: fields `hitsPerPage`, `nbHits` and `page` are marked as required.

## 🧪 Test

CI