### PR TITLE
feat(specs): abtesting winsorizedAmount

### DIFF
--- a/specs/abtesting/common/parameters.yml
+++ b/specs/abtesting/common/parameters.yml
@@ -69,11 +69,13 @@ currencies:
       revenue: 120.0
       mean: 53.7
       standardDeviation: 12.3
+      winsorizedAmount: 23.0
     EUR:
       currency: EUR
       revenue: 100.0
       mean: 43.7
       standardDeviation: 10.3
+      winsorizedAmount: 10.0
   additionalProperties:
     $ref: '#/currency'
     x-additionalPropertiesName: currency code
@@ -100,6 +102,11 @@ currency:
       format: double
       description: Standard deviation for this currency.
       example: 12.3
+    winsorizedAmount:
+      type: number
+      format: double
+      description: The amount of revenue for this currency that was removed after capping purchase amounts to the 95th percentile.
+      example: 23.0
 
 filterEffects:
   type: object

--- a/specs/bundled/abtesting.yml
+++ b/specs/bundled/abtesting.yml
@@ -630,7 +630,7 @@ components:
     PathInPath:
       name: path
       in: path
-      description: Path of the endpoint, anything after "/1" must be specified.
+      description: Path of the endpoint, for example `1/newFeature`.
       required: true
       schema:
         type: string

--- a/specs/bundled/abtesting.yml
+++ b/specs/bundled/abtesting.yml
@@ -630,7 +630,7 @@ components:
     PathInPath:
       name: path
       in: path
-      description: Path of the endpoint, for example `1/newFeature`.
+      description: Path of the endpoint, anything after "/1" must be specified.
       required: true
       schema:
         type: string
@@ -723,11 +723,6 @@ components:
           format: double
           description: Standard deviation for this currency.
           example: 12.3
-        winsorizedAmount:
-          type: number
-          format: double
-          description: The amount of revenue for this currency that was removed after capping purchase amounts to the 95th percentile.
-          example: 115
     currencies:
       type: object
       description: A/B test currencies.
@@ -737,13 +732,11 @@ components:
           revenue: 120
           mean: 53.7
           standardDeviation: 12.3
-          winsorizedAmount: 23
         EUR:
           currency: EUR
           revenue: 100
           mean: 43.7
           standardDeviation: 10.3
-          winsorizedAmount: 10
       additionalProperties:
         $ref: '#/components/schemas/currency'
         x-additionalPropertiesName: currency code

--- a/specs/bundled/abtesting.yml
+++ b/specs/bundled/abtesting.yml
@@ -723,6 +723,11 @@ components:
           format: double
           description: Standard deviation for this currency.
           example: 12.3
+        winsorizedAmount:
+          type: number
+          format: double
+          description: The amount of revenue for this currency that was removed after capping purchase amounts to the 95th percentile.
+          example: 115
     currencies:
       type: object
       description: A/B test currencies.
@@ -732,11 +737,13 @@ components:
           revenue: 120
           mean: 53.7
           standardDeviation: 12.3
+          winsorizedAmount: 23
         EUR:
           currency: EUR
           revenue: 100
           mean: 43.7
           standardDeviation: 10.3
+          winsorizedAmount: 10
       additionalProperties:
         $ref: '#/components/schemas/currency'
         x-additionalPropertiesName: currency code


### PR DESCRIPTION
## 🧭 What and Why

Adding the missing `winsorizedAmount` to the current V2 currency object

### Changes included:

- a new parameter for the abtesting spec

## 🧪 Test

Green CI
