### PR TITLE
chore: prepare release 2025-07-17

### DIFF
--- a/clients/algoliasearch-client-javascript/CHANGELOG.md
+++ b/clients/algoliasearch-client-javascript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.34.0](https://github.com/algolia/algoliasearch-client-javascript/compare/5.33.0...5.34.0)
+
+- [d05999769a](https://github.com/algolia/api-clients-automation/commit/d05999769a) fix(specs): abtests metadata mean ([#5121](https://github.com/algolia/api-clients-automation/pull/5121)) by [@cdhawke](https://github.com/cdhawke/)
+- [278a9e6832](https://github.com/algolia/api-clients-automation/commit/278a9e6832) fix(specs): cleanup for composition API clients ([#5119](https://github.com/algolia/api-clients-automation/pull/5119)) by [@ClaraMuller](https://github.com/ClaraMuller/)
+- [e7dfb35f92](https://github.com/algolia/api-clients-automation/commit/e7dfb35f92) refactor(specs): group files for composition api ([#5122](https://github.com/algolia/api-clients-automation/pull/5122)) by [@ClaraMuller](https://github.com/ClaraMuller/)
+- [2ee13af721](https://github.com/algolia/api-clients-automation/commit/2ee13af721) feat(specs): add lastUpdatedAt to personalization real-time user ([#5126](https://github.com/algolia/api-clients-automation/pull/5126)) by [@raed667](https://github.com/raed667/)
+
 ## [5.33.0](https://github.com/algolia/algoliasearch-client-javascript/compare/5.32.0...5.33.0)
 
 - [a7a3c5fc95](https://github.com/algolia/api-clients-automation/commit/a7a3c5fc95) feat(specs): document runMetadata parameter ([#5087](https://github.com/algolia/api-clients-automation/pull/5087)) by [@DevinCodes](https://github.com/DevinCodes/)

--- a/clients/algoliasearch-client-javascript/packages/abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/abtesting/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
@@ -64,5 +64,6 @@
   },
   "engines": {
     "node": ">= 14.0.0"
-  }
+  },
+  "stableVersion": "0.0.1-alpha.4"
 }

--- a/clients/algoliasearch-client-javascript/packages/advanced-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/advanced-personalization/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
@@ -64,5 +64,6 @@
   },
   "engines": {
     "node": ">= 14.0.0"
-  }
+  },
+  "stableVersion": "0.0.1-alpha.6"
 }

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -74,22 +74,22 @@
     "lite.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-abtesting": "5.33.0",
-    "@algolia/client-analytics": "5.33.0",
-    "@algolia/client-common": "5.33.0",
-    "@algolia/client-insights": "5.33.0",
-    "@algolia/client-personalization": "5.33.0",
-    "@algolia/client-query-suggestions": "5.33.0",
-    "@algolia/client-search": "5.33.0",
-    "@algolia/ingestion": "1.33.0",
-    "@algolia/monitoring": "1.33.0",
-    "@algolia/recommend": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-abtesting": "5.34.0",
+    "@algolia/client-analytics": "5.34.0",
+    "@algolia/client-common": "5.34.0",
+    "@algolia/client-insights": "5.34.0",
+    "@algolia/client-personalization": "5.34.0",
+    "@algolia/client-query-suggestions": "5.34.0",
+    "@algolia/client-search": "5.34.0",
+    "@algolia/ingestion": "1.34.0",
+    "@algolia/monitoring": "1.34.0",
+    "@algolia/recommend": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
-    "@algolia/requester-testing": "5.33.0",
+    "@algolia/requester-testing": "5.34.0",
     "@arethetypeswrong/cli": "0.18.2",
     "@cloudflare/vitest-pool-workers": "0.8.53",
     "@cloudflare/workers-types": "4.20250428.0",

--- a/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-abtesting/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-analytics/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-common/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/client-common",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Common package for the Algolia JavaScript API client.",
   "repository": {
     "type": "git",

--- a/clients/algoliasearch-client-javascript/packages/client-composition/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-composition/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.0",
+  "version": "1.10.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-insights/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-insights/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-personalization/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-query-suggestions/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/client-search/package.json
+++ b/clients/algoliasearch-client-javascript/packages/client-search/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/composition/package.json
+++ b/clients/algoliasearch-client-javascript/packages/composition/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.0",
+  "version": "1.10.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/ingestion/package.json
+++ b/clients/algoliasearch-client-javascript/packages/ingestion/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.33.0",
+  "version": "1.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/logger-console/package.json
+++ b/clients/algoliasearch-client-javascript/packages/logger-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/logger-console",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Promise-based log library using console log.",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "vitest": "3.2.4"
   },
   "dependencies": {
-    "@algolia/client-common": "5.33.0"
+    "@algolia/client-common": "5.34.0"
   },
   "engines": {
     "node": ">= 14.0.0"

--- a/clients/algoliasearch-client-javascript/packages/monitoring/package.json
+++ b/clients/algoliasearch-client-javascript/packages/monitoring/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.33.0",
+  "version": "1.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/recommend/package.json
+++ b/clients/algoliasearch-client-javascript/packages/recommend/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.33.0",
+  "version": "5.34.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/algolia/algoliasearch-client-javascript.git"
@@ -49,10 +49,10 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-browser-xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-browser-xhr",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Promise-based request library for browser using xhr.",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "test:bundle": "publint . && attw --pack . --ignore-rules cjs-resolves-to-esm"
   },
   "dependencies": {
-    "@algolia/client-common": "5.33.0"
+    "@algolia/client-common": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-fetch",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Promise-based request library using Fetch.",
   "repository": {
     "type": "git",
@@ -48,7 +48,7 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.33.0"
+    "@algolia/client-common": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-node-http",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "description": "Promise-based request library for node using the native http module.",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.33.0"
+    "@algolia/client-common": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
+++ b/clients/algoliasearch-client-javascript/packages/requester-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/requester-testing",
-  "version": "5.33.0",
+  "version": "5.34.0",
   "private": true,
   "description": "A package that contains the echo requester of the algoliasearch JavaScript requesters, for testing purposes",
   "repository": {
@@ -43,10 +43,10 @@
     "test:bundle": "publint . && attw --pack ."
   },
   "dependencies": {
-    "@algolia/client-common": "5.33.0",
-    "@algolia/requester-browser-xhr": "5.33.0",
-    "@algolia/requester-fetch": "5.33.0",
-    "@algolia/requester-node-http": "5.33.0"
+    "@algolia/client-common": "5.34.0",
+    "@algolia/requester-browser-xhr": "5.34.0",
+    "@algolia/requester-fetch": "5.34.0",
+    "@algolia/requester-node-http": "5.34.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -9,10 +9,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/abtesting@workspace:packages/abtesting"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -26,10 +26,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/advanced-personalization@workspace:packages/advanced-personalization"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -39,14 +39,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-abtesting@npm:5.33.0, @algolia/client-abtesting@workspace:packages/client-abtesting":
+"@algolia/client-abtesting@npm:5.34.0, @algolia/client-abtesting@workspace:packages/client-abtesting":
   version: 0.0.0-use.local
   resolution: "@algolia/client-abtesting@workspace:packages/client-abtesting"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -56,14 +56,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-analytics@npm:5.33.0, @algolia/client-analytics@workspace:packages/client-analytics":
+"@algolia/client-analytics@npm:5.34.0, @algolia/client-analytics@workspace:packages/client-analytics":
   version: 0.0.0-use.local
   resolution: "@algolia/client-analytics@workspace:packages/client-analytics"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -73,7 +73,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-common@npm:5.33.0, @algolia/client-common@workspace:packages/client-common":
+"@algolia/client-common@npm:5.34.0, @algolia/client-common@workspace:packages/client-common":
   version: 0.0.0-use.local
   resolution: "@algolia/client-common@workspace:packages/client-common"
   dependencies:
@@ -92,10 +92,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/client-composition@workspace:packages/client-composition"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -105,14 +105,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-insights@npm:5.33.0, @algolia/client-insights@workspace:packages/client-insights":
+"@algolia/client-insights@npm:5.34.0, @algolia/client-insights@workspace:packages/client-insights":
   version: 0.0.0-use.local
   resolution: "@algolia/client-insights@workspace:packages/client-insights"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -122,14 +122,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-personalization@npm:5.33.0, @algolia/client-personalization@workspace:packages/client-personalization":
+"@algolia/client-personalization@npm:5.34.0, @algolia/client-personalization@workspace:packages/client-personalization":
   version: 0.0.0-use.local
   resolution: "@algolia/client-personalization@workspace:packages/client-personalization"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -139,14 +139,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-query-suggestions@npm:5.33.0, @algolia/client-query-suggestions@workspace:packages/client-query-suggestions":
+"@algolia/client-query-suggestions@npm:5.34.0, @algolia/client-query-suggestions@workspace:packages/client-query-suggestions":
   version: 0.0.0-use.local
   resolution: "@algolia/client-query-suggestions@workspace:packages/client-query-suggestions"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -156,14 +156,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/client-search@npm:5.33.0, @algolia/client-search@workspace:packages/client-search":
+"@algolia/client-search@npm:5.34.0, @algolia/client-search@workspace:packages/client-search":
   version: 0.0.0-use.local
   resolution: "@algolia/client-search@workspace:packages/client-search"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -177,10 +177,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/composition@workspace:packages/composition"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -190,14 +190,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/ingestion@npm:1.33.0, @algolia/ingestion@workspace:packages/ingestion":
+"@algolia/ingestion@npm:1.34.0, @algolia/ingestion@workspace:packages/ingestion":
   version: 0.0.0-use.local
   resolution: "@algolia/ingestion@workspace:packages/ingestion"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -211,7 +211,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@algolia/logger-console@workspace:packages/logger-console"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     jsdom: "npm:26.1.0"
@@ -223,14 +223,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/monitoring@npm:1.33.0, @algolia/monitoring@workspace:packages/monitoring":
+"@algolia/monitoring@npm:1.34.0, @algolia/monitoring@workspace:packages/monitoring":
   version: 0.0.0-use.local
   resolution: "@algolia/monitoring@workspace:packages/monitoring"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -240,14 +240,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/recommend@npm:5.33.0, @algolia/recommend@workspace:packages/recommend":
+"@algolia/recommend@npm:5.34.0, @algolia/recommend@workspace:packages/recommend":
   version: 0.0.0-use.local
   resolution: "@algolia/recommend@workspace:packages/recommend"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -257,11 +257,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-browser-xhr@npm:5.33.0, @algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr":
+"@algolia/requester-browser-xhr@npm:5.34.0, @algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-browser-xhr@workspace:packages/requester-browser-xhr"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     jsdom: "npm:26.1.0"
@@ -273,11 +273,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-fetch@npm:5.33.0, @algolia/requester-fetch@workspace:packages/requester-fetch":
+"@algolia/requester-fetch@npm:5.34.0, @algolia/requester-fetch@workspace:packages/requester-fetch":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-fetch@workspace:packages/requester-fetch"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     cross-fetch: "npm:4.1.0"
@@ -289,11 +289,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-node-http@npm:5.33.0, @algolia/requester-node-http@workspace:packages/requester-node-http":
+"@algolia/requester-node-http@npm:5.34.0, @algolia/requester-node-http@workspace:packages/requester-node-http":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-node-http@workspace:packages/requester-node-http"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     nock: "npm:14.0.5"
@@ -304,14 +304,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@algolia/requester-testing@npm:5.33.0, @algolia/requester-testing@workspace:packages/requester-testing":
+"@algolia/requester-testing@npm:5.34.0, @algolia/requester-testing@workspace:packages/requester-testing":
   version: 0.0.0-use.local
   resolution: "@algolia/requester-testing@workspace:packages/requester-testing"
   dependencies:
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@types/node": "npm:22.16.3"
     publint: "npm:0.3.12"
@@ -2530,20 +2530,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "algoliasearch@workspace:packages/algoliasearch"
   dependencies:
-    "@algolia/client-abtesting": "npm:5.33.0"
-    "@algolia/client-analytics": "npm:5.33.0"
-    "@algolia/client-common": "npm:5.33.0"
-    "@algolia/client-insights": "npm:5.33.0"
-    "@algolia/client-personalization": "npm:5.33.0"
-    "@algolia/client-query-suggestions": "npm:5.33.0"
-    "@algolia/client-search": "npm:5.33.0"
-    "@algolia/ingestion": "npm:1.33.0"
-    "@algolia/monitoring": "npm:1.33.0"
-    "@algolia/recommend": "npm:5.33.0"
-    "@algolia/requester-browser-xhr": "npm:5.33.0"
-    "@algolia/requester-fetch": "npm:5.33.0"
-    "@algolia/requester-node-http": "npm:5.33.0"
-    "@algolia/requester-testing": "npm:5.33.0"
+    "@algolia/client-abtesting": "npm:5.34.0"
+    "@algolia/client-analytics": "npm:5.34.0"
+    "@algolia/client-common": "npm:5.34.0"
+    "@algolia/client-insights": "npm:5.34.0"
+    "@algolia/client-personalization": "npm:5.34.0"
+    "@algolia/client-query-suggestions": "npm:5.34.0"
+    "@algolia/client-search": "npm:5.34.0"
+    "@algolia/ingestion": "npm:1.34.0"
+    "@algolia/monitoring": "npm:1.34.0"
+    "@algolia/recommend": "npm:5.34.0"
+    "@algolia/requester-browser-xhr": "npm:5.34.0"
+    "@algolia/requester-fetch": "npm:5.34.0"
+    "@algolia/requester-node-http": "npm:5.34.0"
+    "@algolia/requester-testing": "npm:5.34.0"
     "@arethetypeswrong/cli": "npm:0.18.2"
     "@cloudflare/vitest-pool-workers": "npm:0.8.53"
     "@cloudflare/workers-types": "npm:4.20250428.0"

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -196,7 +196,7 @@
     ],
     "folder": "clients/algoliasearch-client-javascript",
     "gitRepoId": "algoliasearch-client-javascript",
-    "packageVersion": "5.33.0",
+    "packageVersion": "5.34.0",
     "modelFolder": "model",
     "apiFolder": "src",
     "tests": {

--- a/docs/versions-history-with-sla-and-support-policy.json
+++ b/docs/versions-history-with-sla-and-support-policy.json
@@ -741,9 +741,9 @@
       "releaseDate": "2025-07-07"
     },
     "7.23.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "dart": {
@@ -1945,9 +1945,9 @@
       "releaseDate": "2025-07-07"
     },
     "4.22.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "java": {
@@ -2729,9 +2729,9 @@
       "releaseDate": "2025-07-08"
     },
     "4.22.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "javascript": {
@@ -4179,7 +4179,12 @@
       "releaseDate": "2025-07-08"
     },
     "5.33.0": {
-      "releaseDate": "2025-07-15",
+      "slaStatus": "eligible",
+      "supportStatus": "not eligible",
+      "releaseDate": "2025-07-15"
+    },
+    "5.34.0": {
+      "releaseDate": "2025-07-17",
       "slaStatus": "eligible",
       "supportStatus": "eligible"
     }
@@ -4702,9 +4707,9 @@
       "releaseDate": "2025-07-08"
     },
     "3.25.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "php": {
@@ -5518,9 +5523,9 @@
       "releaseDate": "2025-07-07"
     },
     "4.25.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "python": {
@@ -6222,9 +6227,9 @@
       "releaseDate": "2025-07-07"
     },
     "4.23.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "ruby": {
@@ -6982,9 +6987,9 @@
       "releaseDate": "2025-07-07"
     },
     "3.22.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "scala": {
@@ -7656,9 +7661,9 @@
       "releaseDate": "2025-07-08"
     },
     "2.24.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   },
   "swift": {
@@ -8406,9 +8411,9 @@
       "releaseDate": "2025-07-07"
     },
     "9.25.0": {
-      "releaseDate": "2025-07-15",
       "slaStatus": "eligible",
-      "supportStatus": "eligible"
+      "supportStatus": "eligible",
+      "releaseDate": "2025-07-15"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR has been created using the `apic release` script. Once merged, the clients will try to release their new version if their version has changed.

## Version Changes

- ~csharp: 7.23.0 (no commit)~
- ~dart: 1.34.1 (no commit)~
- ~go: 4.22.0 (no commit)~
- ~java: 4.22.0 (no commit)~
- javascript: 5.33.0 -> **`minor` _(e.g. 5.34.0)_**
- ~kotlin: 3.25.0 (no commit)~
- ~php: 4.25.0 (no commit)~
- ~python: 4.23.0 (no commit)~
- ~ruby: 3.22.0 (no commit)~
- ~scala: 2.24.0 (no commit)~
- ~swift: 9.25.0 (no commit)~

### Skipped Commits


<p>It doesn't mean these commits are being excluded from the release. It means they're not taken into account when the release process figured out the next version number, and updated the changelog.</p>

<details>
  <summary>
    <i>Commits without language scope:</i>
  </summary>

  - fix(specs): add back rate-limit information for crawlUrls
- chore(CODEOWNERS): add composition team as code owner of Composition API client specs
</details>