### PR TITLE
Fix/scala release

### DIFF
--- a/clients/algoliasearch-client-scala/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-scala/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: checkout the release tag
+        run: |
+          TAG=$(sed -n 's/.*version := "\(.*\)"/\1/p' version.sbt)
+          echo "Checking out tag $TAG"
+          git checkout "v$TAG"
 
       - name: Install Java
         uses: actions/setup-java@v4
@@ -26,7 +34,7 @@ jobs:
 
       - run: sbt ci-release
         env:
-          PGP_PASSPHRASE: ${{ secrets.SIGNING_PRIVATE_KEY_PASSWORD }}
-          PGP_SECRET: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -99,7 +99,7 @@ async function spreadGeneration(): Promise<void> {
       // ruby tag is already pushed by `rake release`
       if (IS_RELEASE_COMMIT && lang !== 'ruby') {
         // Go needs a 'v' prefix for tags.
-        const tagVersion = lang === 'go' ? `v${version}` : version;
+        const tagVersion = lang === 'go' || lang === 'scala' ? `v${version}` : version;
 
         console.log(`Processing release commit, creating new release tag ('${version}') for '${lang}' repository.`);
 


### PR DESCRIPTION
## 🧭 What and Why

`sbt-ci-release` expects that we checkout the tag directly, and that the tag starts with a v.