### PR TITLE
fix(clients): push helper smooth traffic

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/IngestionClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/IngestionClientExtensions.cs
@@ -163,6 +163,7 @@ public partial class IngestionClient : IIngestionClient
               },
               eventResponse => eventResponse != null,
               maxRetries: 50,
+              timeout: retryCount => Math.Min(retryCount * 1500, 5000),
               ct: cancellationToken
             )
             .ConfigureAwait(false);

--- a/clients/algoliasearch-client-python/algoliasearch/http/helpers.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/helpers.py
@@ -24,7 +24,7 @@ async def create_iterable(
     func: Callable[[Optional[T]], Awaitable[T]],
     validate: Callable[[T], bool],
     aggregator: Optional[Callable[[T], None]],
-    timeout: Callable[[], int] = Timeout(),
+    timeout: Callable[[], float] = Timeout(),
     error_validate: Optional[Callable[[T], bool]] = None,
     error_message: Optional[Callable[[T], str]] = None,
 ) -> T:
@@ -56,7 +56,7 @@ def create_iterable_sync(
     func: Callable[[Optional[T]], T],
     validate: Callable[[T], bool],
     aggregator: Optional[Callable[[T], None]],
-    timeout: Callable[[], int] = Timeout(),
+    timeout: Callable[[], float] = Timeout(),
     error_validate: Optional[Callable[[T], bool]] = None,
     error_message: Optional[Callable[[T], str]] = None,
 ) -> T:

--- a/templates/go/ingestion_helpers.mustache
+++ b/templates/go/ingestion_helpers.mustache
@@ -16,14 +16,14 @@ func (c *APIClient) ChunkedPush(indexName string, objects []map[string]any, acti
 		batchSize:    1000,
 	}
 
+	for _, opt := range opts {
+		opt.apply(&conf)
+	}
+
 	offset := 0
 	waitBatchSize := conf.batchSize / 10
 	if waitBatchSize < 1 {
 		waitBatchSize = conf.batchSize
-	}
-
-	for _, opt := range opts {
-		opt.apply(&conf)
 	}
 
 	records := make([]map[string]any, 0, len(objects)%conf.batchSize)
@@ -70,7 +70,7 @@ func (c *APIClient) ChunkedPush(indexName string, objects []map[string]any, acti
 			var waitableResponses []WatchResponse
 
 			if len(responses) > offset+waitBatchSize {
-				waitableResponses = responses[offset:waitBatchSize]
+				waitableResponses = responses[offset:offset+waitBatchSize]
 			} else {
 				waitableResponses = responses[offset:]
 			}
@@ -92,7 +92,7 @@ func (c *APIClient) ChunkedPush(indexName string, objects []map[string]any, acti
 
 						return true, err
 					},
-					WithTimeout(func(count int) time.Duration { return time.Duration(min(500*count, 5000)) * time.Millisecond }), WithMaxRetries(50),
+					WithTimeout(func(count int) time.Duration { return time.Duration(min(1500*count, 5000)) * time.Millisecond }), WithMaxRetries(50),
 				)
 				if err != nil {
 					return nil, err

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -99,7 +99,7 @@ public <T> List<WatchResponse> chunkedPush(
               return resp != null;
             },
             50,
-            null
+            (retries) -> Math.min(retries * 1500, 5000)
           );
         });
 

--- a/templates/javascript/clients/client/api/ingestionHelpers.mustache
+++ b/templates/javascript/clients/client/api/ingestionHelpers.mustache
@@ -65,7 +65,7 @@ async chunkedPush(
             validate: () => retryCount >= 50,
             message: () => `The maximum number of retries exceeded. (${retryCount}/${50})`,
           },
-          timeout: (): number => Math.min(retryCount * 500, 5000),
+          timeout: (): number => Math.min(retryCount * 1500, 5000),
         });
       }
       offset += waitBatchSize;

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -395,8 +395,6 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
             }
 
             if ($waitForTasks && !empty($responses) && (0 === sizeof($responses) % $waitBatchSize || $count === sizeof($objects))) {
-                $timeoutCalculation = 'Algolia\AlgoliaSearch\Support\Helpers::linearTimeout';
-
                 foreach (array_slice($responses, $offset, $waitBatchSize) as $response) {
                     $retry = 0;
 
@@ -412,9 +410,7 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
                         }
 
                         ++$retry;
-                        usleep(
-                            call_user_func_array($timeoutCalculation, [$this->config->getWaitTaskTimeBeforeRetry(), $retry])
-                        );
+                        usleep(min($retry * 1500, 5000) * 1000);
                     }
 
                     if (false === $ok) {

--- a/templates/python/ingestion_helpers.mustache
+++ b/templates/python/ingestion_helpers.mustache
@@ -64,13 +64,11 @@
                     def _validate(_resp: Event | None) -> bool:
                         return _resp is not None
 
-                    timeout = RetryTimeout()
-
                     {{^isSyncClient}}await {{/isSyncClient}}create_iterable{{#isSyncClient}}_sync{{/isSyncClient}}(
                         func=_func,
                         validate=_validate,
                         aggregator=_aggregator,
-                        timeout=lambda: timeout(_retry_count),
+                        timeout=lambda: min(_retry_count * 1.5, 5),
                         error_validate=lambda _: _retry_count >= 50,
                         error_message=lambda _: f"The maximum number of retries exceeded. (${_retry_count}/${50})",
                     )

--- a/templates/python/ingestion_helpers.mustache
+++ b/templates/python/ingestion_helpers.mustache
@@ -68,7 +68,7 @@
                         func=_func,
                         validate=_validate,
                         aggregator=_aggregator,
-                        timeout=lambda: min(_retry_count * 1.5, 5),
+                        timeout=lambda: float(min(_retry_count * 1.5, 5)),
                         error_validate=lambda _: _retry_count >= 50,
                         error_message=lambda _: f"The maximum number of retries exceeded. (${_retry_count}/${50})",
                     )


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: https://algolia.atlassian.net/browse/DI-4807

### Changes included:

a push request takes in average 4.1s for completion, so we can increase the retry timeout logic to avoid spamming the API