### PR TITLE
chore: use !cancelled instead of always

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -333,6 +333,10 @@ jobs:
           language: ${{ matrix.client.language }}
           version: ${{ matrix.client.version }}
 
+      - name: test cancel
+        if: ${{ matrix.client.language == 'php' }}
+        run: exit 1
+
       - name: Generate clients
         run: yarn cli generate ${{ matrix.client.language }}
 
@@ -652,7 +656,7 @@ jobs:
       - codegen
       - swift_build_linux
       - kotlin_build_macos
-    if: ${{ !cancelled() }} 
+    if: always()
     steps:
       - run: |
           if [[ ("${{ needs.codegen.outputs.success }}" != "true") || ("${{ needs.swift_build_linux.result }}" != "skipped" && "${{ needs.swift_build_linux.outputs.success }}" != "true") || ("${{ needs.kotlin_build_macos.result }}" != "skipped" && "${{ needs.kotlin_build_macos.outputs.success }}" != "true")]]; then

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -178,7 +178,7 @@ jobs:
       - specs
       - scripts
     if: |
-      always() &&
+      !cancelled() &&
       needs.setup.outputs.RUN_GEN_JAVASCRIPT == 'true' &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
@@ -305,7 +305,7 @@ jobs:
       - specs
       - scripts
     if: |
-      always() &&
+      !cancelled() &&
       needs.setup.outputs.RUN_GEN == 'true' &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
@@ -426,7 +426,7 @@ jobs:
       - specs
       - scripts
     if: |
-      always() &&
+      !cancelled() &&
       needs.setup.outputs.RUN_GEN == 'true' &&
       needs.setup.outputs.KOTLIN_DATA != '' &&
       !contains(needs.*.result, 'cancelled') &&
@@ -472,7 +472,7 @@ jobs:
       - specs
       - scripts
     if: |
-      always() &&
+      !cancelled() &&
       needs.setup.outputs.RUN_GEN == 'true' &&
       needs.setup.outputs.SWIFT_DATA != '' &&
       !contains(needs.*.result, 'cancelled') &&
@@ -518,7 +518,7 @@ jobs:
       - client_gen
       - client_gen_javascript
     if: |
-      always() &&
+      !cancelled() &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure')
     permissions:
@@ -652,7 +652,7 @@ jobs:
       - codegen
       - swift_build_linux
       - kotlin_build_macos
-    if: always()
+    if: ${{ !cancelled() }} 
     steps:
       - run: |
           if [[ ("${{ needs.codegen.outputs.success }}" != "true") || ("${{ needs.swift_build_linux.result }}" != "skipped" && "${{ needs.swift_build_linux.outputs.success }}" != "true") || ("${{ needs.kotlin_build_macos.result }}" != "skipped" && "${{ needs.kotlin_build_macos.outputs.success }}" != "true")]]; then
@@ -667,7 +667,7 @@ jobs:
       - codegen
       - check_green
     if: |
-      always() &&
+      !cancelled() &&
       !contains(needs.*.result, 'cancelled') &&
       !contains(needs.*.result, 'failure') &&
       github.ref == 'refs/heads/main'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -333,10 +333,6 @@ jobs:
           language: ${{ matrix.client.language }}
           version: ${{ matrix.client.version }}
 
-      - name: test cancel
-        if: ${{ matrix.client.language == 'php' }}
-        run: exit 1
-
       - name: Generate clients
         run: yarn cli generate ${{ matrix.client.language }}
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: -

### Changes included:

seems like this is more suitable if we want to cancel in progress matrix, which avoid waiting minuts before the next run https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#cancelled

see it in action when failure occurs, it continues https://github.com/algolia/api-clients-automation/actions/runs/15486920547