### PR TITLE
fix(csharp): ReplaceAllObjectsAsync intermittently fails with "maximum number of retries exceeded (51/50)" response (C# API client)

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -243,13 +243,15 @@ public partial interface ISearchClient
   /// <param name="scopes"> The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms'].</param>
   /// <param name="options">Add extra http header or query parameters to Algolia.</param>
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+  /// <param name="maxRetries">The maximum number of retry. 50 by default. (optional)</param>
   Task<ReplaceAllObjectsResponse> ReplaceAllObjectsAsync<T>(
     string indexName,
     IEnumerable<T> objects,
     int batchSize = 1000,
     List<ScopeType> scopes = null,
     RequestOptions options = null,
-    CancellationToken cancellationToken = default
+    CancellationToken cancellationToken = default,
+    int maxRetries = SearchClient.DefaultMaxRetries
   )
     where T : class;
 
@@ -260,7 +262,8 @@ public partial interface ISearchClient
     int batchSize = 1000,
     List<ScopeType> scopes = null,
     RequestOptions options = null,
-    CancellationToken cancellationToken = default
+    CancellationToken cancellationToken = default,
+    int maxRetries = SearchClient.DefaultMaxRetries
   )
     where T : class;
 
@@ -881,7 +884,8 @@ public partial class SearchClient : ISearchClient
     int batchSize = 1000,
     List<ScopeType> scopes = null,
     RequestOptions options = null,
-    CancellationToken cancellationToken = default
+    CancellationToken cancellationToken = default,
+    int maxRetries = SearchClient.DefaultMaxRetries
   )
     where T : class
   {
@@ -932,6 +936,7 @@ public partial class SearchClient : ISearchClient
       await WaitForTaskAsync(
           tmpIndexName,
           copyResponse.TaskID,
+          maxRetries: maxRetries,
           requestOptions: options,
           ct: cancellationToken
         )
@@ -947,6 +952,7 @@ public partial class SearchClient : ISearchClient
       await WaitForTaskAsync(
           tmpIndexName,
           copyResponse.TaskID,
+          maxRetries: maxRetries,
           requestOptions: options,
           ct: cancellationToken
         )
@@ -963,6 +969,7 @@ public partial class SearchClient : ISearchClient
       await WaitForTaskAsync(
           tmpIndexName,
           moveResponse.TaskID,
+          maxRetries: maxRetries,
           requestOptions: options,
           ct: cancellationToken
         )
@@ -1003,11 +1010,12 @@ public partial class SearchClient : ISearchClient
     int batchSize = 1000,
     List<ScopeType> scopes = null,
     RequestOptions options = null,
-    CancellationToken cancellationToken = default
+    CancellationToken cancellationToken = default,
+    int maxRetries = SearchClient.DefaultMaxRetries
   )
     where T : class =>
     AsyncHelper.RunSync(() =>
-      ReplaceAllObjectsAsync(indexName, objects, batchSize, scopes, options, cancellationToken)
+      ReplaceAllObjectsAsync(indexName, objects, batchSize, scopes, options, cancellationToken, maxRetries)
     );
 
   /// <inheritdoc/>


### PR DESCRIPTION
## 🧭 What and Why

We have a scheduled task that runs method ReplaceAllObjectsAsync is run on the prod_shawcontract_resource index weekly on Sundays, starting at 12pm UTC, and usually taking about 20-30 minutes to complete, but fails more often than not with the response “maximum number of retries exceeded (51/50)”. 

🎟 JIRA Ticket [CR-11342:](https://algolia.atlassian.net/browse/CR-11342)

### Changes included:

- List changes

## 🧪 Test
