### PR TITLE
fix(specs): typoTolerance can be a boolean string

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/utils/OneOf.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/OneOf.java
@@ -205,8 +205,12 @@ public class OneOf {
       List<?> discriminatorsA = (List<?>) propA.vendorExtensions.get("x-discriminator-fields");
       List<?> discriminatorsB = (List<?>) propB.vendorExtensions.get("x-discriminator-fields");
       return discriminatorsB.size() - discriminatorsA.size();
-    } else {
-      return 0;
+    } else if (propA.isBoolean && !propB.isBoolean) {
+      // put boolean last, because of typoTolerance
+      return 1;
+    } else if (!propA.isBoolean && propB.isBoolean) {
+      return -1;
     }
+    return 0;
   };
 }

--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -929,7 +929,7 @@ typoToleranceEnum:
       But if there are no matches without typos (with 1 typo), include matches with 1 typo (2 typos).
     - `strict`. Return matches with the two lowest numbers of typos.
       With `strict`, the Typo ranking criterion is applied first in the `ranking` setting.
-  enum: [min, strict]
+  enum: [min, strict, 'true', 'false']
 
 ignorePlurals:
   description: |

--- a/tests/CTS/requests/search/getSettings.json
+++ b/tests/CTS/requests/search/getSettings.json
@@ -34,7 +34,8 @@
         "alternativesAsExact": [
           "ignorePlurals",
           "singleWordSynonym"
-        ]
+        ],
+        "typoTolerance": "false"
       }
     }
   }

--- a/tests/CTS/requests/search/setSettings.json
+++ b/tests/CTS/requests/search/setSettings.json
@@ -4,7 +4,8 @@
     "parameters": {
       "indexName": "cts_e2e_settings",
       "indexSettings": {
-        "paginationLimitedTo": 10
+        "paginationLimitedTo": 10,
+        "typoTolerance": "false"
       },
       "forwardToReplicas": true
     },
@@ -12,7 +13,8 @@
       "path": "/1/indexes/cts_e2e_settings/settings",
       "method": "PUT",
       "body": {
-        "paginationLimitedTo": 10
+        "paginationLimitedTo": 10,
+        "typoTolerance": "false"
       },
       "queryParameters": {
         "forwardToReplicas": "true"


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CR-8559](https://algolia.atlassian.net/browse/CR-8559)

The `setSettings` accepts `true`, `false`, `"true"`, `"false"`, `"min"`, `"strict"` for `typoTolerance`,
but `getSettings` always returns a string.

It would be better to remove the `oneOf` entirely, but it would be a breaking change.

[CR-8559]: https://algolia.atlassian.net/browse/CR-8559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ