### PR TITLE
fix(clients): validate empty string for required string parameters

### DIFF
--- a/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/utils/Parameters.java
+++ b/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/utils/Parameters.java
@@ -13,4 +13,10 @@ public class Parameters {
       throw new AlgoliaRuntimeException(error);
     }
   }
+
+  public static void requireNonEmpty(String param, String error) {
+    if (param == null || param.trim().isEmpty()) {
+      throw new AlgoliaRuntimeException(error);
+    }
+  }
 }

--- a/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/internal/util/package.scala
+++ b/clients/algoliasearch-client-scala/src/main/scala/algoliasearch/internal/util/package.scala
@@ -16,6 +16,10 @@ package object util {
     if (param == null) throw new IllegalArgumentException(error)
   }
 
+  private[algoliasearch] def requireNotEmpty(param: String, error: String): Unit = {
+    if (param == null || param.trim.isEmpty) throw new IllegalArgumentException(error)
+  }
+
   /** Escape the given string to be used as URL query value.
     */
   private[algoliasearch] def escape(input: Any): String = input match {

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -261,6 +261,10 @@ namespace Algolia.Search.Clients;
           if ({{paramName}} == null)
               throw new ArgumentException("Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
             {{/isEnumRef}}{{/vendorExtensions.x-csharp-value-type}}
+          {{#isString}}
+          if (string.IsNullOrWhiteSpace({{paramName}}))
+              throw new ArgumentException("Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+          {{/isString}}
           {{/required}}
           {{/allParams}}
           var requestOptions = new InternalRequestOptions(options);
@@ -350,6 +354,10 @@ namespace Algolia.Search.Clients;
           if ({{paramName}} == null)
               throw new ArgumentException("Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
             {{/isEnumRef}}{{/vendorExtensions.x-csharp-value-type}}
+          {{#isString}}
+          if (string.IsNullOrWhiteSpace({{paramName}}))
+              throw new ArgumentException("Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+          {{/isString}}
           {{/required}}
           {{/allParams}}
           var requestOptions = new InternalRequestOptions(options);

--- a/templates/dart/api.mustache
+++ b/templates/dart/api.mustache
@@ -110,11 +110,14 @@ final class {{classname}} implements ApiClient {
   }) async {
     {{#requiredParams}}
     {{#isString}}
-    assert({{paramName}}.isNotEmpty, 'Parameter `{{paramName}}` is required when calling `{{operationId}}`.',);
+    if ({{paramName}}.isEmpty) {
+      throw ArgumentError('Parameter `{{paramName}}` is required when calling `{{operationId}}`.');
+    }
     {{/isString}}
     {{#isFreeFormObject}}
-    if ({{paramName}} is Map) { assert({{paramName}}.isNotEmpty, 'Parameter `{{paramName}}` is required when calling `{{operationId}}`.',); }
-    if ({{paramName}} is Map) { assert({{paramName}} .isNotEmpty, 'Parameter `{{paramName}} ` is required when calling `{{operationId}}`.', ); }
+    if ({{paramName}} is Map && {{paramName}}.isEmpty) {
+      throw ArgumentError('Parameter `{{paramName}}` is required when calling `{{operationId}}`.');
+    }
     {{/isFreeFormObject}}
     {{/requiredParams}}
     final request = ApiRequest(

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -319,6 +319,9 @@ public class {{classname}} extends ApiClient {
   public {{> return_type_async}} {{operationId}}Async({{#requiredParams}}@Nonnull {{{dataType}}} {{paramName}},{{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}}, {{/optionalParams}}{{#vendorExtensions}}{{#x-is-generic}}Class<T> innerType, {{/x-is-generic}}{{/vendorExtensions}}@Nullable RequestOptions requestOptions) throws AlgoliaRuntimeException {
     {{#allParams}}{{#required}}
     Parameters.requireNonNull({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+    {{#isString}}
+    Parameters.requireNonEmpty({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+    {{/isString}}
     {{/required}}{{/allParams}}
 
     HttpRequest request = HttpRequest.builder()
@@ -342,6 +345,9 @@ public class {{classname}} extends ApiClient {
   public CompletableFuture<Response> {{operationId}}WithHTTPInfoAsync({{#requiredParams}}@Nonnull {{{dataType}}} {{paramName}},{{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}}, {{/optionalParams}}{{#vendorExtensions}}{{#x-is-generic}}Class<Response> innerType, {{/x-is-generic}}{{/vendorExtensions}}@Nullable RequestOptions requestOptions) throws AlgoliaRuntimeException {
     {{#allParams}}{{#required}}
     Parameters.requireNonNull({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+    {{#isString}}
+    Parameters.requireNonEmpty({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.");
+    {{/isString}}
     {{/required}}{{/allParams}}
 
     HttpRequest request = HttpRequest.builder()

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -275,6 +275,14 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
                 'Parameter `{{paramName}}` is required when calling `{{operationId}}`.'
                 );
                 }
+                {{#isString}}
+                // verify the required parameter '{{paramName}}' is not empty
+                if (isset(${{paramName}}) && ${{paramName}} === '') {
+                throw new \InvalidArgumentException(
+                'Parameter `{{paramName}}` is required when calling `{{operationId}}`.'
+                );
+                }
+                {{/isString}}
             {{/required}}
         {{/allParams}}
 

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -191,6 +191,11 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
         if {{paramName}} is None:
             raise ValueError("Parameter `{{paramName}}` is required when calling `{{nickname}}`.")
 
+        {{#isString}}
+        if not {{paramName}}:
+            raise ValueError("Parameter `{{paramName}}` is required when calling `{{nickname}}`.")
+
+        {{/isString}}
         {{/required}}
         {{/allParams}}
 

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -122,6 +122,12 @@ module {{moduleName}}
       if @api_client.config.client_side_validation && {{{paramName}}}.nil?
         raise ArgumentError, "Parameter `{{paramName}}` is required when calling `{{operationId}}`."
       end
+      {{#isString}}
+      # verify the required parameter '{{paramName}}' is not empty
+      if @api_client.config.client_side_validation && {{{paramName}}}.empty?
+        raise ArgumentError, "Parameter `{{paramName}}` is required when calling `{{operationId}}`."
+      end
+      {{/isString}}
       {{/required}}
       {{/isNullable}}
       {{/allParams}}

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -145,6 +145,9 @@ class {{classname}}(
   def {{operationId}}{{#vendorExtensions}}{{#x-is-custom-request}}[T: Manifest]{{/x-is-custom-request}}{{/vendorExtensions}}({{> methodParameters}} requestOptions: Option[RequestOptions] = None)(implicit ec: ExecutionContext): Future[{{#vendorExtensions}}{{#x-is-custom-request}}T{{/x-is-custom-request}}{{^x-is-custom-request}}{{{returnType}}}{{^returnType}}Unit{{/returnType}}{{/x-is-custom-request}}{{/vendorExtensions}}] = Future {
     {{#requiredParams}}
     requireNotNull({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.")
+    {{#isString}}
+    requireNotEmpty({{paramName}}, "Parameter `{{paramName}}` is required when calling `{{operationId}}`.")
+    {{/isString}}
     {{/requiredParams}}
 
     val request = HttpRequest.builder()


### PR DESCRIPTION
[API-414]

## Summary

fixes algolia/algoliasearch-client-csharp#872

Passing an empty string as a required path parameter (e.g. `objectID = ""`) bypasses null guards and corrupts the URL path — causing the wrong API endpoint to be called (e.g. delete index instead of delete object).

This PR adds empty string validation for required string parameters across the **7 vulnerable languages**. 4 languages (JavaScript, Go, Swift, Kotlin) were already safe.

## What changed

### Templates (guard empty string for `{{#isString}}` + `{{#required}}` params)

| Language | Guard added | File |
|----------|-------------|------|
| **C#** | `string.IsNullOrWhiteSpace()` | `templates/csharp/api.mustache` |
| **Java** | `Parameters.requireNonEmpty()` | `templates/java/api.mustache` |
| **Python** | `if not paramName:` (falsy) | `templates/python/api.mustache` |
| **Ruby** | `.empty?` (respects `client_side_validation` flag) | `templates/ruby/api.mustache` |
| **PHP** | `=== ''` strict comparison | `templates/php/api.mustache` |
| **Scala** | `requireNotEmpty()` | `templates/scala/api.mustache` |
| **Dart** | `throw ArgumentError` (replaces `assert()` which was stripped in release builds) | `templates/dart/api.mustache` |

### Hand-written utilities

| File | Change |
|------|--------|
| `clients/.../java/.../utils/Parameters.java` | Added `requireNonEmpty(String, String)` |
| `clients/.../scala/.../internal/util/package.scala` | Added `requireNotEmpty(String, String)` |

### Dart bonus fix

Removed a duplicate buggy line in the `isFreeFormObject` block (had trailing spaces in variable name and error message — copy-paste artifact).

## Already safe (no changes needed)

| Language | Existing guard |
|----------|---------------|
| **JavaScript** | `!paramName` (falsy catches empty) |
| **Go** | `paramName == ""` explicit check |
| **Swift** | `guard !paramName.isEmpty` |
| **Kotlin** | `require(paramName.isNotBlank())` |

## Next steps

After merge, regenerate clients for the 7 affected languages:
```bash
yarn cli generate csharp java python ruby php scala dart
```

[API-414]: https://algolia.atlassian.net/browse/API-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ