### PR TITLE
fix(clients): add batchSize to accountCopyIndex

### DIFF
--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -25,7 +25,7 @@ const aciState: Record<
 export function assertValidAccountCopyIndex(expectedCount: number): void {
   expect(Object.keys(aciState)).to.have.length(expectedCount);
   for (const lang in aciState) {
-    expect(aciState[lang].waitTaskCount).to.equal(4);
+    expect(aciState[lang].waitTaskCount).to.equal(5);
   }
 }
 
@@ -167,23 +167,25 @@ function addRoutes(app: Express): void {
   app.post('/1/indexes/:indexName/browse', (req, res) => {
     const lang = req.params.indexName.match(/^cts_e2e_account_copy_index_source_(.*)$/)?.[1] as string;
     expect(aciState).to.include.keys(lang);
+    expect(req.body.hitsPerPage).to.equal(2);
 
     aciState[lang].browseObjectsCount++;
 
     res.json({
       page: 0,
-      nbHits: 1,
+      nbHits: 4,
       nbPages: 1,
-      hitsPerPage: 1000,
+      hitsPerPage: req.body.hitsPerPage,
       query: '',
       params: '',
-      hits: [{ objectID: 'bar' }],
+      hits: [{ objectID: 'bar' }, { objectID: 'foo' }, { objectID: 'baz' }, { objectID: 'qux' }],
     });
   });
 
   app.post('/1/indexes/:indexName/batch', (req, res) => {
     const lang = req.params.indexName.match(/^cts_e2e_account_copy_index_destination_(.*)$/)?.[1] as string;
     expect(aciState).to.include.keys(lang);
+    expect(req.body.requests).to.have.lengthOf(2);
 
     aciState[lang].saveObjectsCount++;
 

--- a/specs/search/helpers/accountCopyIndex.yml
+++ b/specs/search/helpers/accountCopyIndex.yml
@@ -40,6 +40,13 @@ method:
         required: true
         schema:
           type: string
+      - in: query
+        name: batchSize
+        description: The size of the chunk of `objects`. Defaults to 1000.
+        required: false
+        schema:
+          type: integer
+          default: 1000
     responses:
       '400':
         $ref: '../../common/responses/IndexInSameApp.yml'

--- a/templates/javascript/clients/client/api/nodeHelpers.mustache
+++ b/templates/javascript/clients/client/api/nodeHelpers.mustache
@@ -45,10 +45,11 @@ generateSecuredApiKey: ({
  * @param accountCopyIndex.destinationAppID - The application ID to write the index to.
  * @param accountCopyIndex.destinationApiKey - The API Key of the `destinationAppID` to write the index to, must have write ACLs.
  * @param accountCopyIndex.destinationIndexName - The name of the index to write the copied index to.
+ * @param accountCopyIndex.batchSize - The size of the chunk of `objects`. Defaults to 1000.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `setSettings`, `saveRules`, `saveSynonyms` and `saveObjects` method and merged with the transporter requestOptions.
  */
 async accountCopyIndex(
-  { sourceIndexName, destinationAppID, destinationApiKey, destinationIndexName }: AccountCopyIndexOptions,
+  { sourceIndexName, destinationAppID, destinationApiKey, destinationIndexName, batchSize }: AccountCopyIndexOptions,
   requestOptions?: RequestOptions | undefined,
 ): Promise<void> {
   const responses: Array<{ taskID: UpdatedAtResponse['taskID'] }> = [];
@@ -118,10 +119,11 @@ async accountCopyIndex(
 
   await this.browseObjects({
     indexName: sourceIndexName,
+    browseParams: batchSize ? { hitsPerPage: batchSize } : undefined,
     async aggregator(response: BrowseResponse) {
       responses.push(
         ...(await destinationClient.saveObjects(
-          { indexName: destinationIndexName, objects: response.hits },
+          { indexName: destinationIndexName, objects: response.hits, batchSize },
           requestOptions,
         )),
       );

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -210,6 +210,11 @@ export type AccountCopyIndexOptions = {
    * The name of the index to write the copy in.
    */
   destinationIndexName: string;
+
+  /**
+   * The size of the chunk of `objects`. Defaults to 1000.
+   */
+  batchSize?: number | undefined;
 };
 {{/isAlgoliasearchClient}}
 {{/isSearchClient}}

--- a/tests/CTS/client/search/accountCopyIndex.json
+++ b/tests/CTS/client/search/accountCopyIndex.json
@@ -22,7 +22,8 @@
           "sourceIndexName": "cts_e2e_account_copy_index_source_${{language}}",
           "destinationAppID": "test-app-id-destination",
           "destinationApiKey": "test-api-key-destination",
-          "destinationIndexName": "cts_e2e_account_copy_index_destination_${{language}}"
+          "destinationIndexName": "cts_e2e_account_copy_index_destination_${{language}}",
+          "batchSize": 2
         }
       }
     ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CR-8910](https://algolia.atlassian.net/browse/CR-8910)

Customers want to configure the `batchSize` when using `accountCopyIndex`, we can just forward the value to the other helpers.

[CR-8910]: https://algolia.atlassian.net/browse/CR-8910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ