### PR TITLE
fix(scripts): only checkout tag on release

### DIFF
--- a/clients/algoliasearch-client-scala/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-scala/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish jar
 on:
   push:
     tags:
-      - '*'
+      - v*
 
 jobs:
   release:


### PR DESCRIPTION
## 🧭 What and Why

Scala release failed because of `Error: fatal: Cannot fetch both 7a7a0a3dbf37cfbe8359c2e6f1b66faead40c40b and refs/tags/v2.30.1 to refs/tags/v2.30.1`.

We need to check out the tag only