### PR TITLE
guides: fix error in deleteMultipleIndices template for Go

### DIFF
--- a/templates/go/guides/search/deleteMultipleIndices.mustache
+++ b/templates/go/guides/search/deleteMultipleIndices.mustache
@@ -51,7 +51,7 @@ func deleteMultipleIndices() {
 
   // Now, delete replica indices
   if len(replicaIndices) > 0 {
-		requests := make([]search.MultipleBatchRequest, 0, len(primaryIndices))
+		requests := make([]search.MultipleBatchRequest, 0, len(replicaIndices))
 
 		for _, index := range primaryIndices {
 			requests = append(requests, search.MultipleBatchRequest{


### PR DESCRIPTION
## 🧭 What and Why

Fix a small issue for the "guide" snippet for deleting multiple indices.
When looping over replica indices, the slice length should be of length `replicaIndices`, not `primaryIndices`.

(From documentation feedback)

🎟 JIRA Ticket: [DOC-1710](https://algolia.atlassian.net/browse/DOC-1710)

### Changes included:

- List changes

## 🧪 Test


[DOC-1710]: https://algolia.atlassian.net/browse/DOC-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ