### PR TITLE
fix(specs): improve documentation output for Comp API

### DIFF
--- a/specs/composition/common/schemas/components/injection/InjectedItemSource.yml
+++ b/specs/composition/common/schemas/components/injection/InjectedItemSource.yml
@@ -47,11 +47,11 @@ injectedItemExternalSource:
     - external
 
 externalOrdering:
+  description: Ordering to apply on the injected items coming from the external source. 'default' means the items will be ordered as they are in the index (natural relevance) in the smart group. 'userDefined' means the order in which the objectIDs are provided in the run request payload will be preserved in the smart group.
   enum: ['default', 'userDefined']
   default: 'default'
 
 injectedItemRecommendSource:
-  title: injectedItemRecommendSource
   description: Injected items will originate from a recommendation request performed on the specified index.
   x-discriminator-fields:
     - recommend


### PR DESCRIPTION
## 🧭 What and Why

Try to improve generated documentation for Comp API as current state is inconsistent:

[
<img width="412" height="138" alt="Screenshot 2026-04-23 at 11 05 42" src="https://github.com/user-attachments/assets/7d818d60-eb4d-4ccc-bd16-400bd885a0cc" />
](url)

Also add description for another field

## 🧪 Test

CI