### PR TITLE
chore(spec): fix comment of custom path

### DIFF
--- a/specs/common/schemas/CustomRequest.yml
+++ b/specs/common/schemas/CustomRequest.yml
@@ -26,7 +26,7 @@ Responses:
 PathInPath:
   name: path
   in: path
-  description: Path of the endpoint, anything after "/1" must be specified.
+  description: Path of the endpoint, for example `1/newFeature`.
   required: true
   schema:
     type: string


### PR DESCRIPTION
## 🧭 What and Why

The custom endpoints will append the path after the host + `/`, so it should start with the version.