### PR TITLE
fix(python): remove warnings for HighlightResult and SnippetResult

### DIFF
--- a/playground/python/app/search.py
+++ b/playground/python/app/search.py
@@ -11,48 +11,47 @@ load_dotenv("../.env")
 def main():
     print("SearchClient version", __version__)
 
-    # client = SearchClientSync(
-    #     environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
-    # )
-    # client.add_user_agent("playground")
-    # client.add_user_agent("bar", "baz")
-    #
-    # print("user_agent", client._config._user_agent.get())
-    # print("client initialized", client)
-    #
-    # try:
-    #     resp = client.search_synonyms("foo")
-    #     print(resp)
-    #     client.browse_synonyms("foo", lambda _resp: print(_resp))
-    # finally:
-    #     client.close()
-    #
-    #     print("client closed")
-    #
-    # print("with transformations")
-    #
-    config = SearchConfig(
+    client = SearchClientSync(
         environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
     )
-
-    config.set_transformation_region("eu")
-
-    print("region in playground")
-    print(config.region)
-
-    client = SearchClientSync.create_with_config(config)
-    client.add_user_agent("playground search with ingestion")
+    client.add_user_agent("playground")
+    client.add_user_agent("bar", "baz")
 
     print("user_agent", client._config._user_agent.get())
+    print("client initialized", client)
 
     try:
-        resp = client.replace_all_objects_with_transformation(
-            "boyd", [{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"}], 2
-        )
-        print(resp)
-    except Exception as e:
-        print(e)
+        resp = client.search_single_index("poussing-RECORDS")
+        print(resp.to_dict())
     finally:
         client.close()
 
         print("client closed")
+
+    # print("with transformations")
+    #
+    # config = SearchConfig(
+    #     environ.get("ALGOLIA_APPLICATION_ID"), environ.get("ALGOLIA_ADMIN_KEY")
+    # )
+    #
+    # config.set_transformation_region("eu")
+    #
+    # print("region in playground")
+    # print(config.region)
+    #
+    # client = SearchClientSync.create_with_config(config)
+    # client.add_user_agent("playground search with ingestion")
+    #
+    # print("user_agent", client._config._user_agent.get())
+    #
+    # try:
+    #     resp = client.replace_all_objects_with_transformation(
+    #         "boyd", [{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"},{"objectID": "bar"}], 2
+    #     )
+    #     print(resp)
+    # except Exception as e:
+    #     print(e)
+    # finally:
+    #     client.close()
+    #
+    #     print("client closed")

--- a/playground/python/poetry.lock
+++ b/playground/python/poetry.lock
@@ -142,7 +142,7 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "algoliasearch"
-version = "4.20.0"
+version = "4.25.0"
 description = "A fully-featured and blazing-fast Python API client to interact with Algolia."
 optional = false
 python-versions = ">= 3.8.1"

--- a/specs/search/common/schemas/Hit.yml
+++ b/specs/search/common/schemas/Hit.yml
@@ -5,6 +5,7 @@ hit:
 
     A hit is a record from your index, augmented with special attributes for highlighting, snippeting, and ranking.
   x-is-generic: true
+  x-is-hit-object: true
   additionalProperties: true
   required:
     - objectID

--- a/templates/python/imports.mustache
+++ b/templates/python/imports.mustache
@@ -24,6 +24,7 @@ from pydantic import (
   StrictStr,
   ValidationError,
   field_validator,
+  field_serializer,
   model_serializer,
 )
 from typing import (

--- a/templates/python/model_generic.mustache
+++ b/templates/python/model_generic.mustache
@@ -82,7 +82,12 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{#vendorExtensions.x-is-hit-object}}
     @staticmethod
     def __dump_item(item):
-        return item.model_dump(warnings="none") if isinstance(item, BaseModel) else item
+        return item.model_dump(
+            by_alias=True,
+            exclude_none=True,
+            exclude_unset=True,
+            warnings="none",
+        ) if isinstance(item, BaseModel) else item
 
     @field_serializer("highlight_result")
     def serialize_highlight_result(self, v: HighlightResult | None):

--- a/templates/python/model_generic.mustache
+++ b/templates/python/model_generic.mustache
@@ -79,6 +79,36 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         extra='allow',
     )
 
+    {{#vendorExtensions.x-is-hit-object}}
+    @staticmethod
+    def __dump_item(item):
+        return item.model_dump(warnings="none") if isinstance(item, BaseModel) else item
+
+    @field_serializer("highlight_result")
+    def serialize_highlight_result(self, v: HighlightResult | None):
+        if v is None:
+            return None
+
+        if isinstance(v, dict):
+            return {k: self.__dump_item(val) for k, val in v.items()}
+        elif isinstance(v, list):
+            return [self.__dump_item(val) for val in v]
+        else:
+            return self.__dump_item(v)
+
+    @field_serializer("snippet_result")
+    def serialize_snippet_result(self, v: SnippetResult | None):
+        if v is None:
+            return None
+
+        if isinstance(v, dict):
+            return {k: self.__dump_item(val) for k, val in v.items()}
+        elif isinstance(v, list):
+            return [self.__dump_item(val) for val in v]
+        else:
+            return self.__dump_item(v)
+    {{/vendorExtensions.x-is-hit-object}}
+
     def to_json(self) -> str:
         return self.model_dump_json(by_alias=True, exclude_unset=True)
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CR-8953 https://algolia.atlassian.net/browse/DI-4020

### Changes included:

closes https://github.com/algolia/algoliasearch-client-python/issues/569

When calling `to_dict` on a search response, pydantic yells about recursion issue and incorrect typings of our HighlightResult and SnippetResults models.

<img width="3080" height="1392" alt="image" src="https://github.com/user-attachments/assets/a9782609-46dd-42dd-b134-ea705121eef3" />

I tried many ways to solve this, and sadly the only other solution that would work (except the one proposed in this PR) is to implement a custom serializer for every models, which would be a much harder work to put in place.

In the meantime, I propose using a custom serializer (with the `field_serializer` feature from Pydantic), that allows us to simply remove warnings for those two models.