### PR TITLE
fix(clients): upgrade to maven central publishing

### DIFF
--- a/clients/algoliasearch-client-java/api/build.gradle
+++ b/clients/algoliasearch-client-java/api/build.gradle
@@ -9,7 +9,10 @@ plugins {
 }
 
 repositories {
-  maven { url = "https://oss.sonatype.org/content/repositories/" }
+   maven {
+      name = 'ossrh-staging-api'
+      url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+  }
   mavenCentral()
 }
 


### PR DESCRIPTION
## 🧭 What and Why

We used OSSRH to release our JVM clients, but the support has been dropped on the 30th of June: https://central.sonatype.org/pages/ossrh-eol/#central-support

Migrate to the new Maven Central Publishing.

I've generated a new token, it's stored in vault and the Java, Kotlin and Scala github secrets.