### PR TITLE
chore(scripts): increase memory for kotlin release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -718,4 +718,4 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":alert: Some clients failed to release :alert: \n${{ steps.waitForAllReleases.outputs.FAILED_RELEASES }}\nYou can retry the CI jobs to release them again, it will not affect already released clients."
+            text: ":alert: Some clients failed to release :alert: \n**${{ steps.waitForAllReleases.outputs.FAILED_RELEASES }}**\n\nYou can retry the CI jobs to release them again, it will not affect already released clients."

--- a/templates/kotlin/gradle.properties.mustache
+++ b/templates/kotlin/gradle.properties.mustache
@@ -27,3 +27,4 @@ POM_ISSUE_URL=https://github.com/algolia/algoliasearch-client-kotlin/issues
 mavenCentralPublishing=true
 mavenCentralAutomaticPublishing=true
 signAllPublications=true
+kotlin.daemon.jvmargs=-Xmx4096m


### PR DESCRIPTION
## 🧭 What and Why

The Kotlin released failed because of OOM https://github.com/algolia/algoliasearch-client-kotlin/actions/runs/17431280970/job/49490485139#step:5:639

Also edit the slack message.