### PR TITLE
fix(java): prevent chunkedPush subList index errors

### DIFF
--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -42,19 +42,27 @@ public <T> List<WatchResponse> chunkedPush(
   String referenceIndexName,
   RequestOptions requestOptions
 ) {
+  if (batchSize < 1) {
+      throw new AlgoliaRuntimeException("`batchSize` must be greater than 0");
+  }
+
   List<WatchResponse> responses = new ArrayList<>();
   List<T> records = new ArrayList<>();
   int offset = 0;
-  int waitBatchSize = batchSize / 10;
-  if (waitBatchSize < 1) {
-    waitBatchSize = batchSize;
-  }
+  // Poll for task completion every 10% of total batches to balance throughput and feedback.
+  int pollInterval = Math.max(1, batchSize / 10);
 
   Iterator<T> it = objects.iterator();
+
+  if (!it.hasNext()) {
+    return responses;
+  }
+  
   T current = it.next();
 
   while (true) {
     records.add(current);
+    boolean pushed = false;
 
     if (records.size() == batchSize || !it.hasNext()) {
       WatchResponse watch = this.push(
@@ -66,11 +74,14 @@ public <T> List<WatchResponse> chunkedPush(
       );
       responses.add(watch);
       records.clear();
+      pushed = true;
     }
 
-    if (waitForTasks && responses.size() > 0 && (responses.size() % waitBatchSize == 0 || !it.hasNext())) {
+    if (waitForTasks && pushed && responses.size() > 0 && (responses.size() % pollInterval == 0 || !it.hasNext())) {
+      int nextOffset = Math.min(offset + pollInterval, responses.size());
+
       responses
-        .subList(offset, Math.min(offset + waitBatchSize, responses.size()))
+        .subList(offset, nextOffset)
         .forEach(response -> {
           TaskUtils.retryUntil(
             () -> {
@@ -92,11 +103,11 @@ public <T> List<WatchResponse> chunkedPush(
           );
         });
 
-      offset += waitBatchSize;
+      offset = nextOffset;
     }
 
     if (!it.hasNext()) {
-      break;
+        break;
     }
 
     current = it.next();


### PR DESCRIPTION
## 🧭 What and Why

`chunkedPush` processes records one-by-one, but it only gets a new server response when it actually sends a chunk. I think there is a bug in the “wait for responses” logic that can run on loop iterations where no chunk was sent. So it keeps moving its response window (`offset`) even though the response list didn’t grow. After enough iterations, the window becomes invalid and it crashes.

In short: it mixes two counters (records vs pushed responses), and the response cursor can drift out of sync.

### Changes included:

- Polling only runs on iterations where a new push response was actually created (`pushed == true`), which prevents repeated re-processing while iterating records inside the same response window.
- Changing offset advancement from `offset += waitBatchSize` to `offset = nextOffset`, where `nextOffset` is capped to `responses.size()`.
- Changing the name `waitBatchSize` to `pollInterval` to avoid the confusion with `batchSize`