### PR TITLE
feat(specs): add fields for metadata in composition injectedItems

### DIFF
--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -81,6 +81,23 @@ injectedItem:
       type: integer
       minimum: 0
       maximum: 20
+    metadata:
+      title: injectedItemMetadata
+      type: object
+      description: Used to add metadata to the results of the injectedItem.
+      properties:
+        hits:
+          title: injectedItemHitsMetadata
+          type: object
+          description: Adds the provided metadata to each injected hit via an `_extra` attribute.
+          properties:
+            addItemKey:
+              type: boolean
+              description: When true, the `_injectedItemKey` field is set in the `_extra` object of each affected hit.
+            extra:
+              type: object
+              additionalProperties: true
+              description: The user-defined key-value pairs that will be placed in the `_extra` field of each affected hit.
   required:
     - key
     - source

--- a/specs/composition-full/common/schemas/responses/Hit.yml
+++ b/specs/composition-full/common/schemas/responses/Hit.yml
@@ -19,6 +19,17 @@ hit:
       $ref: '#/rankingInfo'
     _distinctSeqID:
       $ref: '../../../../common/schemas/Hit.yml#/distinctSeqID'
+    _extra:
+      $ref: '#/hitMetadata'
+
+hitMetadata:
+  type: object
+  description: An object that contains the extra key-value pairs provided in the injectedItem definition.
+  additionalProperties: true
+  properties:
+    _injectedItemKey:
+      type: string
+      description: The key of the injectedItem that inserted this metadata.
 
 rankingInfo:
   allOf:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CMP-485](https://algolia.atlassian.net/browse/CMP-485)

Add support for the new `metadata` field on `injectedItems` and the corresponding `_extra` field on each `hit`.

### Changes included:

- Add the `metadata` property to `injectedItems`
  - It currently only has a `hits` property. You can see the full details [here](https://algolia.atlassian.net/wiki/spaces/CMP/pages/5149753345/Models#Key-definition).
- Add the `_extra` property to `hit`
  - This contains the metadata specified in `injectedItems` + an optional `_injectedItemKey` property

## 🧪 Test

- Green CI

[CMP-485]: https://algolia.atlassian.net/browse/CMP-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ