### PR TITLE
feat(specs): add external injection source definition and runtime parameter

### DIFF
--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -46,17 +46,9 @@ externalInjectedItem:
     objectID:
       type: string
     metadata:
-      $ref: '#/injectedItemMetadata'
+      $ref: '../schemas/components/CompositionBehavior.yml#/metadata'
   description: |
     An objectID injected into an external source.
   required:
     - objectID
   example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
-
-injectedItemMetadata:
-  type: object
-  additionalProperties: true
-  description: |
-    User defined key-values that will be added to injected item in the response.
-    This is identical to Hits metadata which is defined in Composition or Composition Rule, with the benefit of being set at runtime.
-  example: {'my-value': 'my-field'}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -27,3 +27,36 @@ ruleContexts:
   example: [mobile]
   x-categories:
     - Rules
+
+injectedItems:
+  type: array
+  items:
+    $ref: '#/externalInjectedItem'
+  description: |
+    A list of injected objectIDs into an external source.
+  default: []
+  example:
+    [{'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}]
+  x-categories:
+    - Advanced
+
+externalInjectedItem:
+  type: object
+  properties:
+    objectID:
+      type: string
+    metadata:
+      $ref: '#/injectedItemMetadata'
+  description: |
+    A list of injected objectIDs into an external source.
+  required:
+    - objectID
+  example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
+
+injectedItemMetadata:
+  type: object
+  additionalProperties: true
+  description: |
+    User defined key-values that will be added to injected item in the response.
+    This is identical to Hits metadata which is defined in Composition or Composition Rule, with the benefit of being set at runtime.
+  example: {'my-value': 'my-field'}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -46,17 +46,16 @@ externalInjectedItem:
     objectID:
       type: string
     metadata:
-      $ref: '#/injectedItemMetadata'
-  description: |
-    An objectID injected into an external source.
+      type: object
+      additionalProperties: true
+      description: |
+        User-defined key-values that will be added to the injected item in the response.
+        This is identical to Hits metadata defined in Composition or Composition Rule,
+        with the benefit of being set at runtime.
+      example: {'my-field': 'my-value'}
   required:
     - objectID
+  description: |
+    An objectID injected into an external source.
   example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
 
-injectedItemMetadata:
-  type: object
-  additionalProperties: true
-  description: |
-    User defined key-values that will be added to injected item in the response.
-    This is identical to Hits metadata which is defined in Composition or Composition Rule, with the benefit of being set at runtime.
-  example: {'my-value': 'my-field'}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -48,7 +48,7 @@ externalInjectedItem:
     metadata:
       $ref: '#/injectedItemMetadata'
   description: |
-    A list of injected objectIDs into an external source.
+    An objectID injected into an external source.
   required:
     - objectID
   example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -29,32 +29,37 @@ ruleContexts:
     - Rules
 
 injectedItems:
-  type: array
-  items:
+  type: object
+  additionalProperties:
     $ref: '#/externalInjectedItem'
   description: |
-    A list of injected objectIDs into an external source.
-  default: []
-  example:
-    [{'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}]
+    A list of extenrally injected objectID groups into from an external source.
+  default: {}
   x-categories:
     - Advanced
 
 externalInjectedItem:
   type: object
   properties:
-    objectID:
-      type: string
-    metadata:
-      type: object
-      additionalProperties: true
-      description: |
-        User-defined key-values that will be added to the injected item in the response.
-        This is identical to Hits metadata defined in Composition or Composition Rule,
-        with the benefit of being set at runtime.
-      example: {'my-field': 'my-value'}
-  required:
-    - objectID
-  description: |
-    An objectID injected into an external source.
-  example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
+    items:
+      type: array
+      items:
+        title: externalInjectedItemsArray
+        type: object
+        additionalProperties: false
+        properties:
+          objectID:
+            type: string
+            description: An objectID injected into an external source.
+          metadata:
+            type: object
+            additionalProperties: true
+            description: |
+              User-defined key-values that will be added to the injected item in the response.
+              This is identical to Hits metadata defined in Composition or Composition Rule,
+              with the benefit of being set at runtime.
+            example: {'my-field': 'my-value'}
+        required:
+          - objectID
+        example:
+          {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -44,7 +44,7 @@ externalInjectedItem:
     items:
       type: array
       items:
-        title: externalInjectedItemsArray
+        title: externalInjection
         type: object
         additionalProperties: false
         properties:
@@ -63,3 +63,5 @@ externalInjectedItem:
           - objectID
         example:
           {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
+  required:
+    - items

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -46,9 +46,17 @@ externalInjectedItem:
     objectID:
       type: string
     metadata:
-      $ref: '../schemas/components/CompositionBehavior.yml#/metadata'
+      $ref: '#/injectedItemMetadata'
   description: |
     An objectID injected into an external source.
   required:
     - objectID
   example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
+
+injectedItemMetadata:
+  type: object
+  additionalProperties: true
+  description: |
+    User defined key-values that will be added to injected item in the response.
+    This is identical to Hits metadata which is defined in Composition or Composition Rule, with the benefit of being set at runtime.
+  example: {'my-value': 'my-field'}

--- a/specs/composition-full/common/params/Composition.yml
+++ b/specs/composition-full/common/params/Composition.yml
@@ -58,4 +58,3 @@ externalInjectedItem:
   description: |
     An objectID injected into an external source.
   example: {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
-

--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -54,25 +54,8 @@ injectedItem:
       type: string
       description: injected Item unique identifier.
     source:
-      title: injectedItemSource
-      type: object
-      additionalProperties: false
-      properties:
-        search:
-          title: injectedItemSourceSearch
-          type: object
-          additionalProperties: false
-          properties:
-            index:
-              type: string
-              description: Composition Main Index name.
-              example: Products
-            params:
-              $ref: './Injection.yml#/injectedItemsQueryParameters'
-          required:
-            - index
-      required:
-        - search
+      description: Search source to be used to inject items into result set.
+      $ref: '#/injectionSource'
     position:
       type: integer
       minimum: 0
@@ -103,3 +86,8 @@ injectedItem:
     - source
     - position
     - length
+
+injectionSource:
+  oneOf:
+    - $ref: './InjectionSource.yml#/search'
+    - $ref: './InjectionSource.yml#/external'

--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -88,13 +88,6 @@ injectedItem:
     - length
 
 injectedItemSource:
-  type: object
-  additionalProperties: false
-  properties:
-    search:
-      $ref: './InjectionSource.yml#/search'
-    external:
-      $ref: './InjectionSource.yml#/external'
   oneOf:
-    - required: [search]
-    - required: [external]
+    - $ref: './InjectionSource.yml#/SearchSource'
+    - $ref: './InjectionSource.yml#/ExternalSource'

--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -55,7 +55,7 @@ injectedItem:
       description: injected Item unique identifier.
     source:
       description: Search source to be used to inject items into result set.
-      $ref: '#/injectionSource'
+      $ref: '#/injectedItemSource'
     position:
       type: integer
       minimum: 0
@@ -65,32 +65,29 @@ injectedItem:
       minimum: 0
       maximum: 20
     metadata:
-      $ref: '#/metadata'
+      title: injectedItemMetadata
+      type: object
+      description: Used to add metadata to the results of the injectedItem.
+      properties:
+        hits:
+          title: injectedItemHitsMetadata
+          type: object
+          description: Adds the provided metadata to each injected hit via an `_extra` attribute.
+          properties:
+            addItemKey:
+              type: boolean
+              description: When true, the `_injectedItemKey` field is set in the `_extra` object of each affected hit.
+            extra:
+              type: object
+              additionalProperties: true
+              description: The user-defined key-value pairs that will be placed in the `_extra` field of each affected hit.
   required:
     - key
     - source
     - position
     - length
 
-injectionSource:
+injectedItemSource:
   oneOf:
     - $ref: './InjectionSource.yml#/search'
     - $ref: './InjectionSource.yml#/external'
-
-metadata:
-  title: injectedItemMetadata
-  type: object
-  description: Used to add metadata to the results of the injectedItem.
-  properties:
-    hits:
-      title: injectedItemHitsMetadata
-      type: object
-      description: Adds the provided metadata to each injected hit via an `_extra` attribute.
-      properties:
-        addItemKey:
-          type: boolean
-          description: When true, the `_injectedItemKey` field is set in the `_extra` object of each affected hit.
-        extra:
-          type: object
-          additionalProperties: true
-          description: The user-defined key-value pairs that will be placed in the `_extra` field of each affected hit.

--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -65,22 +65,7 @@ injectedItem:
       minimum: 0
       maximum: 20
     metadata:
-      title: injectedItemMetadata
-      type: object
-      description: Used to add metadata to the results of the injectedItem.
-      properties:
-        hits:
-          title: injectedItemHitsMetadata
-          type: object
-          description: Adds the provided metadata to each injected hit via an `_extra` attribute.
-          properties:
-            addItemKey:
-              type: boolean
-              description: When true, the `_injectedItemKey` field is set in the `_extra` object of each affected hit.
-            extra:
-              type: object
-              additionalProperties: true
-              description: The user-defined key-value pairs that will be placed in the `_extra` field of each affected hit.
+      $ref: '#/metadata'
   required:
     - key
     - source
@@ -91,3 +76,21 @@ injectionSource:
   oneOf:
     - $ref: './InjectionSource.yml#/search'
     - $ref: './InjectionSource.yml#/external'
+
+metadata:
+  title: injectedItemMetadata
+  type: object
+  description: Used to add metadata to the results of the injectedItem.
+  properties:
+    hits:
+      title: injectedItemHitsMetadata
+      type: object
+      description: Adds the provided metadata to each injected hit via an `_extra` attribute.
+      properties:
+        addItemKey:
+          type: boolean
+          description: When true, the `_injectedItemKey` field is set in the `_extra` object of each affected hit.
+        extra:
+          type: object
+          additionalProperties: true
+          description: The user-defined key-value pairs that will be placed in the `_extra` field of each affected hit.

--- a/specs/composition-full/common/schemas/components/CompositionBehavior.yml
+++ b/specs/composition-full/common/schemas/components/CompositionBehavior.yml
@@ -88,6 +88,13 @@ injectedItem:
     - length
 
 injectedItemSource:
+  type: object
+  additionalProperties: false
+  properties:
+    search:
+      $ref: './InjectionSource.yml#/search'
+    external:
+      $ref: './InjectionSource.yml#/external'
   oneOf:
-    - $ref: './InjectionSource.yml#/search'
-    - $ref: './InjectionSource.yml#/external'
+    - required: [search]
+    - required: [external]

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -4,31 +4,41 @@ SearchSource:
   type: object
   additionalProperties: false
   properties:
-    index:
-      type: string
-      description: Composition Index name.
-      example: Products
-    params:
-      $ref: './Injection.yml#/injectedItemsQueryParameters'
-  required:
-    - index
+    search:
+      title: searchSource
+      type: object
+      additionalProperties: false
+      properties:
+        index:
+          type: string
+          description: Composition Index name.
+          example: Products
+        params:
+          $ref: './Injection.yml#/injectedItemsQueryParameters'
+      required:
+        - index
 
 ExternalSource:
   title: external
   description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
   type: object
   additionalProperties: false
-  allOf:
-    - $ref: '#/SearchSource'
-    - $ref: '#/externalFields'
-
-externalFields:
-  title: externalSourceFields
-  type: object
-  additionalProperties: false
   properties:
-    ordering:
-      $ref: '#/externalOrdering'
+    external:
+      title: externalSource
+      type: object
+      additionalProperties: false
+      properties:
+        index:
+          type: string
+          description: Composition Index name.
+          example: Products
+        params:
+          $ref: './Injection.yml#/injectedItemsQueryParameters'
+        ordering:
+          $ref: '#/externalOrdering'
+      required:
+        - index
 
 externalOrdering:
   enum: ['default', 'userDefined']

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -1,0 +1,37 @@
+search:
+  title: injectedItemSearchSource
+  description: Injected items will originate from a search request performed on the specified index.
+  type: object
+  additionalProperties: false
+  allOf:
+    - $ref: '#/baseSource'
+    - type: object
+      additionalProperties: false
+
+external:
+  title: injectedItemExternalSource
+  description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
+  type: object
+  additionalProperties: false
+  allOf:
+    - $ref: '#/baseSource'
+  properties:
+    ordering:
+      $ref: '#/externalOrdering'
+
+baseSource:
+  type: object
+  additionalProperties: false
+  properties:
+    index:
+      type: string
+      description: Composition Index name.
+      example: Products
+    params:
+      $ref: './Injection.yml#/injectedItemsQueryParameters'
+  required:
+    - index
+
+externalOrdering:
+  enum: ['default', 'user-defined']
+  default: 'default'

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -1,11 +1,11 @@
 SearchSource:
-  title: search
+  title: searchSource
   description: Injected items will originate from a search request performed on the specified index.
   type: object
   additionalProperties: false
   properties:
     search:
-      title: searchSource
+      title: search
       type: object
       additionalProperties: false
       properties:
@@ -17,15 +17,17 @@ SearchSource:
           $ref: './Injection.yml#/injectedItemsQueryParameters'
       required:
         - index
+  required:
+    - search
 
 ExternalSource:
-  title: external
+  title: externalSource
   description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
   type: object
   additionalProperties: false
   properties:
     external:
-      title: externalSource
+      title: external
       type: object
       additionalProperties: false
       properties:
@@ -39,6 +41,8 @@ ExternalSource:
           $ref: '#/externalOrdering'
       required:
         - index
+  required:
+    - external
 
 externalOrdering:
   enum: ['default', 'userDefined']

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -3,25 +3,6 @@ search:
   description: Injected items will originate from a search request performed on the specified index.
   type: object
   additionalProperties: false
-  allOf:
-    - $ref: '#/baseSource'
-    - type: object
-      additionalProperties: false
-
-external:
-  title: injectedItemExternalSource
-  description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
-  type: object
-  additionalProperties: false
-  allOf:
-    - $ref: '#/baseSource'
-  properties:
-    ordering:
-      $ref: '#/externalOrdering'
-
-baseSource:
-  type: object
-  additionalProperties: false
   properties:
     index:
       type: string
@@ -32,6 +13,17 @@ baseSource:
   required:
     - index
 
+external:
+  title: injectedItemExternalSource
+  description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
+  type: object
+  additionalProperties: false
+  allOf:
+    - $ref: '#/search'
+  properties:
+    ordering:
+      $ref: '#/externalOrdering'
+
 externalOrdering:
-  enum: ['default', 'user-defined']
+  enum: ['default', 'userDefined']
   default: 'default'

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -20,6 +20,12 @@ external:
   additionalProperties: false
   allOf:
     - $ref: '#/search'
+    - $ref: '#/externalFields'
+
+externalFields:
+  title: externalSourceFields
+  type: object
+  additionalProperties: false
   properties:
     ordering:
       $ref: '#/externalOrdering'

--- a/specs/composition-full/common/schemas/components/InjectionSource.yml
+++ b/specs/composition-full/common/schemas/components/InjectionSource.yml
@@ -1,5 +1,5 @@
-search:
-  title: injectedItemSearchSource
+SearchSource:
+  title: search
   description: Injected items will originate from a search request performed on the specified index.
   type: object
   additionalProperties: false
@@ -13,13 +13,13 @@ search:
   required:
     - index
 
-external:
-  title: injectedItemExternalSource
+ExternalSource:
+  title: external
   description: Injected items will originate from externally provided objectIDs (that must exist in the index) given at runtime in the run request payload.
   type: object
   additionalProperties: false
   allOf:
-    - $ref: '#/search'
+    - $ref: '#/SearchSource'
     - $ref: '#/externalFields'
 
 externalFields:

--- a/specs/composition-full/common/schemas/requestBodies/RunParams.yml
+++ b/specs/composition-full/common/schemas/requestBodies/RunParams.yml
@@ -55,3 +55,5 @@ params:
       $ref: '../../params/Composition.yml#/enableABTest'
     enableReRanking:
       $ref: '../../params/Search.yml#/enableReRanking'
+    injectedItems:
+      $ref: '../../params/Composition.yml#/injectedItems'

--- a/tests/CTS/requests/composition-full/putComposition.json
+++ b/tests/CTS/requests/composition-full/putComposition.json
@@ -61,5 +61,76 @@
         }
       }
     }
+  },
+  {
+    "parameters": {
+      "compositionID": "my-external-injection-compo",
+      "composition": {
+        "objectID": "my-external-injection-compo",
+        "name": "my first composition",
+        "behavior": {
+          "injection": {
+            "main": {
+              "source": {
+                "search": {
+                  "index": "foo"
+                }
+              }
+            },
+            "injectedItems": [
+              {
+                "key": "injectedItem1",
+                "source": {
+                  "external": {
+                    "index": "foo",
+                    "ordering": "userDefined",
+                    "params": {
+                      "filters": "brand:adidas"
+                    }
+                  }
+                },
+                "position": 2,
+                "length": 1
+              }
+            ]
+          }
+        }
+      }
+    },
+    "request": {
+      "path": "/1/compositions/my-external-injection-compo",
+      "method": "PUT",
+      "body": {
+        "objectID": "my-external-injection-compo",
+        "name": "my first composition",
+        "behavior": {
+          "injection": {
+            "main": {
+              "source": {
+                "search": {
+                  "index": "foo"
+                }
+              }
+            },
+            "injectedItems": [
+              {
+                "key": "injectedItem1",
+                "source": {
+                  "external": {
+                    "index": "foo",
+                    "ordering": "userDefined",
+                    "params": {
+                      "filters": "brand:adidas"
+                    }
+                  }
+                },
+                "position": 2,
+                "length": 1
+              }
+            ]
+          }
+        }
+      }
+    }
   }
 ]

--- a/tests/CTS/requests/composition-full/search.json
+++ b/tests/CTS/requests/composition-full/search.json
@@ -13,5 +13,54 @@
         "params": { "query": "batman" }
       }
     }
+  },
+  {
+    "parameters": {
+      "compositionID": "foo",
+      "requestBody": {
+        "params": {
+          "query": "batman",
+          "injectedItems": {
+            "injectedItem1": {
+              "items": [
+                {
+                  "objectID": "my-object-1"
+                },
+                {
+                  "objectID": "my-object-2",
+                  "metadata": {
+                    "my-key": "my-value"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "request": {
+      "path": "/1/compositions/foo/run",
+      "method": "POST",
+      "body": {
+        "params": {
+          "query": "batman",
+          "injectedItems": {
+            "injectedItem1": {
+              "items": [
+                {
+                  "objectID": "my-object-1"
+                },
+                {
+                  "objectID": "my-object-2",
+                  "metadata": {
+                    "my-key": "my-value"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: 
- https://algolia.atlassian.net/browse/CMP-486
as part of 
- https://algolia.atlassian.net/browse/CMP-471

### Changes included:

- Add `external` injection search source
- `injectedItems` can now either be a `search` or `external` source.
- Add `injectedItems` compositions runtime parameter.

## 🧪 Test

CI
