### PR TITLE
feat(specs): deprecate Predict real-time endpoints

### DIFF
--- a/specs/advanced-personalization/paths/computeRealtimeUser.yml
+++ b/specs/advanced-personalization/paths/computeRealtimeUser.yml
@@ -4,8 +4,9 @@ post:
   operationId: computeRealtimeUser
   x-acl:
     - recommendation
-  summary: Compute the user's personalization profile
-  description: Sends a request to compute the user's personalization profile.
+  summary: Compute the real-time user's personalization profile
+  description: Sends a request to compute the real-time user's personalization profile.
+  deprecated: true
   parameters:
     - $ref: '../common/parameters.yml#/UserToken'
   responses:

--- a/specs/advanced-personalization/paths/getRealtimeUser.yml
+++ b/specs/advanced-personalization/paths/getRealtimeUser.yml
@@ -4,8 +4,8 @@ get:
   operationId: getRealtimeUser
   x-acl:
     - recommendation
-  summary: Retrieve the user's personalization profile
-  description: Retrieves the user's personalization profiles containing search filters.
+  summary: Retrieve the real-time user's personalization profile
+  description: Retrieves the real-time user's personalization profiles containing search filters.
   parameters:
     - $ref: '../common/parameters.yml#/UserToken'
   responses:


### PR DESCRIPTION
## 🧭 What and Why

Deprecate the `compute real-time user` endpoint.

The Real-time Personalization feature now does this behind the scenes automatically.


I also updated the description of the `getRealtimeUser` endpoint to make it clearer to differentiate with the "regular" get-profile endpoint 