### PR TITLE
fix(specs): add x-acl to insights endpoints

### DIFF
--- a/specs/insights/paths/deleteUserToken.yml
+++ b/specs/insights/paths/deleteUserToken.yml
@@ -7,6 +7,8 @@ delete:
     Deletes all events related to the specified user token from events metrics and analytics.
     The deletion is asynchronous, and processed within 48 hours.
     To delete a personalization user profile, see `Delete a user profile` in the Personalization API.
+  x-acl:
+    - deleteObject
   parameters:
     - name: userToken
       in: path

--- a/specs/insights/paths/pushEvents.yml
+++ b/specs/insights/paths/pushEvents.yml
@@ -3,6 +3,8 @@ post:
     - events
   operationId: pushEvents
   summary: Send events
+  x-acl:
+    - search
   description: |
     Sends a list of events to the Insights API.
 


### PR DESCRIPTION
## 🧭 What and Why

Adds the required ACL to the Insights API endpoints, `search` for sending events, and `deleteObject` for deleting user token. After a request from a Support Engineer.

🎟 JIRA Ticket:

### Changes included:

- List changes

## 🧪 Test
