### PR TITLE
docs(insights): Update the user token deletion summary

### DIFF
--- a/specs/insights/paths/deleteUserToken.yml
+++ b/specs/insights/paths/deleteUserToken.yml
@@ -2,7 +2,7 @@ delete:
   tags:
     - usertokens
   operationId: deleteUserToken
-  summary: Delete user token
+  summary: Delete user token events
   description: |
     Deletes all events related to the specified user token from events metrics and analytics.
     The deletion is asynchronous, and processed within 48 hours.


### PR DESCRIPTION
## 🧭 What and Why

Update the summary of the user token deletion API to make it clear we delete events, not user tokens

corresponding docs change: https://github.com/algolia/docs-new/pull/714

### Changes included:

- user token deletion summary

## 🧪 Test
N/A