### PR TITLE
fix(python): change badge to correctly reflect supported python versions

### DIFF
--- a/clients/algoliasearch-client-python/README.md
+++ b/clients/algoliasearch-client-python/README.md
@@ -7,7 +7,7 @@
 
   <p align="center">
     <a href="https://pypi.org/project/algoliasearch"><img src="https://img.shields.io/pypi/v/algoliasearch.svg" alt="PyPI"></img></a>
-    <a href="https://pypi.org/project/algoliasearch"><img src="https://img.shields.io/pypi/pyversions/ansicolortags.svg" alt="Python versions"></img></a>
+    <a href="https://pypi.org/project/algoliasearch"><img src="https://img.shields.io/badge/python-3.8|3.9|3.10|3.11|3.12-blue" alt="Python versions"></img></a>
     <a href="https://pypi.org/project/algoliasearch"><img src="https://img.shields.io/pypi/l/ansicolortags.svg" alt="License"></a>
   </p>
 </p>


### PR DESCRIPTION
## 🧭 What and Why
The badge in the [python repository](https://github.com/algolia/algoliasearch-client-python) and, therefore, in the [pypi site](https://pypi.org/project/algoliasearch/) are confusing. They currently show that versions supported are 2.7, 3.4, 3.5 and 3.6. However, according to [pyproject.toml](https://github.com/algolia/api-clients-automation/blob/dd3bb1b93b779576875905a2fbdf2fe9d3da5ced/clients/algoliasearch-client-python/pyproject.toml#L17) this is not the case, (>3.8.1).

### Changes included:
I've changed the badge link to display the supported versions manually (afaik, these should be >3.8.1).

<img width="607" height="106" alt="image" src="https://github.com/user-attachments/assets/dcc5d4ee-3ba2-460b-9ff2-2f43f6ab455e" />

<img width="838" height="384" alt="image" src="https://github.com/user-attachments/assets/dc028982-7626-4947-8213-34a6202c9906" />
