### PR TITLE
fix(scripts): disable doclint when releasing java

### DIFF
--- a/clients/algoliasearch-client-java/algoliasearch/build.gradle
+++ b/clients/algoliasearch-client-java/algoliasearch/build.gradle
@@ -31,4 +31,5 @@ tasks.withType(JavaCompile).configureEach {
 
 javadoc {
   options.encoding = 'UTF-8'
+  options.addStringOption('Xdoclint:none', '-quiet')
 }

--- a/clients/algoliasearch-client-scala/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-scala/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Install Java
         uses: actions/setup-java@v5


### PR DESCRIPTION
## 🧭 What and Why

The Java release is broken because there is a breaking change in the latest version of the release plugin, caused by https://github.com/vanniktech/gradle-maven-publish-plugin/pull/1133.
To fix this, we can disable Doclint.

Also try to fix the scala release by checking out the tag directly.