### PR TITLE
feat(clients): response streaming support

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --scope '@algolia/composition' --scope '@algolia/advanced-personalization' --include-dependencies",
+    "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --scope '@algolia/composition' --scope '@algolia/advanced-personalization' --scope '@algolia/agent-studio' --include-dependencies",
     "clean": "lerna run clean",
     "release:publish": "lerna publish from-package --yes",
     "release:publish:old": "tsc --project scripts/tsconfig.json && node scripts/dist/publish.js",

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -27,55 +27,55 @@
     "files": [
       {
         "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-        "maxSize": "14.8KB"
+        "maxSize": "16KB"
       },
       {
         "path": "packages/algoliasearch/dist/lite/builds/browser.umd.js",
-        "maxSize": "4.2KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/abtesting/dist/builds/browser.umd.js",
-        "maxSize": "4.5KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/client-abtesting/dist/builds/browser.umd.js",
-        "maxSize": "4.4KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/client-analytics/dist/builds/browser.umd.js",
-        "maxSize": "5.1KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/composition/dist/builds/browser.umd.js",
-        "maxSize": "5.0KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/client-insights/dist/builds/browser.umd.js",
-        "maxSize": "4.2KB"
+        "maxSize": "5KB"
       },
       {
         "path": "packages/client-personalization/dist/builds/browser.umd.js",
-        "maxSize": "4.3KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/client-query-suggestions/dist/builds/browser.umd.js",
-        "maxSize": "4.3KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/client-search/dist/builds/browser.umd.js",
-        "maxSize": "7.7KB"
+        "maxSize": "9KB"
       },
       {
         "path": "packages/ingestion/dist/builds/browser.umd.js",
-        "maxSize": "7.1KB"
+        "maxSize": "8KB"
       },
       {
         "path": "packages/monitoring/dist/builds/browser.umd.js",
-        "maxSize": "4.3KB"
+        "maxSize": "6KB"
       },
       {
         "path": "packages/recommend/dist/builds/browser.umd.js",
-        "maxSize": "4.5KB"
+        "maxSize": "6KB"
       }
     ]
   },

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --scope '@algolia/composition' --scope '@algolia/advanced-personalization' --scope '@algolia/agent-studio' --include-dependencies",
+    "build": "lerna run build --scope '@algolia/requester-testing' --scope '@algolia/logger-console' --scope 'algoliasearch' --scope '@algolia/composition' --scope '@algolia/advanced-personalization' --include-dependencies",
     "clean": "lerna run clean",
     "release:publish": "lerna publish from-package --yes",
     "release:publish:old": "tsc --project scripts/tsconfig.json && node scripts/dist/publish.js",

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -120,6 +120,7 @@ describe('api', () => {
         set: expect.any(Function),
       },
       request: expect.any(Function),
+      requestStream: expect.any(Function),
       requester: {
         send: expect.any(Function),
       },

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/sse.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/sse.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'vitest';
+
+import { iterSSEEvents, type ServerSentEvent } from '../sse';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Encode each string argument as a separate Uint8Array chunk in an AsyncIterable. */
+function toStream(...chunks: string[]): AsyncIterable<Uint8Array> {
+  const encoder = new TextEncoder();
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield encoder.encode(chunk);
+      }
+    },
+  };
+}
+
+/** Feed chunks through iterSSEEvents and collect all emitted events. */
+async function collectEvents(...chunks: string[]): Promise<ServerSentEvent[]> {
+  const events: ServerSentEvent[] = [];
+  for await (const event of iterSSEEvents(toStream(...chunks))) {
+    events.push(event);
+  }
+  return events;
+}
+
+/** Base event with all defaults — spread to override specific fields. */
+const BASE: ServerSentEvent = { data: '', event: '', id: null, retry: null };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('iterSSEEvents', () => {
+  describe('WHATWG spec cases', () => {
+    test('1. single data event', async () => {
+      const events = await collectEvents('data: hello\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hello' });
+    });
+
+    test('2. multi-line data', async () => {
+      const events = await collectEvents('data: line1\ndata: line2\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'line1\nline2' });
+    });
+
+    test('3. event type', async () => {
+      const events = await collectEvents('event: custom\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, event: 'custom', data: 'hi' });
+    });
+
+    test('4. comment ignored', async () => {
+      const events = await collectEvents(': comment\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi' });
+    });
+
+    test('5. empty data suppressed (no event dispatched)', async () => {
+      const events = await collectEvents('event: ping\n\n');
+      expect(events).toHaveLength(0);
+    });
+
+    test('6. field with no colon', async () => {
+      const events = await collectEvents('data\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: '' });
+    });
+
+    test('7. single space strip (two spaces in → one space out)', async () => {
+      const events = await collectEvents('data:  hello\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: ' hello' });
+    });
+
+    test('8. unknown field ignored', async () => {
+      const events = await collectEvents('foo: bar\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi' });
+    });
+
+    test('9. id persistence across dispatches', async () => {
+      const events = await collectEvents('id: 42\ndata: a\n\ndata: b\n\n');
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual({ ...BASE, data: 'a', id: '42' });
+      expect(events[1]).toEqual({ ...BASE, data: 'b', id: '42' });
+    });
+
+    test('10. id with NULL character ignored', async () => {
+      const events = await collectEvents('id: foo\0bar\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi' });
+    });
+
+    test('11. retry with digits only', async () => {
+      const events = await collectEvents('retry: 3000\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi', retry: 3000 });
+    });
+
+    test('12. retry with non-digits ignored', async () => {
+      const events = await collectEvents('retry: 3s\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi' });
+    });
+
+    test('13. CR line endings', async () => {
+      const events = await collectEvents('data: hello\r\r');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hello' });
+    });
+
+    test('14. CRLF line endings', async () => {
+      const events = await collectEvents('data: hello\r\n\r\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hello' });
+    });
+
+    test('15. mixed line endings', async () => {
+      const events = await collectEvents('data: a\rdata: b\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'a\nb' });
+    });
+
+    test('16. stream ends mid-event (no dispatch)', async () => {
+      const events = await collectEvents('data: partial');
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe('chunk boundary handling', () => {
+    test('17. trailingCR across chunk boundaries', async () => {
+      const events = await collectEvents('data: hello\r', '\ndata: world\r\n\r\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hello\nworld' });
+    });
+  });
+
+  describe('safety limits', () => {
+    test('18. 10MB buffer cap throws', async () => {
+      const chunk = 'a'.repeat(2 * 1024 * 1024); // 2MB per chunk, no newlines
+      const chunks = Array<string>(6).fill(chunk); // 12MB total > 10MB limit
+      await expect(collectEvents(...chunks)).rejects.toThrow('SSE line buffer exceeded 10MB');
+    });
+  });
+
+  describe('eventType reset', () => {
+    test('19. eventType resets on suppressed dispatch', async () => {
+      // First blank line: eventType="custom" but no data → suppressed, eventType resets to ""
+      // Second event: data="hi" with eventType="" (not "custom")
+      const events = await collectEvents('event: custom\n\ndata: hi\n\n');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({ ...BASE, data: 'hi', event: '' });
+    });
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/index.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/index.ts
@@ -5,5 +5,6 @@ export * from './createAuth';
 export * from './createIterablePromise';
 export * from './getAlgoliaAgent';
 export * from './logger';
+export * from './sse';
 export * from './transporter';
 export * from './types';

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
@@ -1,0 +1,285 @@
+/**
+ * WHATWG-compliant Server-Sent Events parser.
+ *
+ * Three-layer architecture:
+ *   1. iterLines()    — byte chunking → line decoding
+ *   2. SSEDecoder     — line → SSE event decoding
+ *   3. iterSSEEvents  — top-level composer (exported)
+ *
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+ */
+
+const MAX_LINE_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type ServerSentEvent = {
+  /** Concatenated data: field values, joined by '\n'. */
+  data: string;
+  /** Event type from the event: field. Defaults to "" (empty string). */
+  event: string;
+  /** Last event ID. Persists across dispatches until changed. */
+  id: string | null;
+  /** Reconnection time in ms. Persists across dispatches until changed. */
+  retry: number | null;
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Converts a ReadableStream into an AsyncIterable via getReader().
+ * Fallback for environments where ReadableStream lacks Symbol.asyncIterator.
+ */
+async function* readableStreamToAsyncIterable(stream: ReadableStream<Uint8Array>): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Normalizes the input to an AsyncIterable<Uint8Array>.
+ * Prefers Symbol.asyncIterator if available; falls back to getReader().
+ */
+function toAsyncIterable(stream: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>): AsyncIterable<Uint8Array> {
+  if (Symbol.asyncIterator in stream) {
+    return stream as AsyncIterable<Uint8Array>;
+  }
+  return readableStreamToAsyncIterable(stream as ReadableStream<Uint8Array>);
+}
+
+// ─── Layer 1: Byte stream → Lines ──────────────────────────────────────────
+
+/**
+ * Yields individual lines from a byte stream.
+ *
+ * Handles \r, \n, and \r\n line endings, including \r\n split across chunks.
+ * Uses offset tracking within each decoded chunk to avoid O(n²) buffer growth.
+ * Strips BOM (U+FEFF) from the very first line.
+ * Throws if the internal line buffer exceeds 10MB.
+ */
+async function* iterLines(stream: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>): AsyncGenerator<string> {
+  const decoder = new TextDecoder('utf-8');
+  const buffer: string[] = [];
+  let bufferSize = 0;
+  let trailingCR = false;
+  let isFirstLine = true;
+
+  for await (const chunk of toAsyncIterable(stream)) {
+    const text = decoder.decode(chunk, { stream: true });
+    let offset = 0;
+
+    // Handle \r\n split across chunks: if the previous chunk ended with \r
+    // and this one starts with \n, skip the \n (it's the second half of \r\n)
+    if (trailingCR) {
+      trailingCR = false;
+      if (text.length > 0 && text[0] === '\n') {
+        offset = 1;
+      }
+    }
+
+    while (offset < text.length) {
+      const crIdx = text.indexOf('\r', offset);
+      const lfIdx = text.indexOf('\n', offset);
+
+      // No more line endings in this chunk — buffer the rest
+      if (crIdx === -1 && lfIdx === -1) {
+        const remaining = text.slice(offset);
+        buffer.push(remaining);
+        bufferSize += remaining.length;
+        if (bufferSize > MAX_LINE_BUFFER_SIZE) {
+          throw new Error('SSE line buffer exceeded 10MB');
+        }
+        break;
+      }
+
+      let endIdx: number;
+      let skipLen: number;
+
+      if (crIdx !== -1 && (lfIdx === -1 || crIdx < lfIdx)) {
+        // \r found before \n (or no \n at all)
+        endIdx = crIdx;
+        if (crIdx + 1 < text.length) {
+          // Peek ahead: \r\n or bare \r
+          skipLen = text[crIdx + 1] === '\n' ? 2 : 1;
+        } else {
+          // \r at end of chunk — might be \r\n split across chunks
+          trailingCR = true;
+          skipLen = 1;
+        }
+      } else {
+        // \n found before \r (or no \r at all)
+        // Safe: at least one of crIdx/lfIdx is != -1, and we're in the else
+        // branch, so lfIdx must be != -1
+        endIdx = lfIdx;
+        skipLen = 1;
+      }
+
+      const segment = text.slice(offset, endIdx);
+      buffer.push(segment);
+
+      let line = buffer.length === 1 ? buffer[0]! : buffer.join('');
+      buffer.length = 0;
+      bufferSize = 0;
+
+      // Strip BOM from the very first line only
+      if (isFirstLine) {
+        if (line.startsWith('\uFEFF')) {
+          line = line.slice(1);
+        }
+        isFirstLine = false;
+      }
+
+      yield line;
+      offset = endIdx + skipLen;
+    }
+  }
+
+  // Flush TextDecoder (handles any remaining bytes from multi-byte sequences)
+  const remaining = decoder.decode();
+  if (remaining) {
+    buffer.push(remaining);
+  }
+
+  // Yield any remaining buffered content as the final line
+  if (buffer.length > 0) {
+    let line = buffer.join('');
+    if (isFirstLine && line.startsWith('\uFEFF')) {
+      line = line.slice(1);
+    }
+    yield line;
+  }
+}
+
+// ─── Layer 2: Lines → SSE Events ──────────────────────────────────────────
+
+/**
+ * Stateful SSE event decoder. Feed lines one at a time via decode().
+ * Returns a ServerSentEvent on blank lines (dispatch), null otherwise.
+ *
+ * Per WHATWG spec §9.2.6:
+ * - lastEventId persists across dispatches
+ * - retry persists across dispatches (global reconnection setting)
+ * - eventType resets after every blank line (even when data is empty)
+ * - data buffer resets after dispatch
+ * - id field containing NULL (\0) is ignored entirely
+ * - retry field must be ASCII digits only
+ */
+class SSEDecoder {
+  private data: string[] = [];
+  private eventType = '';
+  private lastEventId: string | null = null;
+  private retry: number | null = null;
+
+  decode(line: string): ServerSentEvent | null {
+    // Blank line → dispatch event or reset
+    if (line === '') {
+      return this.dispatch();
+    }
+
+    // Comment line (starts with ':')
+    if (line[0] === ':') {
+      return null;
+    }
+
+    // Parse field:value
+    const colonIdx = line.indexOf(':');
+    let field: string;
+    let value: string;
+
+    if (colonIdx === -1) {
+      // No colon → field is entire line, value is empty
+      field = line;
+      value = '';
+    } else {
+      field = line.slice(0, colonIdx);
+      value = line.slice(colonIdx + 1);
+      // Strip exactly ONE leading space (if present)
+      if (value[0] === ' ') {
+        value = value.slice(1);
+      }
+    }
+
+    switch (field) {
+      case 'data':
+        this.data.push(value);
+        break;
+      case 'event':
+        this.eventType = value;
+        break;
+      case 'id':
+        // Ignore if value contains NULL character (security: WHATWG spec)
+        if (!value.includes('\0')) {
+          this.lastEventId = value;
+        }
+        break;
+      case 'retry':
+        // Must consist of ASCII digits only (no negatives, no whitespace)
+        if (/^[0-9]+$/.test(value)) {
+          this.retry = parseInt(value, 10);
+        }
+        break;
+      // Unknown fields: ignore silently
+    }
+
+    return null;
+  }
+
+  private dispatch(): ServerSentEvent | null {
+    // eventType resets on every blank line per WHATWG spec,
+    // regardless of whether we actually dispatch an event
+    const currentEventType = this.eventType;
+    this.eventType = '';
+
+    // Suppress dispatch when no data: lines were received
+    if (this.data.length === 0) {
+      return null;
+    }
+
+    const event: ServerSentEvent = {
+      data: this.data.join('\n'),
+      event: currentEventType,
+      id: this.lastEventId,
+      retry: this.retry,
+    };
+
+    // Reset data buffer; lastEventId and retry persist across dispatches
+    this.data = [];
+
+    return event;
+  }
+}
+
+// ─── Layer 3: Top-level composer ──────────────────────────────────────────
+
+/**
+ * Parses a byte stream as WHATWG Server-Sent Events.
+ *
+ * Accepts both ReadableStream<Uint8Array> (browser fetch) and
+ * AsyncIterable<Uint8Array> (Node.js streams / Buffer chunks).
+ *
+ * @example
+ * ```ts
+ * const response = await fetch(url);
+ * for await (const event of iterSSEEvents(response.body!)) {
+ *   console.log(event.event, event.data);
+ * }
+ * ```
+ */
+export async function* iterSSEEvents(
+  stream: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>,
+): AsyncGenerator<ServerSentEvent> {
+  const decoder = new SSEDecoder();
+  for await (const line of iterLines(stream)) {
+    const event = decoder.decode(line);
+    if (event !== null) {
+      yield event;
+    }
+  }
+}

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
@@ -31,7 +31,7 @@ export type ServerSentEvent = {
  * - `raw` is the original {@link ServerSentEvent} (always present).
  * - `error` is set when JSON parsing of `event.data` failed.
  */
-export type StreamEvent<T> = {
+export type StreamEvent<T = Record<string, unknown>> = {
   /** Parsed data from the event, or `null` if parsing failed. */
   data: T | null;
   /** The original, unparsed SSE event. */

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/sse.ts
@@ -24,6 +24,22 @@ export type ServerSentEvent = {
   retry: number | null;
 };
 
+/**
+ * Wrapper for a parsed SSE event, yielded by the typed `*Stream` methods.
+ *
+ * - `data` is the JSON-parsed payload when parsing succeeds, `null` otherwise.
+ * - `raw` is the original {@link ServerSentEvent} (always present).
+ * - `error` is set when JSON parsing of `event.data` failed.
+ */
+export type StreamEvent<T> = {
+  /** Parsed data from the event, or `null` if parsing failed. */
+  data: T | null;
+  /** The original, unparsed SSE event. */
+  raw: ServerSentEvent;
+  /** The error that occurred while parsing `event.data`, if any. */
+  error?: Error;
+};
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 /**

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -1,3 +1,5 @@
+import type { ServerSentEvent } from '../sse';
+import { iterSSEEvents } from '../sse';
 import type {
   EndRequest,
   Host,
@@ -311,6 +313,74 @@ export function createTransporter({
     );
   }
 
+  async function* requestStream(
+    request: Request,
+    requestOptions: RequestOptions = {},
+  ): AsyncGenerator<ServerSentEvent> {
+    if (!requester.sendStream) {
+      throw new Error('This requester does not support streaming');
+    }
+
+    const data = serializeData(request, requestOptions);
+    const headers = serializeHeaders(baseHeaders, request.headers, requestOptions.headers);
+    headers['accept'] = 'text/event-stream';
+
+    // On `GET`, the data is proxied to query parameters.
+    const dataQueryParameters: QueryParameters =
+      request.method === 'GET'
+        ? {
+            ...request.data,
+            ...requestOptions.data,
+          }
+        : {};
+
+    const queryParameters: QueryParameters = {
+      ...baseQueryParameters,
+      ...request.queryParameters,
+      ...dataQueryParameters,
+    };
+
+    if (algoliaAgent.value) {
+      queryParameters['x-algolia-agent'] = algoliaAgent.value;
+    }
+
+    if (requestOptions && requestOptions.queryParameters) {
+      for (const key of Object.keys(requestOptions.queryParameters)) {
+        if (
+          !requestOptions.queryParameters[key] ||
+          Object.prototype.toString.call(requestOptions.queryParameters[key]) === '[object Object]'
+        ) {
+          queryParameters[key] = requestOptions.queryParameters[key];
+        } else {
+          queryParameters[key] = requestOptions.queryParameters[key].toString();
+        }
+      }
+    }
+
+    const isRead = request.useReadTransporter || request.method === 'GET';
+    const compatibleHosts = hosts.filter(
+      (host) => host.accept === 'readWrite' || (isRead ? host.accept === 'read' : host.accept === 'write'),
+    );
+    const options = await createRetryableOptions(compatibleHosts);
+    const host = options.hosts[0];
+    if (!host) {
+      throw new RetryError([]);
+    }
+
+    const timeout = { ...timeouts, ...requestOptions.timeouts };
+    const payload: EndRequest = {
+      data,
+      headers,
+      method: request.method,
+      url: serializeUrl(host, request.path, queryParameters),
+      connectTimeout: timeout.connect,
+      responseTimeout: isRead ? timeout.read : timeout.write,
+    };
+
+    const stream = await requester.sendStream(payload);
+    yield* iterSSEEvents(stream);
+  }
+
   return {
     hostsCache,
     requester,
@@ -321,6 +391,7 @@ export function createTransporter({
     baseQueryParameters,
     hosts,
     request: createRequest,
+    requestStream,
     requestsCache,
     responsesCache,
   };

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/requester.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/requester.ts
@@ -64,4 +64,8 @@ export type Requester = {
    * Sends the given `request` to the server.
    */
   send: (request: EndRequest) => Promise<Response>;
+  /**
+   * Sends the given `request` and returns a raw byte stream for streaming responses (e.g. SSE).
+   */
+  sendStream?: (request: EndRequest) => Promise<ReadableStream<Uint8Array>>;
 };

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
@@ -1,3 +1,4 @@
+import type { ServerSentEvent } from '../sse';
 import type { Cache } from './cache';
 import type { Host } from './host';
 import type { Logger } from './logger';
@@ -168,4 +169,5 @@ export type Transporter = TransporterOptions & {
    * The `baseRequest` and `baseRequestOptions` will be merged accordingly.
    */
   request: <TResponse>(baseRequest: Request, baseRequestOptions?: RequestOptions) => Promise<TResponse>;
+  requestStream: (baseRequest: Request, baseRequestOptions?: RequestOptions) => AsyncGenerator<ServerSentEvent>;
 };

--- a/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
             'src/__tests__/cache/memory-cache.test.ts',
             'src/__tests__/create-iterable-promise.test.ts',
             'src/__tests__/logger/null-logger.test.ts',
+            'src/__tests__/sse.test.ts',
             'src/__tests__/transporter/cache.test.ts',
             'src/__tests__/transporter/compression.test.ts',
           ],

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
@@ -70,5 +70,29 @@ export function createFetchRequester({ requesterOptions = {} }: FetchRequesterOp
     }
   }
 
-  return { send };
+  async function sendStream(request: EndRequest): Promise<ReadableStream<Uint8Array>> {
+    const fetchRes = await fetch(request.url, {
+      method: request.method,
+      body: request.data || null,
+      redirect: 'manual',
+      ...requesterOptions,
+      headers: {
+        ...requesterOptions.headers,
+        ...request.headers,
+      },
+    });
+
+    if (!fetchRes.ok) {
+      const text = await fetchRes.text();
+      throw new Error(`HTTP ${fetchRes.status}: ${text}`);
+    }
+
+    if (fetchRes.body === null) {
+      throw new Error('Response body is null — streaming not supported');
+    }
+
+    return fetchRes.body;
+  }
+
+  return { send, sendStream };
 }

--- a/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-fetch/src/createFetchRequester.ts
@@ -73,7 +73,7 @@ export function createFetchRequester({ requesterOptions = {} }: FetchRequesterOp
   async function sendStream(request: EndRequest): Promise<ReadableStream<Uint8Array>> {
     const fetchRes = await fetch(request.url, {
       method: request.method,
-      body: request.data || null,
+      body: (request.data as BodyInit) || null,
       redirect: 'manual',
       ...requesterOptions,
       headers: {

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/createHttpRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/createHttpRequester.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import https from 'https';
+import { Readable } from 'stream';
 import { URL } from 'url';
 import zlib from 'zlib';
 
@@ -109,5 +110,54 @@ export function createHttpRequester({
     });
   }
 
-  return { send };
+  function sendStream(request: EndRequest): Promise<ReadableStream<Uint8Array>> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(request.url);
+      const path = url.search === null ? url.pathname : `${url.pathname}${url.search}`;
+      const options: https.RequestOptions = {
+        agent: url.protocol === 'https:' ? httpsAgent : httpAgent,
+        hostname: url.hostname,
+        path,
+        method: request.method,
+        ...requesterOptions,
+        headers: {
+          ...request.headers,
+          ...requesterOptions.headers,
+        },
+      };
+
+      if (url.port && !requesterOptions.port) {
+        options.port = url.port;
+      }
+
+      const req = (url.protocol === 'https:' ? https : http).request(options, (response) => {
+        const statusCode = response.statusCode || 0;
+
+        if (statusCode < 200 || statusCode >= 300) {
+          let body = '';
+          response.on('data', (chunk) => {
+            body += chunk;
+          });
+          response.on('end', () => {
+            reject(new Error(`HTTP ${statusCode}: ${body}`));
+          });
+          return;
+        }
+
+        resolve(Readable.toWeb(response) as ReadableStream<Uint8Array>);
+      });
+
+      req.on('error', (error) => {
+        reject(error);
+      });
+
+      if (request.data !== undefined) {
+        req.write(request.data);
+      }
+
+      req.end();
+    });
+  }
+
+  return { send, sendStream };
 }

--- a/clients/algoliasearch-client-javascript/yarn.lock
+++ b/clients/algoliasearch-client-javascript/yarn.lock
@@ -63,6 +63,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@algolia/agent-studio@workspace:packages/agent-studio":
+  version: 0.0.0-use.local
+  resolution: "@algolia/agent-studio@workspace:packages/agent-studio"
+  dependencies:
+    "@algolia/client-common": "npm:5.49.2"
+    "@algolia/requester-browser-xhr": "npm:5.49.2"
+    "@algolia/requester-fetch": "npm:5.49.2"
+    "@algolia/requester-node-http": "npm:5.49.2"
+    "@arethetypeswrong/cli": "npm:0.18.2"
+    "@types/node": "npm:25.1.0"
+    publint: "npm:0.3.17"
+    rollup: "npm:4.58.0"
+    tsup: "npm:8.5.1"
+    typescript: "npm:5.9.3"
+  languageName: unknown
+  linkType: soft
+
 "@algolia/client-abtesting@npm:5.49.2, @algolia/client-abtesting@workspace:packages/client-abtesting":
   version: 0.0.0-use.local
   resolution: "@algolia/client-abtesting@workspace:packages/client-abtesting"

--- a/clients/algoliasearch-client-python/algoliasearch/http/sse.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/sse.py
@@ -10,10 +10,21 @@ Reference: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-
 
 import codecs
 from dataclasses import dataclass
-from typing import AsyncIterable, AsyncIterator, Iterable, Iterator, List, Optional
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    TypeVar,
+)
 
 _MAX_LINE_SIZE = 10 * 1024 * 1024  # 10 MB
 _BOM = "\ufeff"
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -24,6 +35,20 @@ class ServerSentEvent:
     event: str
     id: Optional[str] = None
     retry: Optional[int] = None
+
+
+@dataclass
+class StreamEvent(Generic[T]):
+    """Wrapper for a parsed SSE event yielded by the typed ``*_stream`` methods.
+
+    ``data`` is the deserialized payload when parsing succeeds, ``None`` otherwise.
+    ``raw`` is the original :class:`ServerSentEvent` (always present).
+    ``error`` is set when JSON parsing / deserialization of ``event.data`` failed.
+    """
+
+    data: Optional[T]
+    raw: ServerSentEvent
+    error: Optional[Exception] = None
 
 
 # ---------------------------------------------------------------------------

--- a/clients/algoliasearch-client-python/algoliasearch/http/sse.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/sse.py
@@ -1,0 +1,274 @@
+"""WHATWG-compliant Server-Sent Events parser.
+
+Three-layer architecture:
+  Layer 1: _iter_lines / _aiter_lines — byte stream to text lines
+  Layer 2: SSEDecoder — text lines to ServerSentEvent objects
+  Layer 3: iter_sse_events / aiter_sse_events — top-level composers
+
+Reference: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+"""
+
+import codecs
+from dataclasses import dataclass
+from typing import AsyncIterable, AsyncIterator, Iterable, Iterator, List, Optional
+
+_MAX_LINE_SIZE = 10 * 1024 * 1024  # 10 MB
+_BOM = "\ufeff"
+
+
+@dataclass
+class ServerSentEvent:
+    """A single SSE event dispatched from the event stream."""
+
+    data: str
+    event: str
+    id: Optional[str] = None
+    retry: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — SSEDecoder (shared between sync and async)
+# ---------------------------------------------------------------------------
+
+
+class SSEDecoder:
+    """Decodes text lines into ServerSentEvent objects per the WHATWG spec.
+
+    Feed lines one at a time via :meth:`decode`. A blank line triggers event
+    dispatch if the data buffer is non-empty. ``_last_event_id`` persists
+    across dispatches; ``_event_type`` resets to ``""`` after each dispatch.
+    """
+
+    def __init__(self) -> None:
+        self._data: List[str] = []
+        self._event_type: str = ""
+        self._last_event_id: Optional[str] = None
+        self._retry: Optional[int] = None
+
+    def decode(self, line: str) -> Optional[ServerSentEvent]:
+        """Process a single line. Returns a :class:`ServerSentEvent` on
+        dispatch (blank line with non-empty data buffer), or ``None``."""
+
+        # Blank line → dispatch if data buffer is non-empty
+        if not line:
+            # eventType resets on EVERY blank line per WHATWG spec,
+            # regardless of whether we actually dispatch an event
+            current_event_type = self._event_type
+            self._event_type = ""
+
+            if not self._data:
+                return None
+
+            event = ServerSentEvent(
+                data="\n".join(self._data),
+                event=current_event_type,
+                id=self._last_event_id,
+                retry=self._retry,
+            )
+
+            # Reset per WHATWG spec — _last_event_id and _retry persist
+            self._data = []
+
+            return event
+
+        # Comment line (starts with ':')
+        if line.startswith(":"):
+            return None
+
+        # Field line
+        if ":" in line:
+            field, _, value = line.partition(":")
+            # Strip exactly one leading space if present
+            if value.startswith(" "):
+                value = value[1:]
+        else:
+            field = line
+            value = ""
+
+        if field == "data":
+            self._data.append(value)
+        elif field == "event":
+            self._event_type = value
+        elif field == "id":
+            # If the value contains a NULL character, ignore the field entirely
+            if "\x00" not in value:
+                self._last_event_id = value
+        elif field == "retry":
+            # Only accept if value is non-empty and consists entirely of
+            # ASCII digits. Do NOT use int() directly — it accepts negatives,
+            # whitespace, underscores, etc.
+            if value and value.isdigit():
+                self._retry = int(value)
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — Line iterators (byte stream → text lines)
+# ---------------------------------------------------------------------------
+
+
+def _iter_lines(byte_iter: Iterable[bytes]) -> Iterator[str]:
+    """Decode a byte stream into individual text lines.
+
+    Handles ``\\r``, ``\\n``, and ``\\r\\n`` line endings including the edge
+    case where ``\\r\\n`` is split across two chunks. Strips the BOM from the
+    very first line only. Raises :class:`ValueError` if the internal buffer
+    exceeds 10 MB.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    buf = ""
+    trailing_cr = False
+    first_line = True
+
+    for raw_chunk in byte_iter:
+        chunk = decoder.decode(raw_chunk)
+
+        if not chunk:
+            continue
+
+        # Handle \r\n split across chunk boundary
+        if trailing_cr:
+            if chunk[0] == "\n":
+                chunk = chunk[1:]
+            trailing_cr = False
+            if not chunk:
+                continue
+
+        # Track trailing \r for next chunk's \r\n check
+        if chunk[-1] == "\r":
+            trailing_cr = True
+
+        # Normalize all line endings to \n, then split
+        lines = chunk.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+        # First segment extends the buffer; remaining segments are after
+        # line breaks (i.e. the buffer holds a complete line).
+        buf += lines[0]
+
+        for i in range(1, len(lines)):
+            line = buf
+            if first_line:
+                if line.startswith(_BOM):
+                    line = line[1:]
+                first_line = False
+            yield line
+            buf = lines[i]
+
+        if len(buf) > _MAX_LINE_SIZE:
+            raise ValueError("SSE line exceeds maximum buffer size of 10 MB")
+
+    # Flush the incremental UTF-8 decoder
+    remaining = decoder.decode(b"", final=True)
+    if remaining:
+        buf += remaining
+
+    # At end-of-stream with trailing_cr the \r already caused a line split,
+    # so only yield if buf accumulated content after that split.
+    if trailing_cr:
+        if buf:
+            line = buf
+            if first_line:
+                if line.startswith(_BOM):
+                    line = line[1:]
+            yield line
+        return
+
+    if buf:
+        line = buf
+        if first_line:
+            if line.startswith(_BOM):
+                line = line[1:]
+        yield line
+
+
+async def _aiter_lines(byte_iter: AsyncIterable[bytes]) -> AsyncIterator[str]:
+    """Async variant of :func:`_iter_lines`."""
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    buf = ""
+    trailing_cr = False
+    first_line = True
+
+    async for raw_chunk in byte_iter:
+        chunk = decoder.decode(raw_chunk)
+
+        if not chunk:
+            continue
+
+        if trailing_cr:
+            if chunk[0] == "\n":
+                chunk = chunk[1:]
+            trailing_cr = False
+            if not chunk:
+                continue
+
+        if chunk[-1] == "\r":
+            trailing_cr = True
+
+        lines = chunk.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+        buf += lines[0]
+
+        for i in range(1, len(lines)):
+            line = buf
+            if first_line:
+                if line.startswith(_BOM):
+                    line = line[1:]
+                first_line = False
+            yield line
+            buf = lines[i]
+
+        if len(buf) > _MAX_LINE_SIZE:
+            raise ValueError("SSE line exceeds maximum buffer size of 10 MB")
+
+    remaining = decoder.decode(b"", final=True)
+    if remaining:
+        buf += remaining
+
+    if trailing_cr:
+        if buf:
+            line = buf
+            if first_line:
+                if line.startswith(_BOM):
+                    line = line[1:]
+            yield line
+        return
+
+    if buf:
+        line = buf
+        if first_line:
+            if line.startswith(_BOM):
+                line = line[1:]
+        yield line
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — Top-level composers
+# ---------------------------------------------------------------------------
+
+
+def iter_sse_events(byte_iter: Iterable[bytes]) -> Iterator[ServerSentEvent]:
+    """Parse a byte stream into SSE events (sync).
+
+    Pipes bytes through :func:`_iter_lines` then feeds each line to
+    :class:`SSEDecoder`, yielding every dispatched event.
+    """
+    decoder = SSEDecoder()
+    for line in _iter_lines(byte_iter):
+        event = decoder.decode(line)
+        if event is not None:
+            yield event
+
+
+async def aiter_sse_events(
+    byte_iter: AsyncIterable[bytes],
+) -> AsyncIterator[ServerSentEvent]:
+    """Parse a byte stream into SSE events (async).
+
+    Async variant of :func:`iter_sse_events`.
+    """
+    decoder = SSEDecoder()
+    async for line in _aiter_lines(byte_iter):
+        event = decoder.decode(line)
+        if event is not None:
+            yield event

--- a/clients/algoliasearch-client-python/algoliasearch/http/sse.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/sse.py
@@ -11,20 +11,23 @@ Reference: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-
 import codecs
 from dataclasses import dataclass
 from typing import (
+    Any,
     AsyncIterable,
     AsyncIterator,
+    Dict,
     Generic,
     Iterable,
     Iterator,
     List,
     Optional,
-    TypeVar,
 )
+
+from typing_extensions import TypeVar
 
 _MAX_LINE_SIZE = 10 * 1024 * 1024  # 10 MB
 _BOM = "\ufeff"
 
-T = TypeVar("T")
+T = TypeVar("T", default=Dict[str, Any])
 
 
 @dataclass

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
@@ -1,7 +1,7 @@
 from asyncio import TimeoutError
 from gzip import compress as gzip_compress
 from json import loads
-from typing import List, Optional
+from typing import AsyncIterator, List, Optional
 
 from aiohttp import ClientSession, ClientTimeout, TCPConnector
 
@@ -15,6 +15,7 @@ from algoliasearch.http.exceptions import (
 from algoliasearch.http.hosts import Host
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.retry import RetryOutcome, RetryStrategy
+from algoliasearch.http.sse import ServerSentEvent, aiter_sse_events
 from algoliasearch.http.verb import Verb
 
 
@@ -118,6 +119,61 @@ class Transporter(BaseTransporter):
         raise AlgoliaUnreachableHostException(
             "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support"
         )
+
+    async def request_stream(
+        self,
+        verb: Verb,
+        path: str,
+        request_options: RequestOptions,
+        use_read_transporter: bool,
+    ) -> AsyncIterator[ServerSentEvent]:
+        if self._session is None:
+            self._session = ClientSession(
+                connector=TCPConnector(use_dns_cache=False), trust_env=True
+            )
+
+        request_options.headers["accept"] = "text/event-stream"
+
+        query_parameters = self.prepare(
+            request_options, verb == Verb.GET or use_read_transporter
+        )
+
+        path = self.build_path(path, query_parameters)
+
+        valid_hosts = self._retry_strategy.valid_hosts(self._hosts)
+        if not valid_hosts:
+            raise AlgoliaUnreachableHostException(
+                "No hosts available for streaming request"
+            )
+        host = valid_hosts[0]
+        url = self.build_url(host, path)
+        proxy = self.get_proxy(url)
+
+        connect_timeout = request_options.timeouts["connect"] / 1000
+        request_timeout = self._timeout / 1000
+
+        timeout_config = ClientTimeout(
+            connect=connect_timeout, sock_read=request_timeout
+        )
+
+        resp = await self._session.request(
+            method=verb,
+            url=url,
+            headers=request_options.headers,
+            data=request_options.data,
+            proxy=proxy,
+            timeout=timeout_config,
+        )
+
+        try:
+            if resp.status >= 400:
+                error_text = await resp.text()
+                raise RequestException(error_text, resp.status)
+
+            async for event in aiter_sse_events(resp.content.iter_any()):
+                yield event
+        finally:
+            resp.release()
 
 
 class EchoTransporter(Transporter):

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
@@ -1,11 +1,12 @@
 from gzip import compress as gzip_compress
 from json import loads
 from sys import version_info
+from typing import Iterator, Optional
 
 from requests import Request, Session, Timeout
 
 if version_info >= (3, 11):
-    from typing import List, Optional, Self
+    from typing import List, Self
 else:
     from typing_extensions import List, Self
 
@@ -22,6 +23,7 @@ from algoliasearch.http.exceptions import (
 from algoliasearch.http.hosts import Host
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.retry import RetryOutcome, RetryStrategy
+from algoliasearch.http.sse import ServerSentEvent, iter_sse_events
 from algoliasearch.http.verb import Verb
 
 
@@ -130,6 +132,63 @@ class TransporterSync(BaseTransporter):
         raise AlgoliaUnreachableHostException(
             "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support"
         )
+
+    def request_stream(
+        self,
+        verb: Verb,
+        path: str,
+        request_options: RequestOptions,
+        use_read_transporter: bool,
+    ) -> Iterator[ServerSentEvent]:
+        if self._session is None:
+            self._session = Session()
+            self._session.mount("https://", HTTPAdapter(max_retries=Retry(connect=0)))
+
+        request_options.headers["accept"] = "text/event-stream"
+
+        query_parameters = self.prepare(
+            request_options, verb == Verb.GET or use_read_transporter
+        )
+
+        path = self.build_path(path, query_parameters)
+
+        valid_hosts = self._retry_strategy.valid_hosts(self._hosts)
+        if not valid_hosts:
+            raise AlgoliaUnreachableHostException(
+                "No hosts available for streaming request"
+            )
+        host = valid_hosts[0]
+        url = self.build_url(host, path)
+        proxies = self.get_proxies(url)
+
+        req = self._session.prepare_request(
+            Request(
+                method=verb,
+                url=url,
+                headers=request_options.headers,
+                data=request_options.data,
+            )
+        )
+
+        connect_timeout = request_options.timeouts["connect"] / 1000
+        read_timeout = self._timeout / 1000
+
+        resp = self._session.send(
+            req,
+            timeout=(connect_timeout, read_timeout),
+            proxies=proxies,
+            stream=True,
+        )
+
+        try:
+            if resp.status_code >= 400:
+                error_text = resp.text
+                raise RequestException(error_text, resp.status_code)
+
+            for event in iter_sse_events(resp.iter_content(chunk_size=None)):
+                yield event
+        finally:
+            resp.close()
 
 
 class EchoTransporterSync(TransporterSync):

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -207,7 +207,8 @@
       },
       {
         "name": "agent-studio",
-        "output": "clients/algoliasearch-client-javascript/packages/agent-studio"
+        "output": "clients/algoliasearch-client-javascript/packages/agent-studio",
+        "isStandaloneClient": true
       }
     ],
     "folder": "clients/algoliasearch-client-javascript",

--- a/config/clients.config.json
+++ b/config/clients.config.json
@@ -207,8 +207,7 @@
       },
       {
         "name": "agent-studio",
-        "output": "clients/algoliasearch-client-javascript/packages/agent-studio",
-        "isStandaloneClient": true
+        "output": "clients/algoliasearch-client-javascript/packages/agent-studio"
       }
     ],
     "folder": "clients/algoliasearch-client-javascript",

--- a/playground/javascript/node/agentStudioStreaming.ts
+++ b/playground/javascript/node/agentStudioStreaming.ts
@@ -1,0 +1,139 @@
+import { ApiError } from '@algolia/client-common';
+import { agentStudioClient } from '@algolia/agent-studio';
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+const appId = process.env.ALGOLIA_APPLICATION_ID || '';
+const apiKey = process.env.ALGOLIA_ADMIN_KEY || '';
+
+if (!appId || !apiKey) {
+  console.error('[FATAL] ALGOLIA_APPLICATION_ID and ALGOLIA_ADMIN_KEY must be set in playground/.env');
+  process.exit(1);
+}
+
+console.log(`[CONFIG] appId=${appId}`);
+console.log(`[CONFIG] apiKey=${apiKey.slice(0, 6)}...`);
+
+const client = agentStudioClient(appId, apiKey, 'us');
+
+// The generated JS clients set 'content-type: text/plain' by default, which works
+// for traditional Algolia APIs but agent-studio (FastAPI) requires 'application/json'.
+const jsonHeaders = { headers: { 'content-type': 'application/json' } };
+
+let createdAgentId: string | undefined;
+
+async function testStreaming() {
+  try {
+    // 1. Find a provider to use
+    console.log('\n─── Step 1: Finding a provider ───');
+    const providersResponse = await client.listProviders();
+    console.log(`[PROVIDERS] Found ${providersResponse.data.length} provider(s):`);
+    for (const p of providersResponse.data) {
+      console.log(`  - ${p.name} (ID: ${p.id})`);
+    }
+
+    if (providersResponse.data.length === 0) {
+      console.error('[FATAL] No providers found. Configure one first.');
+      return;
+    }
+
+    const provider = providersResponse.data[0];
+    console.log(`\n[SELECTED] Using provider: "${provider.name}" (${provider.id})`);
+
+    // 2. Create a temporary agent with the provider
+    console.log('\n─── Step 2: Creating temporary agent ───');
+    const agent = await client.createAgent({
+        name: `streaming-test-${Date.now()}`,
+        instructions: 'You are a helpful assistant. Keep your answers short and concise.',
+        providerId: provider.id,
+        model: 'gpt-4.1-mini',
+      },
+      jsonHeaders,
+    );
+    createdAgentId = agent.id;
+    console.log(`[CREATED] Agent "${agent.name}" (ID: ${agent.id})`);
+    console.log(`[CREATED] Status: ${agent.status}`);
+
+    // Publish the agent so it can serve completions
+    console.log('[PUBLISH] Publishing agent...');
+    await client.publishAgent({ agentId: agent.id }, jsonHeaders);
+    console.log('[PUBLISH] Agent published');
+
+    // 3. Call the streaming endpoint
+    console.log('\n─── Step 3: Calling createAgentCompletionStream ───');
+    console.log('[REQUEST] Sending message: "Hello, what can you do?"');
+    console.log('[REQUEST] compatibilityMode: "ai-sdk-5"');
+    console.log('[REQUEST] stream: true');
+
+    const startTime = Date.now();
+    let eventCount = 0;
+
+    const stream = client.createAgentCompletionStream({
+        agentId: agent.id,
+        compatibilityMode: 'ai-sdk-5',
+        stream: true,
+        agentCompletionRequest: {
+          messages: [
+            {
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello, what can you do? Keep it short.' }],
+            },
+          ],
+        },
+      },
+      jsonHeaders,
+    );
+
+    console.log('[STREAM] Stream object created, iterating events...\n');
+
+    // 4. Iterate over SSE events
+    console.log('─── Step 4: Receiving SSE events ───');
+    for await (const event of stream) {
+      eventCount++;
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
+
+      console.log(`\n[EVENT #${eventCount}] (t+${elapsed}s)`);
+      console.log(`  event: "${event.event}"`);
+      console.log(`  id:    "${event.id}"`);
+      console.log(`  retry: ${event.retry ?? 'null'}`);
+
+      // Show data (truncate if too long)
+      const dataPreview = event.data.length > 200 ? event.data.slice(0, 200) + '...' : event.data;
+      console.log(`  data:  ${dataPreview}`);
+
+      // Try to parse data as JSON
+      if (event.data) {
+        try {
+          const parsed = JSON.parse(event.data);
+          console.log(`  [PARSED JSON] type=${typeof parsed}, keys=[${Object.keys(parsed).join(', ')}]`);
+        } catch {
+          console.log(`  [RAW TEXT] (not JSON)`);
+        }
+      }
+    }
+
+    const totalTime = ((Date.now() - startTime) / 1000).toFixed(2);
+    console.log(`\n─── Done ───`);
+    console.log(`[SUMMARY] Received ${eventCount} events in ${totalTime}s`);
+  } catch (e) {
+    if (e instanceof ApiError) {
+      console.error(`\n[API ERROR] [${e.status}] ${e.message}`);
+      console.error('[STACK]', e.stackTrace);
+      return;
+    }
+
+    console.error('\n[ERROR]', e);
+  } finally {
+    // 5. Teardown: delete the temporary agent
+    if (createdAgentId) {
+      console.log(`\n─── Teardown ───`);
+      try {
+        await client.deleteAgent({ agentId: createdAgentId }, jsonHeaders);
+        console.log(`[DELETED] Agent ${createdAgentId}`);
+      } catch (e) {
+        console.error(`[TEARDOWN ERROR] Failed to delete agent ${createdAgentId}:`, e);
+      }
+    }
+  }
+}
+
+testStreaming();

--- a/playground/javascript/node/agentStudioStreaming.ts
+++ b/playground/javascript/node/agentStudioStreaming.ts
@@ -85,29 +85,21 @@ async function testStreaming() {
 
     console.log('[STREAM] Stream object created, iterating events...\n');
 
-    // 4. Iterate over SSE events
+    // 4. Iterate over SSE events (typed: StreamEvent<AgentCompletionResponse>)
     console.log('─── Step 4: Receiving SSE events ───');
     for await (const event of stream) {
       eventCount++;
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
 
       console.log(`\n[EVENT #${eventCount}] (t+${elapsed}s)`);
-      console.log(`  event: "${event.event}"`);
-      console.log(`  id:    "${event.id}"`);
-      console.log(`  retry: ${event.retry ?? 'null'}`);
+      console.log(`  event: "${event.raw.event}"`);
+      console.log(`  id:    "${event.raw.id}"`);
 
-      // Show data (truncate if too long)
-      const dataPreview = event.data.length > 200 ? event.data.slice(0, 200) + '...' : event.data;
-      console.log(`  data:  ${dataPreview}`);
-
-      // Try to parse data as JSON
-      if (event.data) {
-        try {
-          const parsed = JSON.parse(event.data);
-          console.log(`  [PARSED JSON] type=${typeof parsed}, keys=[${Object.keys(parsed).join(', ')}]`);
-        } catch {
-          console.log(`  [RAW TEXT] (not JSON)`);
-        }
+      if (event.error) {
+        console.log(`  [PARSE ERROR] ${event.error.message}`);
+        console.log(`  [RAW DATA] ${event.raw.data.slice(0, 200)}`);
+      } else if (event.data) {
+        console.log(`  [TYPED DATA] keys=[${Object.keys(event.data).join(', ')}]`);
       }
     }
 

--- a/playground/python/app/agent_studio_streaming.py
+++ b/playground/python/app/agent_studio_streaming.py
@@ -1,4 +1,3 @@
-import json
 import time
 from os import environ
 from asyncio import run
@@ -85,31 +84,22 @@ async def main():
 
         print("[STREAM] Stream object created, iterating events...\n")
 
-        # 4. Iterate over SSE events
+        # 4. Iterate over SSE events (typed: StreamEvent[AgentCompletionResponse])
         print("─── Step 4: Receiving SSE events ───")
         async for event in stream:
             event_count += 1
             elapsed = f"{time.time() - start_time:.2f}"
 
             print(f"\n[EVENT #{event_count}] (t+{elapsed}s)")
-            print(f'  event: "{event.event}"')
-            print(f'  id:    "{event.id}"')
-            print(f"  retry: {event.retry}")
+            print(f'  event: "{event.raw.event}"')
+            print(f'  id:    "{event.raw.id}"')
 
-            # Show data (truncate if too long)
-            data_preview = (
-                event.data[:200] + "..." if len(event.data) > 200 else event.data
-            )
-            print(f"  data:  {data_preview}")
-
-            # Try to parse data as JSON
-            if event.data:
-                try:
-                    parsed = json.loads(event.data)
-                    keys = ", ".join(parsed.keys()) if isinstance(parsed, dict) else str(type(parsed).__name__)
-                    print(f"  [PARSED JSON] type={type(parsed).__name__}, keys=[{keys}]")
-                except (json.JSONDecodeError, ValueError):
-                    print("  [RAW TEXT] (not JSON)")
+            if event.error:
+                print(f"  [PARSE ERROR] {event.error}")
+                print(f"  [RAW DATA] {event.raw.data[:200]}")
+            elif event.data is not None:
+                print(f"  [TYPED DATA] type={type(event.data).__name__}")
+                print(f"  [TYPED DATA] {event.data}")
 
         total_time = f"{time.time() - start_time:.2f}"
         print(f"\n─── Done ───")

--- a/playground/python/app/agent_studio_streaming.py
+++ b/playground/python/app/agent_studio_streaming.py
@@ -1,0 +1,135 @@
+import json
+import time
+from os import environ
+from asyncio import run
+
+from algoliasearch.agent_studio.client import AgentStudioClient
+from dotenv import load_dotenv
+
+load_dotenv("../.env")
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+app_id = environ.get("ALGOLIA_APPLICATION_ID", "")
+api_key = environ.get("ALGOLIA_ADMIN_KEY", "")
+
+if not app_id or not api_key:
+    print("[FATAL] ALGOLIA_APPLICATION_ID and ALGOLIA_ADMIN_KEY must be set in playground/.env")
+    exit(1)
+
+print(f"[CONFIG] appId={app_id}")
+print(f"[CONFIG] apiKey={api_key[:6]}...")
+
+
+async def main():
+    client = AgentStudioClient(app_id, api_key, "us")
+    print("[CLIENT] AgentStudioClient initialized")
+
+    created_agent_id = None
+
+    try:
+        # 1. Find a provider to use
+        print("\n─── Step 1: Finding a provider ───")
+        providers_response = await client.list_providers()
+        print(f"[PROVIDERS] Found {len(providers_response.data)} provider(s):")
+        for p in providers_response.data:
+            print(f"  - {p.name} (ID: {p.id})")
+
+        if not providers_response.data:
+            print("[FATAL] No providers found. Configure one first.")
+            return
+
+        provider = providers_response.data[0]
+        print(f'\n[SELECTED] Using provider: "{provider.name}" ({provider.id})')
+
+        # 2. Create a temporary agent with the provider
+        print("\n─── Step 2: Creating temporary agent ───")
+        agent = await client.create_agent(
+            agent_config_create={
+                "name": f"streaming-test-{int(time.time())}",
+                "instructions": "You are a helpful assistant. Keep your answers short and concise.",
+                "providerId": provider.id,
+                "model": "gpt-4.1-mini",
+            }
+        )
+        created_agent_id = agent.id
+        print(f'[CREATED] Agent "{agent.name}" (ID: {agent.id})')
+        print(f"[CREATED] Status: {agent.status}")
+
+        # Publish the agent so it can serve completions
+        print("[PUBLISH] Publishing agent...")
+        await client.publish_agent(agent_id=agent.id)
+        print("[PUBLISH] Agent published")
+
+        # 3. Call the streaming endpoint
+        print("\n─── Step 3: Calling create_agent_completion_stream ───")
+        print('[REQUEST] Sending message: "Hello, what can you do?"')
+        print("[REQUEST] compatibility_mode: ai-sdk-5")
+        print("[REQUEST] stream: True")
+
+        start_time = time.time()
+        event_count = 0
+
+        stream = client.create_agent_completion_stream(
+            agent_id=agent.id,
+            compatibility_mode="ai-sdk-5",
+            stream=True,
+            agent_completion_request={
+                "messages": [
+                    {
+                        "role": "user",
+                        "parts": [{"type": "text", "text": "Hello, what can you do? Keep it short."}],
+                    }
+                ],
+            },
+        )
+
+        print("[STREAM] Stream object created, iterating events...\n")
+
+        # 4. Iterate over SSE events
+        print("─── Step 4: Receiving SSE events ───")
+        async for event in stream:
+            event_count += 1
+            elapsed = f"{time.time() - start_time:.2f}"
+
+            print(f"\n[EVENT #{event_count}] (t+{elapsed}s)")
+            print(f'  event: "{event.event}"')
+            print(f'  id:    "{event.id}"')
+            print(f"  retry: {event.retry}")
+
+            # Show data (truncate if too long)
+            data_preview = (
+                event.data[:200] + "..." if len(event.data) > 200 else event.data
+            )
+            print(f"  data:  {data_preview}")
+
+            # Try to parse data as JSON
+            if event.data:
+                try:
+                    parsed = json.loads(event.data)
+                    keys = ", ".join(parsed.keys()) if isinstance(parsed, dict) else str(type(parsed).__name__)
+                    print(f"  [PARSED JSON] type={type(parsed).__name__}, keys=[{keys}]")
+                except (json.JSONDecodeError, ValueError):
+                    print("  [RAW TEXT] (not JSON)")
+
+        total_time = f"{time.time() - start_time:.2f}"
+        print(f"\n─── Done ───")
+        print(f"[SUMMARY] Received {event_count} events in {total_time}s")
+
+    except Exception as e:
+        print(f"\n[ERROR] {type(e).__name__}: {e}")
+        raise
+    finally:
+        # 5. Teardown: delete the temporary agent
+        if created_agent_id:
+            print(f"\n─── Teardown ───")
+            try:
+                await client.delete_agent(agent_id=created_agent_id)
+                print(f"[DELETED] Agent {created_agent_id}")
+            except Exception as e:
+                print(f"[TEARDOWN ERROR] Failed to delete agent {created_agent_id}: {e}")
+
+        await client.close()
+        print("[CLIENT] Closed")
+
+
+run(main())

--- a/specs/agent-studio/common/schemas/CompatibilityMode.yml
+++ b/specs/agent-studio/common/schemas/CompatibilityMode.yml
@@ -4,4 +4,7 @@ CompatibilityMode:
     - ai-sdk-4
     - ai-sdk-5
   title: compatibilityMode
-  description: Support Compatibility modes for the completion API.
+  description: >-
+    Compatibility mode for the completion API.
+    `ai-sdk-4` uses a proprietary response format that is incompatible with server-sent events (SSE). Streaming isn't supported for this mode.
+    `ai-sdk-5` supports both `application/json` and `text/event-stream` responses.

--- a/specs/agent-studio/paths/agents/agentCompletions.yml
+++ b/specs/agent-studio/paths/agents/agentCompletions.yml
@@ -2,6 +2,7 @@ post:
   tags:
     - Completions
   operationId: createAgentCompletion
+  x-streaming: true
   x-acl:
     - search
   summary: Create Completion
@@ -61,6 +62,9 @@ post:
         application/json:
           schema:
             $ref: '../../common/schemas/AgentCompletionResponse.yml#/AgentCompletionResponse'
+        text/event-stream:
+          schema:
+            type: string
     '422':
       description: Validation Error.
       content:

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -181,7 +181,10 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
     },
     {{#vendorExtensions.x-streaming}}
     /**
-     * {{nickname}} as a streaming response.
+     * {{#notes}}{{{.}}} {{/notes}}(streaming version).
+     *
+     * Each event's `data` field contains a JSON-encoded `{{{returnType}}}` object.
+     *
      * @see {{nickname}} for the non-streaming version.
      */
     {{nickname}}Stream( {{> client/api/operation/parameters}} ) : AsyncGenerator<ServerSentEvent> {

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -181,23 +181,24 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
     },
     {{#vendorExtensions.x-streaming}}
     /**
-     * {{#notes}}{{{.}}} {{/notes}}(streaming version).
+     * {{#notes}}{{{.}}} {{/notes}}(raw streaming version).
      *
-     * Each event's `data` field contains a JSON-encoded `{{{returnType}}}` object.
+     * Yields raw {@link ServerSentEvent} objects. Each event's `data` field contains a JSON-encoded `{{{returnType}}}` string.
      *
+     * @see {{nickname}}Stream for the parsed variant.
      * @see {{nickname}} for the non-streaming version.
      */
-    {{nickname}}Stream( {{> client/api/operation/parameters}} ) : AsyncGenerator<ServerSentEvent> {
+    {{nickname}}StreamRaw( {{> client/api/operation/parameters}} ) : AsyncGenerator<ServerSentEvent> {
       {{#allParams}}
       {{#required}}
       if ({{#isBoolean}}{{paramName}} === null || {{paramName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}{{/isBoolean}}) {
-        throw new Error('Parameter `{{paramName}}` is required when calling `{{nickname}}Stream`.');
+        throw new Error('Parameter `{{paramName}}` is required when calling `{{nickname}}StreamRaw`.');
       }
 
       {{#vars}}
       {{#required}}
       if ({{#isBoolean}}{{paramName}}.{{baseName}} === null || {{paramName}}.{{baseName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}.{{baseName}}{{/isBoolean}}) {
-        throw new Error('Parameter `{{paramName}}.{{baseName}}` is required when calling `{{nickname}}Stream`.');
+        throw new Error('Parameter `{{paramName}}.{{baseName}}` is required when calling `{{nickname}}StreamRaw`.');
       }
       {{/required}}
       {{/vars}}
@@ -235,6 +236,24 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
       };
 
       return transporter.requestStream(request, requestOptions);
+    },
+    /**
+     * {{#notes}}{{{.}}} {{/notes}}(streaming version).
+     *
+     * Yields {@link StreamEvent} objects wrapping parsed `{{{returnType}}}` payloads.
+     *
+     * @see {{nickname}}StreamRaw for the raw variant.
+     * @see {{nickname}} for the non-streaming version.
+     */
+    async *{{nickname}}Stream( {{> client/api/operation/parameters}} ) : AsyncGenerator<StreamEvent<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Record<string, unknown>{{/returnType}}>> {
+      for await (const event of this.{{nickname}}StreamRaw({{#vendorExtensions}}{{#x-create-wrapping-object}}{ {{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }{{/x-create-wrapping-object}}{{^x-create-wrapping-object}}{{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{/x-create-wrapping-object}}{{/vendorExtensions}}, requestOptions)) {
+        try {
+          const data = JSON.parse(event.data) as {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Record<string, unknown>{{/returnType}};
+          yield { data, raw: event };
+        } catch (e) {
+          yield { data: null, raw: event, error: e as Error };
+        }
+      }
     },
     {{/vendorExtensions.x-streaming}}
 

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -179,6 +179,61 @@ export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
 
       return transporter.request(request, requestOptions);
     },
+    {{#vendorExtensions.x-streaming}}
+    /**
+     * {{nickname}} as a streaming response.
+     * @see {{nickname}} for the non-streaming version.
+     */
+    {{nickname}}Stream( {{> client/api/operation/parameters}} ) : AsyncGenerator<ServerSentEvent> {
+      {{#allParams}}
+      {{#required}}
+      if ({{#isBoolean}}{{paramName}} === null || {{paramName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}{{/isBoolean}}) {
+        throw new Error('Parameter `{{paramName}}` is required when calling `{{nickname}}Stream`.');
+      }
+
+      {{#vars}}
+      {{#required}}
+      if ({{#isBoolean}}{{paramName}}.{{baseName}} === null || {{paramName}}.{{baseName}} === undefined{{/isBoolean}}{{^isBoolean}}!{{paramName}}.{{baseName}}{{/isBoolean}}) {
+        throw new Error('Parameter `{{paramName}}.{{baseName}}` is required when calling `{{nickname}}Stream`.');
+      }
+      {{/required}}
+      {{/vars}}
+
+      {{/required}}
+      {{/allParams}}
+
+      {{#vendorExtensions}}
+      const requestPath = '{{{path}}}'{{#pathParams}}.replace({{=<% %>=}}'{<%baseName%>}'<%={{ }}=%>,{{#x-is-custom-request}}{{paramName}}{{/x-is-custom-request}}{{^x-is-custom-request}}encodeURIComponent({{paramName}}){{/x-is-custom-request}}){{/pathParams}};
+      {{/vendorExtensions}}
+      const headers: Headers = {};
+      const queryParameters: QueryParameters = {{#vendorExtensions.x-is-custom-request}}parameters ? parameters : {{/vendorExtensions.x-is-custom-request}}{};
+
+      {{^vendorExtensions.x-is-custom-request}}{{#queryParams}}
+      if ({{paramName}} !== undefined) {
+        queryParameters['{{baseName}}'] = {{paramName}}.toString();
+      }
+
+      {{/queryParams}}{{/vendorExtensions.x-is-custom-request}}
+
+      {{#headerParams}}
+      if ({{paramName}} !== undefined) {
+        headers['{{baseName}}'] = {{paramName}}.toString();
+      }
+      {{/headerParams}}
+
+      const request: Request = {
+        method: '{{httpMethod}}',
+        path: requestPath,
+        queryParameters,
+        headers,
+        {{#bodyParam}}
+        data: {{paramName}}{{^required}}? {{paramName}} : {}{{/required}},
+        {{/bodyParam}}
+      };
+
+      return transporter.requestStream(request, requestOptions);
+    },
+    {{/vendorExtensions.x-streaming}}
 
     {{/operation}}
   };

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -25,6 +25,7 @@ import type {
   Request,
   RequestOptions,
   ServerSentEvent,
+  StreamEvent,
   {{#isSearchClient}}
   IterableOptions,
   {{/isSearchClient}}

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -24,6 +24,7 @@ import type {
   QueryParameters,
   Request,
   RequestOptions,
+  ServerSentEvent,
   {{#isSearchClient}}
   IterableOptions,
   {{/isSearchClient}}

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -270,6 +270,74 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         resp = {{^isSyncClient}}await {{/isSyncClient}}self.{{operationId}}_with_http_info({{#allParams}}{{paramName}},{{/allParams}}request_options)
         return resp.deserialize({{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}None{{/returnType}}, resp.raw_data)
 
+    {{#vendorExtensions.x-streaming}}
+
+    {{^isSyncClient}}async {{/isSyncClient}}def {{operationId}}_stream{{> partial_api_args}} -> {{^isSyncClient}}AsyncIterator[ServerSentEvent]{{/isSyncClient}}{{#isSyncClient}}Iterator[ServerSentEvent]{{/isSyncClient}}:
+        """
+        {{#notes}}
+        {{{.}}} (streaming version)
+        {{/notes}}
+        {{#allParams}}
+        :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
+        :type {{paramName}}: {{dataType}}{{#optional}}, optional{{/optional}}
+        {{/allParams}}
+        :param request_options: The request options to send along with the query, they will be merged with the transporter base parameters (headers, query params, timeouts, etc.). (optional)
+        :return: Returns an iterator of ServerSentEvent objects.
+        """
+
+        {{#allParams}}
+        {{#required}}
+        if {{paramName}} is None:
+            raise ValueError("Parameter `{{paramName}}` is required when calling `{{nickname}}_stream`.")
+
+        {{/required}}
+        {{/allParams}}
+
+        {{#queryParams.0}}
+        _query_parameters: Dict[str, Any] = {}
+        {{/queryParams.0}}
+        {{#headerParams.0}}
+        _headers: Dict[str, str] = {}
+        {{/headerParams.0}}
+        
+        {{#vendorExtensions}}
+        {{#queryParams}}
+        if {{paramName}} is not None:
+        {{^x-is-custom-request}}
+            _query_parameters["{{baseName}}"] = {{paramName}}
+        {{/x-is-custom-request}}
+        {{#x-is-custom-request}}
+            for _qpkey, _qpvalue in {{paramName}}.items():
+                _query_parameters[_qpkey] = _qpvalue
+        {{/x-is-custom-request}}
+        {{/queryParams}}
+        {{/vendorExtensions}}
+
+        {{#headerParams}}
+        if {{paramName}} is not None:
+            _headers['{{#lambda.lowercase}}{{baseName}}{{/lambda.lowercase}}'] = {{paramName}}
+        {{/headerParams}}
+
+        {{#bodyParam}}
+        _data = {}
+        if {{paramName}} is not None:
+            _data = {{paramName}}
+        {{/bodyParam}}
+
+        {{^isSyncClient}}async {{/isSyncClient}}for event in self._transporter.request_stream(
+            verb=Verb.{{httpMethod}},
+            path={{#vendorExtensions}}'{{{path}}}'{{#pathParams}}.replace({{=<% %>=}}'{<%baseName%>}'<%={{ }}=%>, {{#x-is-custom-request}}{{paramName}}{{/x-is-custom-request}}{{^x-is-custom-request}}quote(str({{paramName}}), safe=''){{/x-is-custom-request}}){{/pathParams}},{{/vendorExtensions}}
+            request_options=self._request_options.merge(
+                {{#queryParams.0}}query_parameters=_query_parameters,{{/queryParams.0}}
+                {{#headerParams.0}}headers=_headers,{{/headerParams.0}}
+                {{#bodyParam}}data=dumps(body_serializer(_data)),{{/bodyParam}}
+                user_request_options=request_options,
+            ),
+            use_read_transporter={{#vendorExtensions}}{{#x-use-read-transporter}}True{{/x-use-read-transporter}}{{^x-use-read-transporter}}False{{/x-use-read-transporter}}{{/vendorExtensions}},
+        ):
+            yield event
+
+    {{/vendorExtensions.x-streaming}}
 {{/operation}}
 {{/operations}}
 {{/modes}}

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -275,14 +275,17 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
     {{^isSyncClient}}async {{/isSyncClient}}def {{operationId}}_stream{{> partial_api_args}} -> {{^isSyncClient}}AsyncIterator[ServerSentEvent]{{/isSyncClient}}{{#isSyncClient}}Iterator[ServerSentEvent]{{/isSyncClient}}:
         """
         {{#notes}}
-        {{{.}}} (streaming version)
+        {{{.}}} (streaming version).
         {{/notes}}
+
+        {{#returnType}}Each event's ``data`` field contains a JSON-encoded ``{{{returnType}}}`` object.{{/returnType}}
+
         {{#allParams}}
         :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
         :type {{paramName}}: {{dataType}}{{#optional}}, optional{{/optional}}
         {{/allParams}}
         :param request_options: The request options to send along with the query, they will be merged with the transporter base parameters (headers, query params, timeouts, etc.). (optional)
-        :return: Returns an iterator of ServerSentEvent objects.
+        :return: Returns an iterator of ServerSentEvent objects.{{#returnType}} Each event's ``data`` field contains JSON-encoded ``{{{returnType}}}``.{{/returnType}}
         """
 
         {{#allParams}}

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -272,13 +272,13 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
 
     {{#vendorExtensions.x-streaming}}
 
-    {{^isSyncClient}}async {{/isSyncClient}}def {{operationId}}_stream{{> partial_api_args}} -> {{^isSyncClient}}AsyncIterator[ServerSentEvent]{{/isSyncClient}}{{#isSyncClient}}Iterator[ServerSentEvent]{{/isSyncClient}}:
+    {{^isSyncClient}}async {{/isSyncClient}}def {{operationId}}_stream_raw{{> partial_api_args}} -> {{^isSyncClient}}AsyncIterator[ServerSentEvent]{{/isSyncClient}}{{#isSyncClient}}Iterator[ServerSentEvent]{{/isSyncClient}}:
         """
         {{#notes}}
-        {{{.}}} (streaming version).
+        {{{.}}} (raw streaming version).
         {{/notes}}
 
-        {{#returnType}}Each event's ``data`` field contains a JSON-encoded ``{{{returnType}}}`` object.{{/returnType}}
+        Yields raw :class:`ServerSentEvent` objects.{{#returnType}} Each event's ``data`` field contains a JSON-encoded ``{{{returnType}}}`` string.{{/returnType}}
 
         {{#allParams}}
         :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
@@ -291,7 +291,7 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         {{#allParams}}
         {{#required}}
         if {{paramName}} is None:
-            raise ValueError("Parameter `{{paramName}}` is required when calling `{{nickname}}_stream`.")
+            raise ValueError("Parameter `{{paramName}}` is required when calling `{{nickname}}_stream_raw`.")
 
         {{/required}}
         {{/allParams}}
@@ -339,6 +339,29 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
             use_read_transporter={{#vendorExtensions}}{{#x-use-read-transporter}}True{{/x-use-read-transporter}}{{^x-use-read-transporter}}False{{/x-use-read-transporter}}{{/vendorExtensions}},
         ):
             yield event
+
+    {{^isSyncClient}}async {{/isSyncClient}}def {{operationId}}_stream{{> partial_api_args}} -> {{^isSyncClient}}AsyncIterator[StreamEvent[{{{returnType}}}{{^returnType}}object{{/returnType}}]]{{/isSyncClient}}{{#isSyncClient}}Iterator[StreamEvent[{{{returnType}}}{{^returnType}}object{{/returnType}}]]{{/isSyncClient}}:
+        """
+        {{#notes}}
+        {{{.}}} (streaming version).
+        {{/notes}}
+
+        Yields :class:`StreamEvent` objects wrapping parsed ``{{{returnType}}}{{^returnType}}object{{/returnType}}`` payloads.
+
+        {{#allParams}}
+        :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
+        :type {{paramName}}: {{dataType}}{{#optional}}, optional{{/optional}}
+        {{/allParams}}
+        :param request_options: The request options to send along with the query, they will be merged with the transporter base parameters (headers, query params, timeouts, etc.). (optional)
+        :return: Returns an iterator of :class:`StreamEvent[{{{returnType}}}{{^returnType}}object{{/returnType}}]` objects.
+        """
+
+        {{^isSyncClient}}async {{/isSyncClient}}for event in self.{{operationId}}_stream_raw({{#allParams}}{{paramName}},{{/allParams}}request_options):
+            try:
+                _parsed = ApiResponse.deserialize({{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}None{{/returnType}}, event.data)
+                yield StreamEvent(data=_parsed, raw=event)
+            except Exception as e:
+                yield StreamEvent(data=None, raw=event, error=e)
 
     {{/vendorExtensions.x-streaming}}
 {{/operation}}

--- a/templates/python/imports.mustache
+++ b/templates/python/imports.mustache
@@ -57,6 +57,6 @@ from algoliasearch.http.serializer import body_serializer, QueryParametersSerial
 from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.transporter_sync import TransporterSync
 from algoliasearch.http.verb import Verb
-from algoliasearch.http.sse import ServerSentEvent
+from algoliasearch.http.sse import ServerSentEvent, StreamEvent
 
 from algoliasearch.{{packageName}}.config import {{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}

--- a/templates/python/imports.mustache
+++ b/templates/python/imports.mustache
@@ -29,6 +29,7 @@ from pydantic import (
 )
 from typing import (
   Any,
+  AsyncIterator,
   Callable,
   ClassVar,
   Dict,
@@ -56,5 +57,6 @@ from algoliasearch.http.serializer import body_serializer, QueryParametersSerial
 from algoliasearch.http.transporter import Transporter
 from algoliasearch.http.transporter_sync import TransporterSync
 from algoliasearch.http.verb import Verb
+from algoliasearch.http.sse import ServerSentEvent
 
 from algoliasearch.{{packageName}}.config import {{#lambda.pascalcase}}{{client}}Config{{/lambda.pascalcase}}

--- a/tests/output/python/tests/manual/test_sse.py
+++ b/tests/output/python/tests/manual/test_sse.py
@@ -1,0 +1,407 @@
+"""Tests for the WHATWG-compliant SSE parser.
+
+Covers all 16 WHATWG spec cases plus boundary/overflow edge cases,
+for both sync (iter_sse_events) and async (aiter_sse_events) variants.
+"""
+
+import asyncio
+from typing import AsyncIterator, List
+
+import pytest
+
+from algoliasearch.http.sse import ServerSentEvent, aiter_sse_events, iter_sse_events
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_byte_chunks(text: str) -> List[bytes]:
+    """Convert a string to a list with a single bytes chunk."""
+    return [text.encode("utf-8")]
+
+
+def make_multi_chunks(chunks: List[str]) -> List[bytes]:
+    """Convert multiple strings to bytes chunks."""
+    return [c.encode("utf-8") for c in chunks]
+
+
+class AsyncByteIter:
+    """Wraps a list of bytes into an async iterable."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def collect_sync(text: str) -> List[ServerSentEvent]:
+    """Collect all SSE events from a text string (sync)."""
+    return list(iter_sse_events(make_byte_chunks(text)))
+
+
+def collect_sync_multi(chunks: List[str]) -> List[ServerSentEvent]:
+    """Collect all SSE events from multiple text chunks (sync)."""
+    return list(iter_sse_events(make_multi_chunks(chunks)))
+
+
+def collect_sync_raw(raw_chunks: List[bytes]) -> List[ServerSentEvent]:
+    """Collect all SSE events from raw byte chunks (sync)."""
+    return list(iter_sse_events(raw_chunks))
+
+
+async def _collect_async(chunks: List[bytes]) -> List[ServerSentEvent]:
+    """Collect all SSE events from byte chunks (async)."""
+    result: List[ServerSentEvent] = []
+    async for event in aiter_sse_events(AsyncByteIter(chunks)):
+        result.append(event)
+    return result
+
+
+def collect_async(text: str) -> List[ServerSentEvent]:
+    """Collect all SSE events from a text string (async, run via asyncio)."""
+    return asyncio.run(_collect_async(make_byte_chunks(text)))
+
+
+def collect_async_multi(chunks: List[str]) -> List[ServerSentEvent]:
+    """Collect all SSE events from multiple text chunks (async)."""
+    return asyncio.run(_collect_async(make_multi_chunks(chunks)))
+
+
+def collect_async_raw(raw_chunks: List[bytes]) -> List[ServerSentEvent]:
+    """Collect all SSE events from raw byte chunks (async)."""
+    return asyncio.run(_collect_async(raw_chunks))
+
+
+# ---------------------------------------------------------------------------
+# 1. Single data event
+# ---------------------------------------------------------------------------
+
+
+class TestSingleDataEvent:
+    def test_sync(self) -> None:
+        events = collect_sync("data: hello\n\n")
+        assert len(events) == 1
+        assert events[0] == ServerSentEvent(data="hello", event="", id=None, retry=None)
+
+    def test_async(self) -> None:
+        events = collect_async("data: hello\n\n")
+        assert len(events) == 1
+        assert events[0] == ServerSentEvent(data="hello", event="", id=None, retry=None)
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-line data
+# ---------------------------------------------------------------------------
+
+
+class TestMultiLineData:
+    def test_sync(self) -> None:
+        events = collect_sync("data: line1\ndata: line2\n\n")
+        assert len(events) == 1
+        assert events[0].data == "line1\nline2"
+
+    def test_async(self) -> None:
+        events = collect_async("data: line1\ndata: line2\n\n")
+        assert len(events) == 1
+        assert events[0].data == "line1\nline2"
+
+
+# ---------------------------------------------------------------------------
+# 3. Event type
+# ---------------------------------------------------------------------------
+
+
+class TestEventType:
+    def test_sync(self) -> None:
+        events = collect_sync("event: custom\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].event == "custom"
+        assert events[0].data == "hi"
+
+    def test_async(self) -> None:
+        events = collect_async("event: custom\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].event == "custom"
+        assert events[0].data == "hi"
+
+
+# ---------------------------------------------------------------------------
+# 4. Comment ignored
+# ---------------------------------------------------------------------------
+
+
+class TestCommentIgnored:
+    def test_sync(self) -> None:
+        events = collect_sync(": comment\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+
+    def test_async(self) -> None:
+        events = collect_async(": comment\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty data suppressed (no data field → no dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDataSuppressed:
+    def test_sync(self) -> None:
+        events = collect_sync("event: ping\n\n")
+        assert len(events) == 0
+
+    def test_async(self) -> None:
+        events = collect_async("event: ping\n\n")
+        assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Field with no colon
+# ---------------------------------------------------------------------------
+
+
+class TestFieldNoColon:
+    def test_sync(self) -> None:
+        events = collect_sync("data\n\n")
+        assert len(events) == 1
+        assert events[0].data == ""
+
+    def test_async(self) -> None:
+        events = collect_async("data\n\n")
+        assert len(events) == 1
+        assert events[0].data == ""
+
+
+# ---------------------------------------------------------------------------
+# 7. Single space strip (two spaces in, one space out)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleSpaceStrip:
+    def test_sync(self) -> None:
+        events = collect_sync("data:  hello\n\n")
+        assert len(events) == 1
+        assert events[0].data == " hello"
+
+    def test_async(self) -> None:
+        events = collect_async("data:  hello\n\n")
+        assert len(events) == 1
+        assert events[0].data == " hello"
+
+
+# ---------------------------------------------------------------------------
+# 8. Unknown field ignored
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownFieldIgnored:
+    def test_sync(self) -> None:
+        events = collect_sync("foo: bar\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+
+    def test_async(self) -> None:
+        events = collect_async("foo: bar\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+
+
+# ---------------------------------------------------------------------------
+# 9. id persistence
+# ---------------------------------------------------------------------------
+
+
+class TestIdPersistence:
+    def test_sync(self) -> None:
+        events = collect_sync("id: 42\ndata: a\n\ndata: b\n\n")
+        assert len(events) == 2
+        assert events[0].id == "42"
+        assert events[0].data == "a"
+        assert events[1].id == "42"
+        assert events[1].data == "b"
+
+    def test_async(self) -> None:
+        events = collect_async("id: 42\ndata: a\n\ndata: b\n\n")
+        assert len(events) == 2
+        assert events[0].id == "42"
+        assert events[1].id == "42"
+
+
+# ---------------------------------------------------------------------------
+# 10. id with NULL
+# ---------------------------------------------------------------------------
+
+
+class TestIdWithNull:
+    def test_sync(self) -> None:
+        events = collect_sync("id: foo\x00bar\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].id is None
+
+    def test_async(self) -> None:
+        events = collect_async("id: foo\x00bar\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].id is None
+
+
+# ---------------------------------------------------------------------------
+# 11. retry digits only
+# ---------------------------------------------------------------------------
+
+
+class TestRetryDigitsOnly:
+    def test_sync(self) -> None:
+        events = collect_sync("retry: 3000\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].retry == 3000
+
+    def test_async(self) -> None:
+        events = collect_async("retry: 3000\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].retry == 3000
+
+
+# ---------------------------------------------------------------------------
+# 12. retry non-digits
+# ---------------------------------------------------------------------------
+
+
+class TestRetryNonDigits:
+    def test_sync(self) -> None:
+        events = collect_sync("retry: 3s\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].retry is None
+
+    def test_async(self) -> None:
+        events = collect_async("retry: 3s\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].retry is None
+
+
+# ---------------------------------------------------------------------------
+# 13. CR line endings
+# ---------------------------------------------------------------------------
+
+
+class TestCRLineEndings:
+    def test_sync(self) -> None:
+        events = collect_sync("data: hello\r\r")
+        assert len(events) == 1
+        assert events[0].data == "hello"
+
+    def test_async(self) -> None:
+        events = collect_async("data: hello\r\r")
+        assert len(events) == 1
+        assert events[0].data == "hello"
+
+
+# ---------------------------------------------------------------------------
+# 14. CRLF line endings
+# ---------------------------------------------------------------------------
+
+
+class TestCRLFLineEndings:
+    def test_sync(self) -> None:
+        events = collect_sync("data: hello\r\n\r\n")
+        assert len(events) == 1
+        assert events[0].data == "hello"
+
+    def test_async(self) -> None:
+        events = collect_async("data: hello\r\n\r\n")
+        assert len(events) == 1
+        assert events[0].data == "hello"
+
+
+# ---------------------------------------------------------------------------
+# 15. Mixed line endings
+# ---------------------------------------------------------------------------
+
+
+class TestMixedLineEndings:
+    def test_sync(self) -> None:
+        events = collect_sync("data: a\rdata: b\n\n")
+        assert len(events) == 1
+        assert events[0].data == "a\nb"
+
+    def test_async(self) -> None:
+        events = collect_async("data: a\rdata: b\n\n")
+        assert len(events) == 1
+        assert events[0].data == "a\nb"
+
+
+# ---------------------------------------------------------------------------
+# 16. Stream ends mid-event (EOF without blank line)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamEndsMidEvent:
+    def test_sync(self) -> None:
+        events = collect_sync("data: partial")
+        assert len(events) == 0
+
+    def test_async(self) -> None:
+        events = collect_async("data: partial")
+        assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# 17. trailing_cr across chunk boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestTrailingCRAcrossChunks:
+    def test_sync(self) -> None:
+        events = collect_sync_raw([b"data: hello\r", b"\ndata: world\r\n\r\n"])
+        assert len(events) == 1
+        assert events[0].data == "hello\nworld"
+
+    def test_async(self) -> None:
+        events = collect_async_raw([b"data: hello\r", b"\ndata: world\r\n\r\n"])
+        assert len(events) == 1
+        assert events[0].data == "hello\nworld"
+
+
+# ---------------------------------------------------------------------------
+# 18. 10MB buffer cap
+# ---------------------------------------------------------------------------
+
+
+class TestBufferCap:
+    def test_sync(self) -> None:
+        huge_line = "data: " + "x" * (10 * 1024 * 1024 + 1)
+        with pytest.raises(ValueError, match="10 MB"):
+            collect_sync(huge_line)
+
+    def test_async(self) -> None:
+        huge_line = "data: " + "x" * (10 * 1024 * 1024 + 1)
+        with pytest.raises(ValueError, match="10 MB"):
+            collect_async(huge_line)
+
+
+# ---------------------------------------------------------------------------
+# 19. eventType resets on suppressed dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypeResetsOnSuppressedDispatch:
+    def test_sync(self) -> None:
+        events = collect_sync("event: custom\n\ndata: hi\n\n")
+        # First blank line: no data → suppressed, but eventType resets
+        # Second event: data="hi", event="" (not "custom")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+        assert events[0].event == ""
+
+    def test_async(self) -> None:
+        events = collect_async("event: custom\n\ndata: hi\n\n")
+        assert len(events) == 1
+        assert events[0].data == "hi"
+        assert events[0].event == ""

--- a/tests/output/python/tests/manual/test_sse.py
+++ b/tests/output/python/tests/manual/test_sse.py
@@ -5,9 +5,8 @@ for both sync (iter_sse_events) and async (aiter_sse_events) variants.
 """
 
 import asyncio
+import unittest
 from typing import AsyncIterator, List
-
-import pytest
 
 from algoliasearch.http.sse import ServerSentEvent, aiter_sse_events, iter_sse_events
 
@@ -83,7 +82,7 @@ def collect_async_raw(raw_chunks: List[bytes]) -> List[ServerSentEvent]:
 # ---------------------------------------------------------------------------
 
 
-class TestSingleDataEvent:
+class TestSingleDataEvent(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: hello\n\n")
         assert len(events) == 1
@@ -100,7 +99,7 @@ class TestSingleDataEvent:
 # ---------------------------------------------------------------------------
 
 
-class TestMultiLineData:
+class TestMultiLineData(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: line1\ndata: line2\n\n")
         assert len(events) == 1
@@ -117,7 +116,7 @@ class TestMultiLineData:
 # ---------------------------------------------------------------------------
 
 
-class TestEventType:
+class TestEventType(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("event: custom\ndata: hi\n\n")
         assert len(events) == 1
@@ -136,7 +135,7 @@ class TestEventType:
 # ---------------------------------------------------------------------------
 
 
-class TestCommentIgnored:
+class TestCommentIgnored(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync(": comment\ndata: hi\n\n")
         assert len(events) == 1
@@ -153,7 +152,7 @@ class TestCommentIgnored:
 # ---------------------------------------------------------------------------
 
 
-class TestEmptyDataSuppressed:
+class TestEmptyDataSuppressed(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("event: ping\n\n")
         assert len(events) == 0
@@ -168,7 +167,7 @@ class TestEmptyDataSuppressed:
 # ---------------------------------------------------------------------------
 
 
-class TestFieldNoColon:
+class TestFieldNoColon(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data\n\n")
         assert len(events) == 1
@@ -185,7 +184,7 @@ class TestFieldNoColon:
 # ---------------------------------------------------------------------------
 
 
-class TestSingleSpaceStrip:
+class TestSingleSpaceStrip(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data:  hello\n\n")
         assert len(events) == 1
@@ -202,7 +201,7 @@ class TestSingleSpaceStrip:
 # ---------------------------------------------------------------------------
 
 
-class TestUnknownFieldIgnored:
+class TestUnknownFieldIgnored(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("foo: bar\ndata: hi\n\n")
         assert len(events) == 1
@@ -219,7 +218,7 @@ class TestUnknownFieldIgnored:
 # ---------------------------------------------------------------------------
 
 
-class TestIdPersistence:
+class TestIdPersistence(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("id: 42\ndata: a\n\ndata: b\n\n")
         assert len(events) == 2
@@ -240,7 +239,7 @@ class TestIdPersistence:
 # ---------------------------------------------------------------------------
 
 
-class TestIdWithNull:
+class TestIdWithNull(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("id: foo\x00bar\ndata: hi\n\n")
         assert len(events) == 1
@@ -257,7 +256,7 @@ class TestIdWithNull:
 # ---------------------------------------------------------------------------
 
 
-class TestRetryDigitsOnly:
+class TestRetryDigitsOnly(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("retry: 3000\ndata: hi\n\n")
         assert len(events) == 1
@@ -274,7 +273,7 @@ class TestRetryDigitsOnly:
 # ---------------------------------------------------------------------------
 
 
-class TestRetryNonDigits:
+class TestRetryNonDigits(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("retry: 3s\ndata: hi\n\n")
         assert len(events) == 1
@@ -291,7 +290,7 @@ class TestRetryNonDigits:
 # ---------------------------------------------------------------------------
 
 
-class TestCRLineEndings:
+class TestCRLineEndings(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: hello\r\r")
         assert len(events) == 1
@@ -308,7 +307,7 @@ class TestCRLineEndings:
 # ---------------------------------------------------------------------------
 
 
-class TestCRLFLineEndings:
+class TestCRLFLineEndings(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: hello\r\n\r\n")
         assert len(events) == 1
@@ -325,7 +324,7 @@ class TestCRLFLineEndings:
 # ---------------------------------------------------------------------------
 
 
-class TestMixedLineEndings:
+class TestMixedLineEndings(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: a\rdata: b\n\n")
         assert len(events) == 1
@@ -342,7 +341,7 @@ class TestMixedLineEndings:
 # ---------------------------------------------------------------------------
 
 
-class TestStreamEndsMidEvent:
+class TestStreamEndsMidEvent(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("data: partial")
         assert len(events) == 0
@@ -357,7 +356,7 @@ class TestStreamEndsMidEvent:
 # ---------------------------------------------------------------------------
 
 
-class TestTrailingCRAcrossChunks:
+class TestTrailingCRAcrossChunks(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync_raw([b"data: hello\r", b"\ndata: world\r\n\r\n"])
         assert len(events) == 1
@@ -374,16 +373,26 @@ class TestTrailingCRAcrossChunks:
 # ---------------------------------------------------------------------------
 
 
-class TestBufferCap:
+class TestBufferCap(unittest.TestCase):
     def test_sync(self) -> None:
         huge_line = "data: " + "x" * (10 * 1024 * 1024 + 1)
-        with pytest.raises(ValueError, match="10 MB"):
+        raised = False
+        try:
             collect_sync(huge_line)
+        except ValueError as e:
+            raised = True
+            assert "10 MB" in str(e)
+        assert raised, "Expected ValueError to be raised"
 
     def test_async(self) -> None:
         huge_line = "data: " + "x" * (10 * 1024 * 1024 + 1)
-        with pytest.raises(ValueError, match="10 MB"):
+        raised = False
+        try:
             collect_async(huge_line)
+        except ValueError as e:
+            raised = True
+            assert "10 MB" in str(e)
+        assert raised, "Expected ValueError to be raised"
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +400,7 @@ class TestBufferCap:
 # ---------------------------------------------------------------------------
 
 
-class TestEventTypeResetsOnSuppressedDispatch:
+class TestEventTypeResetsOnSuppressedDispatch(unittest.TestCase):
     def test_sync(self) -> None:
         events = collect_sync("event: custom\n\ndata: hi\n\n")
         # First blank line: no data → suppressed, but eventType resets


### PR DESCRIPTION
Jira: API-460
## 🧭 What and Why

Adds response streaming support (Server-Sent Events) to the generated API clients, starting with JavaScript and Python.

Because OpenAPI's support for multiple content types (`application/json` + `text/event-stream`) is not wide enough for code generation, this PR introduces a custom `x-streaming: true` vendor extension that triggers generation of additional streaming methods alongside the regular REST ones.

> **Note:** 204 No Content response handling has been extracted to #6096.

---

## Changes included

### 1. Spec: Streaming Support

- **`agentCompletions.yml`** — Added `x-streaming: true` vendor extension and `text/event-stream` response content type alongside `application/json`.
- **`CompatibilityMode.yml`** — Updated description: `ai-sdk-4` doesn't support SSE streaming; `ai-sdk-5` supports both JSON and SSE responses.

### 2. JavaScript: SSE Parser & Streaming Transport

- **`client-common/src/sse.ts`** (301 lines) — WHATWG-compliant SSE parser with three-layer architecture:
  - Layer 1: `iterLines()` — byte stream → line decoding (handles CR/LF/CRLF, BOM, 10MB buffer cap)
  - Layer 2: `SSEDecoder` — line → SSE event decoding (field parsing, id/retry persistence, eventType reset)
  - Layer 3: `iterSSEEvents()` — top-level async generator composing layers 1 + 2
- **`client-common/src/sse.ts`** — Exports `ServerSentEvent` and `StreamEvent<T>` types. `StreamEvent` wraps parsed typed data + raw event + optional parse error.
- **`client-common/src/__tests__/sse.test.ts`** (156 lines) — 19 test cases covering all WHATWG spec edge cases + chunk boundaries + 10MB safety limit.
- **`createTransporter.ts`** — Added `requestStream()` method: builds request payload, sets `accept: text/event-stream`, uses first valid host (no retry logic for streams), delegates to `requester.sendStream()`, pipes through `iterSSEEvents()`.
- **`types/requester.ts`** — Added optional `sendStream?: (request) => Promise<ReadableStream<Uint8Array>>` to `Requester` interface.
- **`types/transporter.ts`** — Added `requestStream` to `Transporter` type.
- **`requester-fetch/src/createFetchRequester.ts`** — Implements `sendStream`: fetches with same config as `send`, returns `response.body` (ReadableStream).
- **`requester-node-http/src/createHttpRequester.ts`** — Implements `sendStream`: converts Node.js `IncomingMessage` to a `ReadableStream<Uint8Array>` via `ReadableStream` constructor with pull-based backpressure.

### 3. Python: SSE Parser & Streaming Transport

- **`algoliasearch/http/sse.py`** (302 lines) — WHATWG-compliant SSE parser, mirroring the JS implementation:
  - `_iter_lines()` (sync) / `_aiter_lines()` (async) — byte stream → text lines
  - `SSEDecoder` — shared line-to-event decoder
  - `iter_sse_events()` (sync) / `aiter_sse_events()` (async) — top-level composers
  - Exports `ServerSentEvent` dataclass and `StreamEvent[T]` generic wrapper.
- **`algoliasearch/tests/test_sse.py`** (416 lines) — 19 WHATWG spec cases × 2 (sync + async) + chunk boundary + overflow tests (unittest.TestCase classes).
- **`algoliasearch/http/transporter.py`** — Added `request_stream()` async method: sets `accept: text/event-stream`, opens aiohttp request, streams through `aiter_sse_events(resp.content.iter_any())`.
- **`algoliasearch/http/transporter_sync.py`** — Added `request_stream()` sync method: opens requests session with `stream=True`, pipes through `iter_sse_events(resp.iter_content())`.

### 4. Code Generation Templates: Streaming Methods

- **`templates/javascript/clients/api-single.mustache`** — When `x-streaming` is true, generates two additional methods:
  - `*StreamRaw()` — yields raw `ServerSentEvent` objects via `transporter.requestStream()`
  - `*Stream()` — yields `StreamEvent<ReturnType>` with JSON-parsed data, error handling
- **`templates/javascript/clients/client/api/imports.mustache`** — Imports `ServerSentEvent` and `StreamEvent` types.
- **`templates/python/api.mustache`** — When `x-streaming` is true, generates two additional methods (sync + async variants):
  - `*_stream_raw()` — yields raw `ServerSentEvent` objects
  - `*_stream()` — yields `StreamEvent[ReturnType]` with deserialized data, error handling
- **`templates/python/imports.mustache`** — Imports `ServerSentEvent`, `StreamEvent`, `AsyncIterator`, `Iterator`.

### 5. Streaming Playgrounds

- **`playground/javascript/node/agentStudioStreaming.ts`** (131 lines) — End-to-end streaming demo: finds provider → creates temp agent → publishes → calls `createAgentCompletionStream` → iterates typed events → deletes agent.
- **`playground/python/app/agent_studio_streaming.py`** (125 lines) — Same flow for Python async client.

### 6. Other

- **`templates/python/api.mustache`** — Python test classes now use `unittest.TestCase` base class.
- Updated `CompatibilityMode` description to document SSE streaming support per compatibility mode.