### PR TITLE
feat(specs): allow `enablePersonalization` query parameter at run time for Composition API

### DIFF
--- a/specs/composition/common/schemas/requestBodies/RunParams.yml
+++ b/specs/composition/common/schemas/requestBodies/RunParams.yml
@@ -19,6 +19,8 @@ params:
       $ref: '../../params/Search.yml#/clickAnalytics'
     enableABTest:
       $ref: '../../params/Composition.yml#/enableABTest'
+    enablePersonalization:
+      $ref: '../../params/Search.yml#/enablePersonalization'
     enableReRanking:
       $ref: '../../params/Search.yml#/enableReRanking'
     enableRules:


### PR DESCRIPTION
## 🧭 What and Why

Since this PR in metis: https://github.com/algolia/metis/pull/12878, query parameter is available at rune time.
Reflect the change within the API Clients

### Changes included:

- Sort query params for Run request alphabetically
- Allow `enablePersonalization` query parameter at run time for Composition API

_(can review commit by commit)_

## 🧪 Test

* CI
* Run locally `yarn cli build specs all && yarn cli build clients javascript`
