### PR TITLE
feat(specs): add `renderingContent` query parameter in Composition API main injection

### DIFF
--- a/specs/composition/common/params/Search.yml
+++ b/specs/composition/common/params/Search.yml
@@ -163,6 +163,9 @@ removeStopWords:
 removeWordsIfNoResults:
   $ref: '../../../common/schemas/IndexSettings.yml#/removeWordsIfNoResults'
 
+renderingContent:
+  $ref: '../../../common/schemas/IndexSettings.yml#/renderingContent'
+
 replaceSynonymsInHighlight:
   $ref: '../../../common/schemas/IndexSettings.yml#/replaceSynonymsInHighlight'
 

--- a/specs/composition/common/schemas/components/Injection.yml
+++ b/specs/composition/common/schemas/components/Injection.yml
@@ -115,6 +115,8 @@ mainInjectionQueryParameters:
           $ref: '../../params/Search.yml#/hitsPerPage'
         maxValuesPerFacet:
           $ref: '../../params/Search.yml#/maxValuesPerFacet'
+        renderingContent:
+          $ref: '../../params/Search.yml#/renderingContent'
         sortFacetValuesBy:
           $ref: '../../params/Search.yml#/sortFacetValuesBy'
         sumOrFiltersScores:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/CMP-634

### Changes included:

Allow `renderingContent` in main injection for Composition API

## 🧪 Test

* CI
* Run locally `yarn cli build specs all && yarn cli build clients javascript`