### PR TITLE
feat(javascript): add transformationOptions and fix ingestion config leak

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -144,29 +144,29 @@ describe('api', () => {
   });
 
   describe('bridge methods', () => {
-    test('throws when missing transformation.region', () => {
+    test('throws when missing transformationOptions.region', () => {
       //@ts-expect-error
-      expect(() => algoliasearch('APP_ID', 'API_KEY', { transformation: {} })).toThrow(
-        '`region` must be provided when leveraging the transformation pipeline',
+      expect(() => algoliasearch('APP_ID', 'API_KEY', { transformationOptions: {} })).toThrow(
+        '`region` is required in `transformationOptions`.',
       );
     });
 
     test('throws when calling the transformation methods without init parameters', async () => {
-      await expect(
+     await expect(
         client.saveObjectsWithTransformation({
           indexName: 'foo',
           objects: [{ objectID: 'bar', baz: 42 }],
           waitForTasks: true,
         }),
-      ).rejects.toThrow('`transformation.region` must be provided at client instantiation before calling this method.');
+      ).rejects.toThrow('`transformationOptions` must be set in the client config before calling this method.');
 
-      await expect(
+     await expect(
         client.partialUpdateObjectsWithTransformation({
           indexName: 'foo',
           objects: [{ objectID: 'bar', baz: 42 }],
           waitForTasks: true,
         }),
-      ).rejects.toThrow('`transformation.region` must be provided at client instantiation before calling this method.');
+      ).rejects.toThrow('`transformationOptions` must be set in the client config before calling this method.');
     });
   });
 });

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -152,7 +152,7 @@ describe('api', () => {
     });
 
     test('throws when calling the transformation methods without init parameters', async () => {
-     await expect(
+      await expect(
         client.saveObjectsWithTransformation({
           indexName: 'foo',
           objects: [{ objectID: 'bar', baz: 42 }],
@@ -160,7 +160,7 @@ describe('api', () => {
         }),
       ).rejects.toThrow('`transformationOptions` must be set in the client config before calling this method.');
 
-     await expect(
+      await expect(
         client.partialUpdateObjectsWithTransformation({
           indexName: 'foo',
           objects: [{ objectID: 'bar', baz: 42 }],

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
@@ -102,6 +102,21 @@ public class TestsClient extends TestsGenerator {
                 stepOut.put("transformationRegion", step.parameters.get("transformationRegion"));
               }
 
+              boolean hasTransformationOptions = step.parameters != null && step.parameters.containsKey("transformationOptions");
+              if (hasTransformationOptions) {
+                testOut.put("useEchoRequester", false);
+                Map<String, Object> transformationOptions = (Map<String, Object>) step.parameters.get("transformationOptions");
+                stepOut.put("transformationRegion", transformationOptions.get("region"));
+                stepOut.put("hasTransformationRegion", true);
+
+                boolean hasTransformationCustomHosts = transformationOptions.containsKey("customHosts");
+                stepOut.put("hasTransformationCustomHosts", hasTransformationCustomHosts);
+                if (hasTransformationCustomHosts) {
+                  stepOut.put("transformationCustomHosts", transformationOptions.get("customHosts"));
+                }
+              }
+              stepOut.put("hasTransformationOptions", hasTransformationOptions);
+
               boolean gzipEncoding = step.parameters != null && step.parameters.getOrDefault("gzip", false).equals(true);
               stepOut.put("gzipEncoding", gzipEncoding);
             } else if (step.type.equals("method")) {

--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -79,6 +79,11 @@ export type Algoliasearch = SearchClient & {
 
 export type TransformationOptions = {
   // When provided, a second transporter will be created in order to leverage the `*WithTransformation` methods exposed by the Push connector (https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/connectors/push/).
+  transformationOptions?: {
+    region: IngestionRegion;
+  } & ClientOptions;
+
+  /** @deprecated Use `transformationOptions` instead. */
   transformation?: {
     // The region of your Algolia application ID, used to target the correct hosts of the transformation service.
     region: IngestionRegion;
@@ -100,14 +105,22 @@ export function algoliasearch(
 
   const client = searchClient(appId, apiKey, options);
 
-  let ingestionTransporter: IngestionClient | undefined;
+  let transformationConfig: { region: IngestionRegion } & ClientOptions | undefined;
 
-  if (options?.transformation) {
-    if (!options.transformation.region) {
-      throw new Error('`region` must be provided when leveraging the transformation pipeline');
+  if (options?.transformationOptions) {
+    transformationConfig = options.transformationOptions;
+  } else if (options?.transformation) {
+    transformationConfig = { region: options.transformation.region };
+  }
+
+  let ingestionTransporter: IngestionClient | undefined;
+  if (transformationConfig) {
+    if (!transformationConfig.region) {
+      throw new Error('`region` is required in `transformationOptions`. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
     }
 
-    ingestionTransporter = ingestionClient(appId, apiKey, options.transformation.region, options);
+    const { region, ...ingestionOptions } = transformationConfig;
+    ingestionTransporter = ingestionClient(appId, apiKey, region, ingestionOptions);
   }
 
   return {
@@ -115,11 +128,7 @@ export function algoliasearch(
 
     async saveObjectsWithTransformation({ indexName, objects, waitForTasks }, requestOptions): Promise<Array<WatchResponse>> {
       if (!ingestionTransporter) {
-        throw new Error('`transformation.region` must be provided at client instantiation before calling this method.');
-      }
-
-      if (!options?.transformation?.region) {
-        throw new Error('`region` must be provided when leveraging the transformation pipeline');
+        throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
       return ingestionTransporter.chunkedPush({ indexName, objects, action: 'addObject', waitForTasks }, requestOptions);
@@ -130,11 +139,7 @@ export function algoliasearch(
       requestOptions,
     ): Promise<Array<WatchResponse>> {
       if (!ingestionTransporter) {
-        throw new Error('`transformation.region` must be provided at client instantiation before calling this method.');
-      }
-
-      if (!options?.transformation?.region) {
-        throw new Error('`region` must be provided when leveraging the transformation pipeline');
+        throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
       return ingestionTransporter.chunkedPush({ indexName, objects, action: createIfNotExists ? 'partialUpdateObject' : 'partialUpdateObjectNoCreate', waitForTasks }, requestOptions);
@@ -145,11 +150,7 @@ export function algoliasearch(
       requestOptions?: RequestOptions | undefined,
     ): Promise<ReplaceAllObjectsWithTransformationResponse> {
       if (!ingestionTransporter) {
-        throw new Error('`transformation.region` must be provided at client instantiation before calling this method.');
-      }
-
-      if (!options?.transformation?.region) {
-        throw new Error('`region` must be provided when leveraging the transformation pipeline');
+        throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
       const randomSuffix = Math.floor(Math.random() * 1000000) + 100000;

--- a/templates/javascript/tests/client/createClient.mustache
+++ b/templates/javascript/tests/client/createClient.mustache
@@ -23,7 +23,21 @@
     compression: 'gzip',
     {{/gzipEncoding}}
     {{#hasTransformationRegion}}
-    transformation: { region : "{{{transformationRegion}}}" },
+    transformationOptions: {
+      region : "{{{transformationRegion}}}",
+      {{#hasTransformationCustomHosts}}
+        hosts:[
+        {{#transformationCustomHosts}}
+        {
+          url: 'localhost',
+          port: {{port}},
+          accept: 'readWrite',
+          protocol: 'http'
+        },
+        {{/transformationCustomHosts}}
+        ],
+      {{/hasTransformationCustomHosts}}
+    },
     {{/hasTransformationRegion}} 
   }
   {{/isStandaloneClient}}

--- a/tests/CTS/client/search/partialUpdateObjectsWithTransformation.json
+++ b/tests/CTS/client/search/partialUpdateObjectsWithTransformation.json
@@ -16,7 +16,13 @@
               "port": 6689
             }
           ],
-          "transformationRegion": "us"
+          "transformationOptions": {
+            "region": "us",
+            "customHosts": [
+              { "port": 6688 },
+              { "port": 6689 }
+            ]
+          }
         }
       },
       {

--- a/tests/CTS/client/search/replaceAllObjectsWithTransformation.json
+++ b/tests/CTS/client/search/replaceAllObjectsWithTransformation.json
@@ -13,7 +13,12 @@
               "port": 6690
             }
           ],
-          "transformationRegion": "us"
+          "transformationOptions": {
+            "region": "us",
+            "customHosts": [
+              { "port": 6690 }
+            ]
+          }
         }
       },
       {

--- a/tests/CTS/client/search/saveObjectsWithTransformation.json
+++ b/tests/CTS/client/search/saveObjectsWithTransformation.json
@@ -16,7 +16,13 @@
               "port": 6689
             }
           ],
-          "transformationRegion": "us"
+          "transformationOptions": {
+            "region": "us",
+            "customHosts": [
+              { "port": 6688 },
+              { "port": 6689 }
+            ]
+          }
         }
       },
       {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-369](https://algolia.atlassian.net/browse/API-369)

### Changes included:

The ingestion transporter was inheriting the parent search client config (timeouts, hosts, compression) instead of using its own defaults. transformationOptions isolates ingestion config so only explicitly provided fields override the ingestion defaults.

[API-369]: https://algolia.atlassian.net/browse/API-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ