### PR TITLE
chore(scripts): allow retry of the release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -693,17 +693,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
       - name: Wait for all release CI
+        id: waitForAllReleases
         run: yarn workspace scripts waitForAllReleases ${{ steps.spreadGeneration.outputs.PUSHED_LANGUAGES }}
         env:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
       - name: Create GitHub release
-        run: yarn workspace scripts createGitHubReleases ${{ steps.spreadGeneration.outputs.PUSHED_LANGUAGES }}
+        run: yarn workspace scripts createGitHubReleases ${{ steps.waitForAllReleases.outputs.RELEASED_LANGUAGES }}
         env:
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
 
-      - name: Push generated files to repositories
+      - name: Push generated files to doc/dashboard repositories
         run: yarn workspace scripts pushToRepository
+        if: ${{ steps.waitForAllReleases.outputs.CAN_PUSH_TO_REPO == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.ALGOLIA_BOT_TOKEN }}
+        
+      - name: notify failures
+        uses: slackapi/slack-github-action@v2.1.1
+        if: ${{ steps.waitForAllReleases.outputs.FAILED_RELEASES != '' }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: ":alert: Some clients failed to release :alert: \n${{ steps.waitForAllReleases.outputs.FAILED_RELEASES }}\nYou can retry the CI jobs to release them again, it will not affect already released clients."

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -52,7 +52,11 @@ async function spreadGeneration(): Promise<void> {
   if (IS_RELEASE_COMMIT) {
     console.log('Creating new `released` tag for latest commit');
     await run(`git tag ${await getNewReleasedTag()}`);
-    await run('git push --tags');
+    try {
+      await run('git push --tags');
+    } catch (e) {
+      console.error('Failed to push tags, it might already exist, ignoring error.', e);
+    }
   }
 
   const pushed: Language[] = [];
@@ -62,7 +66,7 @@ async function spreadGeneration(): Promise<void> {
       const { tempGitDir } = await cloneRepository({
         lang,
         githubToken,
-        tempDir: process.env.RUNNER_TEMP!,
+        tempDir: process.env.RUNNER_TEMP || '/tmp',
       });
 
       const clientPath = toAbsolutePath(getLanguageFolder(lang));

--- a/scripts/ci/codegen/waitForAllReleases.ts
+++ b/scripts/ci/codegen/waitForAllReleases.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import type { components } from '@octokit/openapi-types';
 
 import { exists, getOctokit, run, setVerbose, toAbsolutePath } from '../../common.ts';
@@ -125,8 +126,12 @@ async function waitForAllReleases(languagesReleased: Language[]): Promise<void> 
   }
 
   if (failures.length > 0) {
-    throw new Error(`${failures.join(', ')} failed to release`);
+    console.error(`${failures.join(', ')} releases failed, please check the CI logs.`);
+    core.setOutput('FAILED_RELEASES', failures.join(' '));
   }
+
+  core.setOutput('CAN_PUSH_TO_REPO', true);
+  core.setOutput('RELEASED_LANGUAGES', languagesReleased.filter((lang) => !failures.includes(lang)).join(' '));
 }
 
 if (import.meta.url.endsWith(process.argv[1])) {


### PR DESCRIPTION
## 🧭 What and Why

Make the release non-blocking, it will only create the github release for the language that succeeded to release, and send a slack message for the one that failed.
We can retry the CI since it will only try to release languages that have changes.