### PR TITLE
chore(n8n): update output path

### DIFF
--- a/scripts/ci/codegen/types.ts
+++ b/scripts/ci/codegen/types.ts
@@ -154,7 +154,7 @@ export const pushToRepositoryConfiguration: {
         files: {
           type: 'specs',
           ext: 'json',
-          output: 'src/nodes/Algolia/specs',
+          output: 'nodes/Algolia/specs',
           placeholderVariables: { appId: 'applicationId' },
         },
       },


### PR DESCRIPTION
## 🧭 What and Why

👋 Used the wrong output directory, this PR aims to fix that

### Changes included:

- Updates n8n-nodes-algolia output path for generated spec files