### PR TITLE
fix(specs): normalize spelling of summaries

### DIFF
--- a/specs/ingestion/paths/sources/validate.yml
+++ b/specs/ingestion/paths/sources/validate.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - sources
-  summary: Validates a source payload
+  summary: Validate a source payload
   description: |
     Validates a source payload to ensure it can be created and that the data source can be reached by Algolia.
   operationId: validateSource

--- a/specs/ingestion/paths/sources/validateID.yml
+++ b/specs/ingestion/paths/sources/validateID.yml
@@ -1,7 +1,7 @@
 post:
   tags:
     - sources
-  summary: Validates an update of a source payload
+  summary: Validate an update of a source payload
   description: |
     Validates an update of a source payload to ensure it can be created and that the data source can be reached by Algolia.
   operationId: validateSourceBeforeUpdate

--- a/specs/ingestion/paths/tasks/v2/pushTask.yml
+++ b/specs/ingestion/paths/tasks/v2/pushTask.yml
@@ -1,15 +1,19 @@
 post:
   tags:
     - tasks
-  summary: Push records by taskID
+  summary: Push records by task ID
   description: >
-    Pushes records through the Pipeline, directly to an index. You can make the call synchronous by providing the `watch` parameter,
-    for asynchronous calls, you can use the observability endpoints and/or debugger dashboard to see the status of your task.
+    Pushes records through the pipeline, directly to an index. You can make the call synchronous by providing the `watch` parameter,
+    for asynchronous calls, you can use the observability endpoints or the debugger dashboard to see the status of your task.
 
-    If you want to leverage the [pre-indexing data transformation](https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/how-to/transform-your-data/), this is the recommended way of ingesting your records.
+    If you want to transform your data before indexing, this is the recommended way of ingesting your records.
 
     This method is similar to `push`, but requires a `taskID` instead of a `indexName`, which is useful when many `destinations` target the same `indexName`.
   operationId: pushTask
+  externalDocs:
+    url: https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/how-to/transform-your-data/
+    description: |
+      Related guide: Pre-indexing data transformation.
   x-acl:
     - addObject
     - deleteIndex

--- a/specs/ingestion/paths/tasks/v2/taskID.yml
+++ b/specs/ingestion/paths/tasks/v2/taskID.yml
@@ -23,7 +23,7 @@ get:
 put:
   tags:
     - tasks
-  summary: Fully updates a task
+  summary: Fully update a task
   description: Fully updates a task by its ID, use partialUpdateTask if you only want to update a subset of fields.
   operationId: replaceTask
   parameters:
@@ -48,7 +48,7 @@ put:
 patch:
   tags:
     - tasks
-  summary: Partially updates a task
+  summary: Partially update a task
   description: Partially updates a task by its ID.
   operationId: updateTask
   parameters:


### PR DESCRIPTION
## 🧭 What and Why

A few summaries in the Ingestion API used the wrong word form. 
This commit aligns them with the style guide.

🎟 JIRA Ticket:

### Changes included:

- Summaries use imperative verb form
- `pushTask` uses externalDocs link rather than inline Markdown.

## 🧪 Test
