### PR TITLE
fix(specs): Ingestion API - update destination payload

### DIFF
--- a/specs/ingestion/common/schemas/destination.yml
+++ b/specs/ingestion/common/schemas/destination.yml
@@ -70,12 +70,10 @@ DestinationUpdate:
   additionalProperties: false
   description: API request body for updating a destination.
   properties:
-    type:
-      $ref: '#/DestinationType'
     name:
       $ref: './common.yml#/name'
     input:
-      $ref: '#/DestinationInput'
+      $ref: '#/DestinationUpdateInput'
     authenticationID:
       $ref: './common.yml#/authenticationID'
     transformationIDs:
@@ -134,6 +132,18 @@ DestinationInput:
       $ref: '#/AttributesToExclude'
   required:
     - indexName
+
+DestinationUpdateInput:
+  type: object
+  additionalProperties: false
+  properties:
+    indexName:
+      type: string
+      description: Algolia index name (case-sensitive).
+    recordType:
+      $ref: '#/RecordType'
+    attributesToExclude:
+      $ref: '#/AttributesToExclude'
 
 RecordType:
   type: string


### PR DESCRIPTION
## 🧭 What and Why

Specs are not correct for the "Update a destination" endpoint

### Changes included:

1. `type` can't be changed

Sending the following payload
```json
{
  "type": "search"
}
```
Returns the following error:
```json
{
  "error": {
    "code": "invalid_payload"
  },
  "message": "unknown field \"type\"",
  "status": 400
}
```

2. `input.indexName` is not required

This is a valid payload:
```json
{
  "input": {
    "recordType": "product"
  }
}
```