### PR TITLE
chore(deps): update dependency json4s to 4.1.0

### DIFF
--- a/clients/algoliasearch-client-scala/build.sbt
+++ b/clients/algoliasearch-client-scala/build.sbt
@@ -2,7 +2,7 @@ organization := "com.algolia"
 name := "algoliasearch-scala"
 description := "Scala client for Algolia Search API"
 scalaVersion := "2.13.18"
-crossScalaVersions := Seq("2.13.12", "3.8.2")
+crossScalaVersions := Seq("2.13.17", "3.8.2")
 Test / publishArtifact := false
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 homepage := Some(url("https://github.com/algolia/algoliasearch-client-scala/"))
@@ -33,7 +33,7 @@ lazy val root = project
 // Project dependencies
 libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "5.3.2" % "compile",
-  "org.json4s" %% "json4s-native" % "4.0.7" % "compile",
+  "io.github.json4s" %% "json4s-native" % "4.1.0" % "compile",
   "com.squareup.okhttp3" % "logging-interceptor" % "5.3.2",
   "org.slf4j" % "slf4j-api" % "2.0.17"
 )

--- a/playground/scala/build.sbt
+++ b/playground/scala/build.sbt
@@ -11,4 +11,4 @@ val algoliasearch = ProjectRef(file("../../clients/algoliasearch-client-scala"),
 dependsOn(algoliasearch)
 
 libraryDependencies += "io.github.cdimascio" % "dotenv-java" % "3.2.0"
-libraryDependencies += "org.json4s" %% "json4s-native" % "4.0.7"
+libraryDependencies += "io.github.json4s" %% "json4s-native" % "4.1.0"


### PR DESCRIPTION
## 🧭 What and Why
Updates [json4s](https://github.com/json4s/json4s) to `4.1.0` and modifies the `groupId` as per the [related change](https://github.com/json4s/json4s/commit/db7945b476f12490a3e361cf240f672494ad4433) upstream

🎟 JIRA Ticket: N/A

### Changes included:

- updates artifact version from `4.0.7` -> `4.1.0`
- updates the dependencies `groupId` for the published artifact
- updates minimal expected Scala compiler version for cross version building

## 🧪 Test
