### PR TITLE
chore(scripts): add an option to attach a java debugger

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
         - PYTHON_VERSION=${PYTHON_VERSION}
     command: tail -f /dev/null
     volumes: [./:/app]
-  #    ports:
-  #      - "5009:5009" # So we can debug the OpenAPI Generator process
+    ports:
+      - "5009:5009" # So we can debug the OpenAPI Generator process
 
   ruby:
     container_name: apic_ruby

--- a/scripts/buildLanguages.ts
+++ b/scripts/buildLanguages.ts
@@ -69,7 +69,10 @@ async function buildLanguage(language: Language, gens: Generator[], buildType: B
     case 'kotlin':
       // the playground specify search but it will still build everything
       const isTestClass = buildType === 'guides' || buildType === 'snippets';
-      await run(`./gradle/gradlew -p ${cwd} ${isTestClass ? 'testClasses' : 'assemble'} ${language == 'kotlin' ? '-Pclient=Search' : ''}`, { language });
+      await run(
+        `./gradle/gradlew -p ${cwd} ${isTestClass ? 'testClasses' : 'assemble'} ${language == 'kotlin' ? '-Pclient=Search' : ''}`,
+        { language },
+      );
       break;
     case 'php':
       // await runComposerInstall();

--- a/scripts/cli/index.ts
+++ b/scripts/cli/index.ts
@@ -1,4 +1,4 @@
-import { Argument, program } from 'commander';
+import { Argument, Option, program } from 'commander';
 import semver from 'semver';
 
 import { buildLanguages } from '../buildLanguages.ts';
@@ -29,10 +29,11 @@ const args = {
 };
 
 const flags = {
-  verbose: {
-    flag: '-v, --verbose',
-    description: 'make the generation verbose',
-  },
+  verbose: new Option('-v, --verbose', 'make the generation verbose'),
+  debugger: new Option(
+    '-d, --debugger',
+    'runs the generator in debug mode, it will wait for a Java debugger to be attached',
+  ),
 };
 
 program.name('cli');
@@ -49,8 +50,9 @@ program
   .description('Generate a specified client')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+  .addOption(flags.verbose)
+  .addOption(flags.debugger)
+  .action(async (langArg: LangArg, clientArg: string[], { verbose, debugger: withDebugger }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
       clientArg,
@@ -58,7 +60,9 @@ program
 
     setVerbose(Boolean(verbose));
 
-    await generate(generatorList({ language, client, clientList }));
+    console.log({ withDebugger });
+
+    await generate(generatorList({ language, client, clientList }), Boolean(withDebugger));
   });
 
 const buildCommand = program.command('build').description('Build the clients or specs');
@@ -68,7 +72,7 @@ buildCommand
   .description('Build a specified client')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
@@ -85,7 +89,7 @@ buildCommand
   .description('Build a specified playground')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
@@ -102,7 +106,7 @@ buildCommand
   .description('Build a specified snippets')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
@@ -119,7 +123,7 @@ buildCommand
   .description('Build a specified guides')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
@@ -135,7 +139,7 @@ buildCommand
   .command('specs')
   .description('Build a specified spec')
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .option('-s, --skip-cache', 'skip cache checking to force building specs')
   .option('-j, --json', 'outputs the spec in JSON instead of yml')
   .option('-d, --docs', 'generates the doc specs with the code snippets')
@@ -172,9 +176,10 @@ ctsCommand
   .description('Generate the CTS tests')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
+  .addOption(flags.debugger)
   .option('--lv, --language-version <version>', 'the version of the language to use')
-  .action(async (langArg: LangArg, clientArg: string[], { verbose, languageVersion }) => {
+  .action(async (langArg: LangArg, clientArg: string[], { verbose, debugger: withDebugger, languageVersion }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
       clientArg,
@@ -182,7 +187,7 @@ ctsCommand
 
     setVerbose(Boolean(verbose));
 
-    await ctsGenerateMany(generatorList({ language, client, clientList }), languageVersion);
+    await ctsGenerateMany(generatorList({ language, client, clientList }), withDebugger, languageVersion);
   });
 
 ctsCommand
@@ -190,7 +195,7 @@ ctsCommand
   .description('Run the tests for the CTS')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .option('-e, --no-e2e', 'skip the e2e tests, that requires internet connection')
   .option('-c, --no-client', 'skip the client tests')
   .option('-r, --no-requests', 'skip the requests tests')
@@ -250,7 +255,7 @@ program
   .description('Format the specified folder for a specific language')
   .addArgument(args.requiredLanguage)
   .argument('folder', 'The folder to format')
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .action(async (language: string, folder: string, { verbose }) => {
     setVerbose(Boolean(verbose));
 
@@ -262,8 +267,9 @@ program
   .description('Generate the snippets')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+  .addOption(flags.verbose)
+  .addOption(flags.debugger)
+  .action(async (langArg: LangArg, clientArg: string[], { verbose, debugger: withDebugger }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
       clientArg,
@@ -271,7 +277,7 @@ program
 
     setVerbose(Boolean(verbose));
 
-    await docsGenerateMany(generatorList({ language, client, clientList }), 'snippets');
+    await docsGenerateMany(generatorList({ language, client, clientList }), 'snippets', Boolean(withDebugger));
   });
 
 program
@@ -279,8 +285,9 @@ program
   .description('Generate the guides')
   .addArgument(args.language)
   .addArgument(args.clients)
-  .option(flags.verbose.flag, flags.verbose.description)
-  .action(async (langArg: LangArg, clientArg: string[], { verbose }) => {
+  .addOption(flags.verbose)
+  .addOption(flags.debugger)
+  .action(async (langArg: LangArg, clientArg: string[], { verbose, debugger: withDebugger }) => {
     const { language, client, clientList } = transformSelection({
       langArg,
       clientArg,
@@ -293,13 +300,14 @@ program
         existsSync(toAbsolutePath(`templates/${gen.language}/guides/${gen.client}`)),
       ),
       'guides',
+      Boolean(withDebugger),
     );
   });
 
 program
   .command('release')
   .description('Releases the client')
-  .option(flags.verbose.flag, flags.verbose.description)
+  .addOption(flags.verbose)
   .option<semver.ReleaseType>(
     '--rt --release-type <type>',
     'triggers a release for the given language list with the given releaseType',

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -2,6 +2,7 @@ import fsp from 'fs/promises';
 import path from 'path';
 
 import { Octokit } from '@octokit/rest';
+import chalk from 'chalk';
 import type { ExecaError } from 'execa';
 import { execa, execaCommand } from 'execa';
 import { remove } from 'fs-extra';
@@ -270,13 +271,40 @@ export function isVerbose(): boolean {
   return verbose;
 }
 
-export async function callGenerator(gen: Generator): Promise<void> {
-  await run(
-    // Use the following line if you want to be able to attach a debugger to the generators
-    // `JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=\*:5009" yarn openapi-generator-cli --custom-generator=generators/build/libs/algolia-java-openapi-generator-1.0.0.jar generate --generator-key ${gen.key}`,
-    `yarn openapi-generator-cli --custom-generator=generators/build/libs/algolia-java-openapi-generator-1.0.0.jar generate --generator-key ${gen.key}`,
-    { language: 'java' },
-  );
+export async function callGenerator(gen: Generator, withDebugger: boolean): Promise<void> {
+  const cmd = `yarn openapi-generator-cli --custom-generator=generators/build/libs/algolia-java-openapi-generator-1.0.0.jar generate --generator-key ${gen.key}`;
+  if (!withDebugger) {
+    await run(cmd, { language: 'java' });
+    return;
+  }
+
+  console.log(chalk.yellow('Running the generator in debug mode, waiting for debugger to be attached on port 5009'));
+
+  /*
+  example .vscode/launch.json config to attach the debugger
+  {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "java",
+        "name": "APIC Generator",
+        "request": "attach",
+        "hostName": "localhost",
+        "port": "5009"
+      }
+    ]
+  }
+  */
+
+  const verbose = isVerbose();
+  setVerbose(false); // verbose messes up the order of execution
+
+  // kill previous debuggers
+  await run('(killall -9 java && sleep 1) || true', { language: 'java' });
+  setVerbose(verbose);
+  await run(`JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5009" ${cmd}`, {
+    language: 'java',
+  });
 }
 
 export function isWSL(): boolean {

--- a/scripts/cts/generate.ts
+++ b/scripts/cts/generate.ts
@@ -3,13 +3,17 @@ import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
 
-export async function ctsGenerateMany(generators: Generator[], languageVersion = ''): Promise<void> {
+export async function ctsGenerateMany(
+  generators: Generator[],
+  withDebugger: boolean,
+  languageVersion = '',
+): Promise<void> {
   await setupAndGen(
     generators,
     'tests',
     async (gen) => {
       if (getTestOutputFolder(gen.language)) {
-        await callGenerator(gen);
+        await callGenerator(gen, withDebugger);
       }
     },
     {

--- a/scripts/docker/Dockerfile.base
+++ b/scripts/docker/Dockerfile.base
@@ -16,6 +16,8 @@ SHELL ["/bin/bash", "--login", "-c"]
 # Global dependencies
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git curl zip unzip libexpat1-dev libicu76 \
+  # for killall and ps
+  && apt-get install -y procps \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -3,10 +3,14 @@ import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
 
-export async function docsGenerateMany(generators: Generator[], scope: 'guides' | 'snippets'): Promise<void> {
+export async function docsGenerateMany(
+  generators: Generator[],
+  scope: 'guides' | 'snippets',
+  withDebugger: boolean,
+): Promise<void> {
   await setupAndGen(generators, scope, async (gen) => {
     if (getTestOutputFolder(gen.language)) {
-      await callGenerator(gen);
+      await callGenerator(gen, withDebugger);
     }
   });
 

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -8,10 +8,10 @@ async function preGen(gen: Generator): Promise<void> {
   await removeExistingCodegen(gen);
 }
 
-export async function generate(generators: Generator[]): Promise<void> {
+export async function generate(generators: Generator[], withDebugger: boolean): Promise<void> {
   await setupAndGen(generators, 'client', async (gen) => {
     await preGen(gen);
-    await callGenerator(gen);
+    await callGenerator(gen, withDebugger);
   });
 
   for (const lang of new Set(generators.map((gen) => gen.language))) {


### PR DESCRIPTION
## 🧭 What and Why

Thanks to @Fluf22 for trying this out, we can attach a debugger to the generator !
This works with IntelliJ, VSCode, and the `jdb` cli.

For example, run `apic cts generate csharp search` and then attach the debugger, the java process will wait until it's attached.