### PR TITLE
fix(swift): make response and disjunctiveFacets public in SearchDisjunctiveFacetingResponse

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/DisjunctiveFaceting.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/DisjunctiveFaceting.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct SearchDisjunctiveFacetingResponse<T: Codable> {
-    let response: SearchResponse<T>
-    let disjunctiveFacets: [String: [String: Int]]
+    public let response: SearchResponse<T>
+    public let disjunctiveFacets: [String: [String: Int]]
 }
 
 /// Helper making multiple queries for disjunctive faceting


### PR DESCRIPTION
## 🧭 What and Why

fixes https://github.com/algolia/algoliasearch-client-swift/issues/887

### Changes included:

- make props public so users can access them
