### PR TITLE
fix(javascript): increase default retry max

### DIFF
--- a/templates/javascript/clients/client/api/compositionHelpers.mustache
+++ b/templates/javascript/clients/client/api/compositionHelpers.mustache
@@ -5,7 +5,7 @@
  * @param WaitForCompositionTaskOptions - The `WaitForCompositionTaskOptions` object.
  * @param WaitForCompositionTaskOptions.compositionID - The `compositionID` where the operation was performed.
  * @param WaitForCompositionTaskOptions.taskID - The `taskID` returned in the method response.
- * @param WaitForCompositionTaskOptions.maxRetries - The maximum number of retries. 50 by default.
+ * @param WaitForCompositionTaskOptions.maxRetries - The maximum number of retries. 100 by default.
  * @param WaitForCompositionTaskOptions.timeout - The function to decide how long to wait between retries.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
@@ -13,7 +13,7 @@ waitForCompositionTask(
   {
     compositionID,
     taskID,
-    maxRetries = 50,
+    maxRetries = 100,
     timeout = (retryCount: number): number =>
       Math.min(retryCount * 200, 5000),
   }: WaitForCompositionTaskOptions,
@@ -28,7 +28,7 @@ waitForCompositionTask(
     error: {
       validate: () => retryCount >= maxRetries,
       message: () =>
-        `The maximum number of retries exceeded. (${retryCount}/${maxRetries})`,
+        `Stopped waiting for the task after ${maxRetries} retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries.`,
     },
     timeout: () => timeout(retryCount),
   });

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -6,7 +6,7 @@
  * @param waitForTaskOptions - The `waitForTaskOptions` object.
  * @param waitForTaskOptions.indexName - The `indexName` where the operation was performed.
  * @param waitForTaskOptions.taskID - The `taskID` returned in the method response.
- * @param waitForTaskOptions.maxRetries - The maximum number of retries. 50 by default.
+ * @param waitForTaskOptions.maxRetries - The maximum number of retries. 100 by default.
  * @param waitForTaskOptions.timeout - The function to decide how long to wait between retries.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
@@ -14,7 +14,7 @@ waitForTask(
   {
     indexName,
     taskID,
-    maxRetries = 50,
+    maxRetries = 100,
     timeout = (retryCount: number): number =>
       Math.min(retryCount * 200, 5000),
   }: WaitForTaskOptions,
@@ -29,7 +29,7 @@ waitForTask(
     error: {
       validate: () => retryCount >= maxRetries,
       message: () =>
-        `The maximum number of retries exceeded. (${retryCount}/${maxRetries})`,
+        `Stopped waiting for the task after ${maxRetries} retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries.`,
     },
     timeout: () => timeout(retryCount),
   });
@@ -41,14 +41,14 @@ waitForTask(
  * @summary Helper method that waits for a task to be published (completed).
  * @param waitForAppTaskOptions - The `waitForTaskOptions` object.
  * @param waitForAppTaskOptions.taskID - The `taskID` returned in the method response.
- * @param waitForAppTaskOptions.maxRetries - The maximum number of retries. 50 by default.
+ * @param waitForAppTaskOptions.maxRetries - The maximum number of retries. 100 by default.
  * @param waitForAppTaskOptions.timeout - The function to decide how long to wait between retries.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
 waitForAppTask(
   {
     taskID,
-    maxRetries = 50,
+    maxRetries = 100,
     timeout = (retryCount: number): number =>
       Math.min(retryCount * 200, 5000),
   }: WaitForAppTaskOptions,
@@ -63,7 +63,7 @@ waitForAppTask(
     error: {
       validate: () => retryCount >= maxRetries,
       message: () =>
-        `The maximum number of retries exceeded. (${retryCount}/${maxRetries})`,
+        `Stopped waiting for the task after ${maxRetries} retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries.`,
     },
     timeout: () => timeout(retryCount),
   });
@@ -77,7 +77,7 @@ waitForAppTask(
  * @param waitForApiKeyOptions.operation - The `operation` that was done on a `key`.
  * @param waitForApiKeyOptions.key - The `key` that has been added, deleted or updated.
  * @param waitForApiKeyOptions.apiKey - Necessary to know if an `update` operation has been processed, compare fields of the response with it.
- * @param waitForApiKeyOptions.maxRetries - The maximum number of retries. 50 by default.
+ * @param waitForApiKeyOptions.maxRetries - The maximum number of retries. 100 by default.
  * @param waitForApiKeyOptions.timeout - The function to decide how long to wait between retries.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getApikey` method and merged with the transporter requestOptions.
  */
@@ -86,7 +86,7 @@ waitForApiKey(
     operation,
     key,
     apiKey,
-    maxRetries = 50,
+    maxRetries = 100,
     timeout = (retryCount: number): number =>
       Math.min(retryCount * 200, 5000),
   }: WaitForApiKeyOptions,
@@ -100,7 +100,7 @@ waitForApiKey(
     error: {
       validate: () => retryCount >= maxRetries,
       message: () =>
-        `The maximum number of retries exceeded. (${retryCount}/${maxRetries})`,
+        `Stopped waiting for the API key operation after ${maxRetries} retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries.`,
     },
     timeout: () => timeout(retryCount),
   };

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -58,7 +58,7 @@ export type BrowseOptions<T> = Partial<
 
 type WaitForOptions = Partial<{
   /**
-   * The maximum number of retries. 50 by default.
+   * The maximum number of retries. 100 by default.
    */
   maxRetries: number;
 

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -221,7 +221,7 @@ export type AccountCopyIndexOptions = {
 {{#isCompositionClient}}
 export type WaitForCompositionTaskOptions = {
   /**
-   * The maximum number of retries. 50 by default.
+   * The maximum number of retries. 100 by default.
    */
   maxRetries?: number | undefined;
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Tickets: [CR-11290](https://algolia.atlassian.net/browse/CR-11290) | [API-469](https://algolia.atlassian.net/browse/API-469)

### Changes included:
Bumps the JavaScript search and composition waitFor* helpers' default maxRetries 50 → 100 so they stop throwing on metis apps (5-min noop delays) before the task actually resolves, and rewords the error so it's clear the wait helper gave up, not the indexing job.

[CR-11290]: https://algolia.atlassian.net/browse/CR-11290
[API-469]: https://algolia.atlassian.net/browse/API-469