### PR TITLE
fix(specs): clarify getIndexingTime

### DIFF
--- a/specs/monitoring/paths/getIndexingTime.yml
+++ b/specs/monitoring/paths/getIndexingTime.yml
@@ -1,6 +1,15 @@
 get:
-  summary: Retrieve indexing times
-  description: Retrieves average times for indexing operations for selected clusters.
+  summary: Retrieve indexing monitoring latency
+  description: |
+    Retrieves indexing latency metrics for selected clusters.
+
+    This endpoint is intended for infrastructure-level monitoring and availability checks.
+    The returned value reflects latency measured on Algolia's internal monitoring index
+    and is reported in milliseconds.
+
+    This metric isn't intended to represent the indexing performance of an individual
+    application or index. To measure when an indexing operation has completed for your
+    application, use the `waitTask` method.
   operationId: getIndexingTime
   security: []
   tags:


### PR DESCRIPTION
## 🧭 What and Why

The `getIndexingTime` operation is more intended for infrastructure monitoring,
rather than measuring indexing performance.

The Support team wanted clarification about this.

🎟 JIRA Ticket:

### Changes included:

- Clarify summary and description of the `getIndexingTime` endpoint.

## 🧪 Test
