### PR TITLE
fix(javascript): handle response stream error in `createHttpRequester`

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
@@ -292,3 +292,30 @@ describe('error handling', (): void => {
     expect(response.isTimedOut).toBe(false);
   });
 });
+
+describe('response stream error handling', () => {
+  let server: http.Server;
+
+  beforeAll(() => {
+    server = createTestServer();
+    server.listen('1114');
+  });
+
+  afterAll(
+    () =>
+      new Promise<void>((done) => {
+        done();
+      }),
+  );
+
+  test('resolves response stream errors when connection drops mid-transfer', async () => {
+    const response = await requester.send({
+      ...timeoutRequest,
+      url: 'http://localhost:1114/response_stream_error',
+    });
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBeTruthy();
+    expect(response.isTimedOut).toBe(false);
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/__tests__/node-http-requester.test.ts
@@ -278,4 +278,17 @@ describe('error handling', (): void => {
     expect(response.content).toBe('This is a general error');
     expect(response.isTimedOut).toBe(false);
   });
+
+  test('resolves response stream errors', async () => {
+    nock(testQueryBaseUrl, { reqheaders: headers })
+      .post('/foo')
+      .query(testQueryHeader)
+      .replyWithError('This is a response stream error');
+
+    const response = await requester.send(requestStub);
+
+    expect(response.status).toBe(0);
+    expect(response.content).toBe('This is a response stream error');
+    expect(response.isTimedOut).toBe(false);
+  });
 });

--- a/clients/algoliasearch-client-javascript/packages/requester-node-http/src/createHttpRequester.ts
+++ b/clients/algoliasearch-client-javascript/packages/requester-node-http/src/createHttpRequester.ts
@@ -74,6 +74,12 @@ export function createHttpRequester({
             isTimedOut: false,
           });
         });
+
+        response.on('error', (error) => {
+          clearTimeout(connectTimeout as NodeJS.Timeout);
+          clearTimeout(responseTimeout as NodeJS.Timeout);
+          resolve({ status: 0, content: error.message, isTimedOut: false });
+        });
       });
 
       const createTimeout = (timeout: number, content: string): NodeJS.Timeout => {

--- a/clients/algoliasearch-client-javascript/tests/utils.ts
+++ b/clients/algoliasearch-client-javascript/tests/utils.ts
@@ -64,6 +64,17 @@ export function createTestServer(): http.Server {
         res.write('{"foo": "bar"}');
         res.end();
       }, 5000);
+    } else if (req.url?.endsWith('/response_stream_error')) {
+      // Send headers + partial body, then destroy the socket.
+      // This triggers response.on('error') on the client side (typically ECONNRESET).
+      res.writeHead(200, {
+        'content-type': 'text/plain',
+        'access-control-allow-origin': '*',
+      });
+      res.write('partial');
+      setTimeout(() => {
+        req.socket.destroy();
+      }, 50);
     } else {
       res.writeHead(200, {
         'content-type': 'text/plain',


### PR DESCRIPTION
## 🧭 What and Why

The response stream in `createHttpRequester` had no `error` event handler.
According to the Node.js stream documentation, if an `error` event handler is not added, the error will be thrown as an unhandled exception.

ref: https://nodejs.org/api/stream.html#event-error

### Changes included:

When a network error occurs during response streaming:
- `response.on('error')` was not handled
- `connectTimeout` and `responseTimeout` were never cleared
- Node.js would throw an unhandled exception

Added `response.on('error')` to properly clear timeouts and resolve
the promise on response stream errors.

## 🧪 Test
<img width="738" height="232" alt="スクリーンショット 2026-05-09 15 33 02" src="https://github.com/user-attachments/assets/83e8df39-d2a9-4181-b673-edeb8c820a9f" />
