### PR TITLE
fix(specs): compostion run payload example for external injected items

### DIFF
--- a/eslint/src/rules/hasType.ts
+++ b/eslint/src/rules/hasType.ts
@@ -20,6 +20,13 @@ export const hasType: Rule.RuleModule = {
           return; // allow everything in properties
         }
 
+        // allow everything in example
+        for (let parentNode = node.parent; parentNode; parentNode = parentNode.parent) {
+          if (isPairWithKey(parentNode, 'example')) {
+            return;
+          }
+        }
+
         const type = node.parent.pairs.find((pair) => isPairWithKey(pair, 'type'));
         if (isPairWithKey(node, 'properties') && (!type || !isPairWithValue(type, 'object'))) {
           return context.report({

--- a/eslint/tests/hasType.test.ts
+++ b/eslint/tests/hasType.test.ts
@@ -1,5 +1,5 @@
 import { runClassic } from 'eslint-vitest-rule-tester';
-import * as yamlParser from "yaml-eslint-parser"
+import * as yamlParser from 'yaml-eslint-parser';
 
 import { hasType } from '../src/rules/hasType.js';
 
@@ -19,6 +19,41 @@ withArray:
   type: array
   items:
     type: string
+  `,
+      `
+withExample:
+  type: object
+  properties:
+    items:
+      type: array
+      items:
+        type: string
+  example:
+    items:
+      - 'this'
+      - 'that'
+  `,
+      `
+withExampleNestedItems:
+  type: object
+  additionalProperties:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+  example:
+    someKey:
+      items:
+        - id: '1'
+        - id: '2'
+    someOtherKey:
+      items:
+        - id: '3'
   `,
     ],
     invalid: [

--- a/specs/composition/common/params/Composition.yml
+++ b/specs/composition/common/params/Composition.yml
@@ -48,15 +48,28 @@ injectedItems:
   additionalProperties:
     $ref: '#/externalInjectedItem'
   description: |
-    A list of extenrally injected objectID groups into from an external source.
+    An object containing keys corresponding to the `key`s from an injection's `injectedItems` and values containing a list of hits to inject.
   default: {}
   x-categories:
     - Retail Media Network
   example:
-    'my-group-key': [{'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}, {'objectID': 'my-object-2'}]
+    my-group-key:
+      items:
+        - objectID: 'my-object-1'
+          metadata:
+            my-field: 'my-value'
+        - objectID: 'my-object-2'
+          metadata:
+            my-field: 'my-value-2'
+    my-other-group-key:
+      items:
+        - objectID: 'my-other-object-1'
+        - objectID: 'my-other-object-2'
 
 externalInjectedItem:
   type: object
+  description: |
+    Contains a list of objects to inject from an external source.
   properties:
     items:
       type: array
@@ -67,7 +80,7 @@ externalInjectedItem:
         properties:
           objectID:
             type: string
-            description: An objectID injected into an external source.
+            description: An objectID injected from an external source and also present in the targeted index.
           metadata:
             type: object
             additionalProperties: true
@@ -75,11 +88,14 @@ externalInjectedItem:
               User-defined key-values that will be added to the injected item in the response.
               This is identical to Hits metadata defined in Composition or Composition Rule,
               with the benefit of being set at runtime.
-            example: {'my-field': 'my-value'}
+            example:
+              my-field: 'my-value'
         required:
           - objectID
         example:
-          {'objectID': 'my-object-1', 'metadata': {'my-field': 'my-value'}}
+          objectID: 'my-object-1'
+          metadata':
+            my-field: 'my-value'
   required:
     - items
 


### PR DESCRIPTION
## 🧭 What and Why

https://algolia.slack.com/archives/C07RRSCGUN7/p1776943775025059?thread_ts=1776940591.513199&cid=C07RRSCGUN7

### Changes included:

- Correct the example to include the `items` field for externally-injected items
- Update the descriptions to improve clarity
- Adjust the `has-type` eslint rule to ignore `items` found inside `example`

## 🧪 Test

- Updated `eslint/hasType` tests passing
- Example contains the `items` field inside the value for each injected group key