### PR TITLE
feat(templates): use headers in js advanced perso client

### DIFF
--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -12,7 +12,7 @@
     logger: createNullLogger(),
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
-    authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{#isCompositionFullClient}}Headers{{/isCompositionFullClient}}{{^isCompositionClient}}{{^isCompositionFullClient}}QueryParameters{{/isCompositionFullClient}}{{/isCompositionClient}}',
+    authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{#isAdvancedPersonalizationClient}}Headers{{/isAdvancedPersonalizationClient}}{{#isCompositionFullClient}}Headers{{/isCompositionFullClient}}{{^isCompositionClient}}{{^isCompositionFullClient}}QueryParameters{{/isCompositionFullClient}}{{/isCompositionClient}}',
     responsesCache: createMemoryCache(),
     requestsCache: createMemoryCache({ serializable: false }),
     hostsCache: createFallbackableCache({

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -12,7 +12,7 @@
     logger: createNullLogger(),
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
-    authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{#isAdvancedPersonalizationClient}}Headers{{/isAdvancedPersonalizationClient}}{{#isCompositionFullClient}}Headers{{/isCompositionFullClient}}{{^isCompositionClient}}{{^isCompositionFullClient}}QueryParameters{{/isCompositionFullClient}}{{/isCompositionClient}}',
+    authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{#isAdvancedPersonalizationClient}}Headers{{/isAdvancedPersonalizationClient}}{{#isCompositionFullClient}}Headers{{/isCompositionFullClient}}{{^isAdvancedPersonalizationClient}}{{^isCompositionClient}}{{^isCompositionFullClient}}QueryParameters{{/isCompositionFullClient}}{{/isCompositionClient}}{{/isAdvancedPersonalizationClient}}',
     responsesCache: createMemoryCache(),
     requestsCache: createMemoryCache({ serializable: false }),
     hostsCache: createFallbackableCache({


### PR DESCRIPTION
## 🧭 What and Why
Change the auth mode to default to header auth for the JS advanced perso client, due to query param based auth being disallowed in the API.

🎟 JIRA Ticket: none

### Changes included:

- Change templates

## 🧪 Test
n/a