### PR TITLE
fix(specs): `averageClickPosition` return type

### DIFF
--- a/specs/abtesting/common/schemas/Variant.yml
+++ b/specs/abtesting/common/schemas/Variant.yml
@@ -26,10 +26,11 @@ variant:
         - type: 'null'
     averageClickPosition:
       oneOf:
-        - type: integer
+        - type: number
+          format: double
           description: |
             [Average click position](https://www.algolia.com/doc/guides/search-analytics/concepts/metrics/#click-position) for this variant.
-          example: 0
+          example: 29.12342
         - type: 'null'
     clickCount:
       type: integer


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CR-8944

### Changes included:

the average is not always an integer