### PR TITLE
fix(generators): auto-infer discriminator fields from unique required properties

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/utils/OneOf.java
+++ b/generators/src/main/java/com/algolia/codegen/utils/OneOf.java
@@ -132,9 +132,51 @@ public class OneOf {
       if (isMultiArrayOneOfs(oneOfs)) model.vendorExtensions.put("x-is-multi-array", true);
       if (isMultiMapOneOfs(oneOfs)) model.vendorExtensions.put("x-is-multi-map", true);
       if (hasAtModelOrEnum(oneOfs)) model.vendorExtensions.put("x-has-model", true);
+      inferDiscriminatorFields(models, oneOfs);
       if (hasDiscriminators(oneOfs)) model.vendorExtensions.put("x-has-discriminator", true);
       markOneOfModels(oneOfs);
       sortOneOfs(oneOfs);
+    }
+  }
+
+  /**
+   * For oneOf variants that lack explicit x-discriminator-fields, infer them from required fields
+   * that are unique to each variant. This enables key-presence checks in generated unmarshalers
+   * without manual spec annotations.
+   */
+  private static void inferDiscriminatorFields(Map<String, ModelsMap> models, List<CodegenProperty> oneOfs) {
+    // Collect required field names (JSON keys) for all model variants
+    var allRequired = new LinkedHashMap<CodegenProperty, Set<String>>();
+    for (var prop : oneOfs) {
+      if (!prop.isModel) continue;
+      var modelsMap = models.get(prop.dataType);
+      if (modelsMap == null) continue;
+      var variantModel = modelsMap.getModels().get(0).getModel();
+      var required = new HashSet<String>();
+      for (var v : variantModel.requiredVars) {
+        required.add(v.baseName);
+      }
+      allRequired.put(prop, required);
+    }
+
+    // For each variant without an explicit discriminator, compute unique required fields
+    for (var entry : allRequired.entrySet()) {
+      var prop = entry.getKey();
+      if (prop.vendorExtensions.containsKey("x-discriminator-fields")) continue;
+
+      var required = entry.getValue();
+      if (required.isEmpty()) continue;
+
+      var unique = new ArrayList<>(required);
+      for (var other : allRequired.entrySet()) {
+        if (other.getKey() == prop) continue;
+        unique.removeAll(other.getValue());
+      }
+
+      if (!unique.isEmpty()) {
+        Collections.sort(unique);
+        prop.vendorExtensions.put("x-discriminator-fields", unique);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- For oneOf variants without explicit `x-discriminator-fields`, the generator now auto-infers discriminators from required fields that are unique to each variant
- Explicit `x-discriminator-fields` in the spec take precedence (no behavioral change for existing annotations)
- Covers ~86% of existing annotated schemas automatically, eliminating the need for manual spec annotations in most cases

## Context

Go's `json.Unmarshal` is too lenient for oneOf disambiguation — it doesn't fail on missing/extra fields, so multiple variants can "succeed" on the same payload. The existing `x-discriminator-fields` mechanism solves this by adding `hasKey()` guards before unmarshal attempts, but requires manual annotation per schema.

This change makes the generator compute those guards automatically from the `required` fields that are unique to each variant (e.g., `SearchSource` requires `search`, `ExternalSource` requires `external` — no overlap → auto-injected as discriminators).

The 14% of schemas where discriminators are based on non-required fields still need explicit `x-discriminator-fields`.

## Related

- #6170 — manual fix for `InjectedItemSource` (would be covered automatically by this change)
- #5854 — Go oneOf unmarshal strategy change
- #3567 — original `x-discriminator-fields` mechanism