### PR TITLE
fix(specs): clarify docs for multi-query search

### DIFF
--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -7,16 +7,16 @@ post:
   x-legacy-signature: true
   x-acl:
     - search
-  summary: Search multiple indices
+  summary: Search multiple queries
   description: |
-    Sends multiple search requests to one or more indices.
+    Runs multiple search queries against one or more indices in a single API request.
 
-    This can be useful in these cases:
+    Use cases include:
 
-    - Different indices for different purposes, such as, one index for products, another one for marketing content.
-    - Multiple searches to the same index—for example, with different filters.
+    - Searching different indices, such as products and marketing content.
+    - Run multiple queries on the same index with different parameters or filters.
 
-    Use the helper `searchForHits` or `searchForFacets` to get the results in a more convenient format, if you already know the return type you want.
+    If you know the expected result type, use the `searchForHits` or `searchForFacets` helper to simplify the response format.
   requestBody:
     required: true
     description: Muli-search request body. Results are returned in the same order as the requests.

--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -19,7 +19,7 @@ post:
     If you know the expected result type, use the `searchForHits` or `searchForFacets` helper to simplify the response format.
   requestBody:
     required: true
-    description: Muli-search request body. Results are returned in the same order as the requests.
+    description: Multi-query search request body. Results are returned in the same order as the requests.
     content:
       application/json:
         schema:

--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -454,6 +454,7 @@
   },
   {
     "testName": "search for multiple mixed requests in multiple indices with minimal parameters",
+    "isCodeSample": true,
     "parameters": {
       "requests": [
         {


### PR DESCRIPTION
## 🧭 What and Why

Addressing feedback from the field: https://algolia.slack.com/archives/C0D3A9E82/p1776127959844139

> [!NOTE]
> Don't know why this is a breaking change? Because of `isCodeSample`?

🎟 JIRA Ticket:

### Changes included:

- Use a different summary and shorten the description
- Use a different code sample

## 🧪 Test
