### PR TITLE
chore(scripts): downgrade python version for release

### DIFF
--- a/clients/algoliasearch-client-python/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-python/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-python@v6
       with:
-        python-version: 3.14.0
+        python-version: 3.13.7
 
     - name: install poetry
       shell: bash


### PR DESCRIPTION
## 🧭 What and Why

It's dangerous to upgrade deps in `release.yml` since they are not tested until the real release.
https://github.com/algolia/api-clients-automation/pull/5463/files
https://github.com/algolia/algoliasearch-client-python/actions/runs/18534954740/job/52827577225#step:5:199
