### PR TITLE
fix(cts): rename test

### DIFF
--- a/tests/CTS/requests/search/setSettings.json
+++ b/tests/CTS/requests/search/setSettings.json
@@ -1719,7 +1719,7 @@
     }
   },
   {
-    "testName": "set_searchable_attributes",
+    "testName": "set_attributes_for_faceting",
     "parameters": {
       "indexName": "theIndexName",
       "indexSettings": {


### PR DESCRIPTION
## 🧭 What and Why

The `testName` "set_searchable_attributes" occurred twice.
One of them is actually for `attributesForFaceting`.

🎟 JIRA Ticket:

### Changes included:

- Rename test to `set_attributes_for_faceting`

## 🧪 Test
