### PR TITLE
fix(specs): analytics base url correction

### DIFF
--- a/specs/abtesting/spec.yml
+++ b/specs/abtesting/spec.yml
@@ -14,7 +14,7 @@ info:
 
     - `https://analytics.us.algolia.com`
     - `https://analytics.de.algolia.com`
-    - `https://analytics.algolia.com` (routes requests to the closest of the above servers, based on your geographical location)
+    - `https://analytics.algolia.com` (alias of `analytics.us.algolia.com`)
 
     Use the URL that matches your [analytics region](https://dashboard.algolia.com/account/infrastructure/analytics).
 

--- a/specs/analytics/spec.yml
+++ b/specs/analytics/spec.yml
@@ -14,7 +14,7 @@ info:
 
     - `https://analytics.us.algolia.com`
     - `https://analytics.de.algolia.com`
-    - `https://analytics.algolia.com` (routes requests to the closest of the above servers, based on your geographical location)
+    - `https://analytics.algolia.com` (alias of `analytics.us.algolia.com`)
 
     Use the URL that matches your [analytics region](https://dashboard.algolia.com/account/infrastructure/analytics).
 


### PR DESCRIPTION
## 🧭 What and Why

Turns out that this information was incorrect, `analytics.algolia.com` is just routing to `analytics.us.algolia.com`. 

🎟 JIRA Ticket: [CR-8865](https://algolia.atlassian.net/browse/CR-8865)

### Changes included:

- List changes

## 🧪 Test


[CR-8865]: https://algolia.atlassian.net/browse/CR-8865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ