### PR TITLE
chore(scripts): dont use verbose when releasing from the CI

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,4 +1,4 @@
-name: Scheduled Release
+name: Scheduled/Manual Release
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Scheduled Release
+    name: Scheduled/Manual Release
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5

--- a/scripts/release/updateAPIVersions.ts
+++ b/scripts/release/updateAPIVersions.ts
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises';
 
 import clientsConfig from '../../config/clients.config.json' with { type: 'json' };
-import { CI, exists, setVerbose, toAbsolutePath } from '../common.ts';
+import { exists, toAbsolutePath } from '../common.ts';
 import { getGitHubUrl, getLanguageFolder } from '../config.ts';
 import type { Language } from '../types.ts';
 
@@ -59,7 +59,6 @@ export async function updateAPIVersions(versions: Versions, changelog: Changelog
     }
 
     if (lang === 'javascript' && releaseType) {
-      setVerbose(CI);
       await updateJavaScriptPackages(releaseType);
     }
 


### PR DESCRIPTION
## 🧭 What and Why

The release is not working from the CI because when we use `setVerbose(true)`, the behavior of the `run` function is different and might return unexpected results.

Removing `setVerbose(CI)` might solve the issues.