### PR TITLE
fix(clients): consistent naming in transformation region helper

### DIFF
--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -35,7 +35,7 @@ def main():
         environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
     )
 
-    config.with_transformation("eu")
+    config.set_transformation_region("eu")
 
     print("region in playground")
     print(config.region)

--- a/templates/go/configuration.mustache
+++ b/templates/go/configuration.mustache
@@ -33,8 +33,8 @@ type TransformationConfiguration struct {
   Region ingestion.Region
 }
 
-// WithTransformation sets the region of the current algolia application to the configuration, this is required to be called if you wish to leverage the transformation pipeline (via the *WithTransformation methods).
-func (s *SearchConfiguration) WithTransformation(region ingestion.Region) {
+// SetTransformationRegion sets the region of the current algolia application to the configuration, this is required to be called if you wish to leverage the transformation pipeline (via the *WithTransformation methods).
+func (s *SearchConfiguration) SetTransformationRegion(region ingestion.Region) {
   s.Transformation = &TransformationConfiguration{
     Region: region,
   }

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -81,7 +81,7 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
     {{#isSearchClient}}
         self.region = None
 
-    def with_transformation(self, region: str = ""):
+    def set_transformation_region(self, region: str = ""):
         "This method is required to be called with the appropriate region of your Algolia application if you wish to leverage the *_with_transformation methods."
         self.region = region
     {{/isSearchClient}}

--- a/templates/python/tests/client/createClient.mustache
+++ b/templates/python/tests/client/createClient.mustache
@@ -3,6 +3,6 @@ _config = {{#lambda.pascalcase}}{{clientPrefix}}Config{{/lambda.pascalcase}}("{{
         {{#isError}}    {{/isError}}_config.hosts = HostsCollection([{{#customHosts}}Host(url='localhost' if environ.get('CI') == 'true' else 'host.docker.internal', scheme='http', port={{port}}){{^-last}},{{/-last}}{{/customHosts}}])
         {{/hasCustomHosts}}
         {{#hasTransformationRegion}}
-        {{#isError}}    {{/isError}}_config.with_transformation("{{{transformationRegion}}}")
+        {{#isError}}    {{/isError}}_config.set_transformation_region("{{{transformationRegion}}}")
         {{/hasTransformationRegion}}
         {{#isError}}    {{/isError}}_client = {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isSyncClient}}Sync{{/isSyncClient}}.create_with_config(config=_config{{#useEchoRequester}}, transporter=EchoTransporter{{#isSyncClient}}Sync{{/isSyncClient}}(_config){{/useEchoRequester}})


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

I've went with Go namestyle for this helper to set the region on the config by automatism, but realized while implementing the Java one that we've used the setters instead for other helpers (e.g. `SetClientApiKey`) or similar, in order to make the usage consistent, let's stick with this

The doc is not publicly released and no communication have been done on those helpers so better act quick, i'll do a release right away just after