### PR TITLE
fix(specs): wrong ACL for getSettings

### DIFF
--- a/specs/search/paths/settings/settings.yml
+++ b/specs/search/paths/settings/settings.yml
@@ -4,7 +4,7 @@ get:
   operationId: getSettings
   x-mcp-tool: true
   x-acl:
-    - search
+    - settings
   description: Retrieves an object with non-null index settings.
   summary: Retrieve index settings
   parameters:


### PR DESCRIPTION
## 🧭 What and Why

getSettings should require `settings` ACL.

🎟 JIRA Ticket:

### Changes included:

- List changes

## 🧪 Test
