### PR TITLE
docs: remove slashes from javascript snippets

### DIFF
--- a/templates/javascript/snippets/method.mustache
+++ b/templates/javascript/snippets/method.mustache
@@ -13,7 +13,9 @@ import type { RequestOptions } from '@algolia/client-common';
 export {{#isAsyncMethod}}async{{/isAsyncMethod}} function snippetFor{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{testIndex}}(): {{#isAsyncMethod}}Promise<void>{{/isAsyncMethod}}{{^isAsyncMethod}}void{{/isAsyncMethod}} {
   // >SEPARATOR {{method}} {{{testName}}}
   // Initialize the client
-  {{#hasRegionalHost}}// Replace '{{defaultRegion}}' with your Algolia Application Region{{/hasRegionalHost}}
+  {{#hasRegionalHost}}
+  // Replace '{{defaultRegion}}' with your Algolia Application Region
+  {{/hasRegionalHost}}
   {{> snippets/init}}
 
   // Call the API


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-4155

### Changes included:

the javascript snippets leaves two slashes at the start of a comment when no regions are expected, making everything a bit weird, see https://deploy-preview-10087--algolia-docs.netlify.app/doc/guides/sending-and-managing-data/send-and-update-your-data/connectors/push/?client=javascript#saveobjectswithtransformation