### PR TITLE
snippets: remove snippets for non-existing helpers

### DIFF
--- a/scripts/buildLanguages.ts
+++ b/scripts/buildLanguages.ts
@@ -38,10 +38,7 @@ async function buildLanguage(language: Language, gens: Generator[], buildType: B
       await run('dotnet build --configuration Release', { cwd, language });
       break;
     case 'dart':
-      if (buildType !== 'snippets') {
-        // fix the snippets at some point
-        await run('dart pub get && dart analyze', { cwd, language });
-      }
+      await run('dart pub get && dart analyze', { cwd, language });
       break;
     case 'go':
       await run('go build -o /dev/null ./...', { cwd, language });

--- a/specs/search/helpers/deleteObjects.yml
+++ b/specs/search/helpers/deleteObjects.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Records
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: deleteObjects
     summary: Deletes every records for the given objectIDs
     description: |

--- a/specs/search/helpers/generateSecuredApiKey.yml
+++ b/specs/search/helpers/generateSecuredApiKey.yml
@@ -4,6 +4,17 @@ method:
     x-asynchronous-helper: false
     tags:
       - Api Keys
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: generateSecuredApiKey
     summary: Create secured API keys
     description: |

--- a/specs/search/helpers/indexExists.yml
+++ b/specs/search/helpers/indexExists.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Index
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: indexExists
     summary: Check if an index exists or not
     description: |

--- a/specs/search/helpers/partialUpdateObjects.yml
+++ b/specs/search/helpers/partialUpdateObjects.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Records
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: partialUpdateObjects
     summary: Replaces object content of all the given objects according to their respective `objectID` field
     description: |

--- a/specs/search/helpers/replaceAllObjects.yml
+++ b/specs/search/helpers/replaceAllObjects.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Records
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: replaceAllObjects
     summary: Replace all records in an index
     description: |

--- a/specs/search/helpers/saveObjects.yml
+++ b/specs/search/helpers/saveObjects.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Records
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: saveObjects
     summary: Saves the given array of objects in the given index
     description: |

--- a/specs/search/helpers/waitForApiKey.yml
+++ b/specs/search/helpers/waitForApiKey.yml
@@ -3,6 +3,17 @@ method:
     x-helper: true
     tags:
       - Api Keys
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: waitForApiKey
     summary: Wait for an API key operation
     description: Waits for an API key to be added, updated, or deleted.

--- a/specs/search/helpers/waitForAppTask.yml
+++ b/specs/search/helpers/waitForAppTask.yml
@@ -1,6 +1,17 @@
 method:
   get:
     x-helper: true
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: waitForAppTask
     summary: Wait for application-level operation to complete
     description: Wait for a application-level task to complete.

--- a/specs/search/helpers/waitForTask.yml
+++ b/specs/search/helpers/waitForTask.yml
@@ -3,6 +3,18 @@ method:
     x-helper: true
     tags:
       - Records
+    # it's called waitTask in dart
+    x-available-languages:
+      - csharp
+      - go
+      - java
+      - javascript
+      - kotlin
+      - php
+      - python
+      - ruby
+      - scala
+      - swift
     operationId: waitForTask
     summary: Wait for operation to complete
     description: |

--- a/templates/dart/snippets/method.mustache
+++ b/templates/dart/snippets/method.mustache
@@ -1,4 +1,5 @@
 // {{generationBanner}}
+// ignore_for_file: unused_local_variable
 // >IMPORT
 {{> snippets/import}}
 // IMPORT<


### PR DESCRIPTION
## 🧭 What and Why

Noticed by @kai687, we don't validate dart snippets and some helpers that we call in the snippets don't exists.
We can remove the snippets for now, and validate dart files so this doesn't happen again.