### PR TITLE
feat(javascript): expose maximum number of retries

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/chunkedHelperOptions.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/chunkedHelperOptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared configuration for chunked helpers that poll for task completion.
+ * Designed to grow over time so future helper configs can be added without ballooning option types.
+ */
+export type ChunkedHelperOptions = {
+  /**
+   * The maximum number of retries when polling for task completion. 100 by default.
+   */
+  maxRetries?: number | undefined;
+};

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/chunkedHelperOptions.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/chunkedHelperOptions.ts
@@ -1,6 +1,5 @@
 /**
  * Shared configuration for chunked helpers that poll for task completion.
- * Designed to grow over time so future helper configs can be added without ballooning option types.
  */
 export type ChunkedHelperOptions = {
   /**

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/index.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './cache';
+export * from './chunkedHelperOptions';
 export * from './createClient';
 export * from './createIterablePromise';
 export * from './host';

--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -42,6 +42,7 @@ export type Algoliasearch = SearchClient & {
    * @param saveObjects.objects - The array of `objects` to store in the given Algolia `indexName`.
    * @param saveObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
    * @param saveObjects.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
+   * @param saveObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
    * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `push` method and merged with the transporter requestOptions.
    */
   saveObjectsWithTransformation: (options: SaveObjectsOptions, requestOptions?: RequestOptions | undefined) => Promise<Array<WatchResponse>>;
@@ -56,6 +57,7 @@ export type Algoliasearch = SearchClient & {
    * @param partialUpdateObjects.createIfNotExists - To be provided if non-existing objects are passed, otherwise, the call will fail.
    * @param partialUpdateObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
    * @param partialUpdateObjects.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
+   * @param partialUpdateObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
    * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `push` method and merged with the transporter requestOptions.
    */
   partialUpdateObjectsWithTransformation: (options: PartialUpdateObjectsOptions, requestOptions?: RequestOptions | undefined) => Promise<Array<WatchResponse>>;
@@ -69,6 +71,7 @@ export type Algoliasearch = SearchClient & {
    * @param replaceAllObjects.objects - The array of `objects` to store in the given Algolia `indexName`.
    * @param replaceAllObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `objects.length / batchSize`. Defaults to 1000.
    * @param replaceAllObjects.scopes - The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms'].
+   * @param replaceAllObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
    * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `push`, `operationIndex` and `getEvent` method and merged with the transporter requestOptions.
    */
   replaceAllObjectsWithTransformation: (
@@ -126,27 +129,27 @@ export function algoliasearch(
   return {
     ...client,
 
-    async saveObjectsWithTransformation({ indexName, objects, waitForTasks }, requestOptions): Promise<Array<WatchResponse>> {
+    async saveObjectsWithTransformation({ indexName, objects, waitForTasks, maxRetries }, requestOptions): Promise<Array<WatchResponse>> {
       if (!ingestionTransporter) {
         throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
-      return ingestionTransporter.chunkedPush({ indexName, objects, action: 'addObject', waitForTasks }, requestOptions);
+      return ingestionTransporter.chunkedPush({ indexName, objects, action: 'addObject', waitForTasks, maxRetries }, requestOptions);
     },
 
     async partialUpdateObjectsWithTransformation(
-      { indexName, objects, createIfNotExists, waitForTasks },
+      { indexName, objects, createIfNotExists, waitForTasks, maxRetries },
       requestOptions,
     ): Promise<Array<WatchResponse>> {
       if (!ingestionTransporter) {
         throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
-      return ingestionTransporter.chunkedPush({ indexName, objects, action: createIfNotExists ? 'partialUpdateObject' : 'partialUpdateObjectNoCreate', waitForTasks }, requestOptions);
+      return ingestionTransporter.chunkedPush({ indexName, objects, action: createIfNotExists ? 'partialUpdateObject' : 'partialUpdateObjectNoCreate', waitForTasks, maxRetries }, requestOptions);
     },
 
     async replaceAllObjectsWithTransformation(
-      { indexName, objects, batchSize, scopes }: ReplaceAllObjectsOptions,
+      { indexName, objects, batchSize, scopes, maxRetries = 100 }: ReplaceAllObjectsOptions,
       requestOptions?: RequestOptions | undefined,
     ): Promise<ReplaceAllObjectsWithTransformationResponse> {
       if (!ingestionTransporter) {
@@ -174,13 +177,14 @@ export function algoliasearch(
         );
 
         const watchResponses = await ingestionTransporter.chunkedPush(
-          { indexName: tmpIndexName, objects, waitForTasks: true, batchSize, referenceIndexName: indexName },
+          { indexName: tmpIndexName, objects, waitForTasks: true, batchSize, referenceIndexName: indexName, maxRetries },
           requestOptions,
         );
 
         await this.waitForTask({
           indexName: tmpIndexName,
           taskID: copyOperationResponse.taskID,
+          maxRetries,
         });
 
         copyOperationResponse = await this.operationIndex(
@@ -197,6 +201,7 @@ export function algoliasearch(
         await this.waitForTask({
           indexName: tmpIndexName,
           taskID: copyOperationResponse.taskID,
+          maxRetries,
         });
 
         const moveOperationResponse = await this.operationIndex(
@@ -209,6 +214,7 @@ export function algoliasearch(
         await this.waitForTask({
           indexName: tmpIndexName,
           taskID: moveOperationResponse.taskID,
+          maxRetries,
         });
 
         return { copyOperationResponse, watchResponses, moveOperationResponse };

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -287,9 +287,10 @@ browseSynonyms(
  * @param chunkedBatch.action - The `batch` `action` to perform on the given array of `objects`, defaults to `addObject`.
  * @param chunkedBatch.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
  * @param chunkedBatch.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
+ * @param chunkedBatch.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
-async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, batchSize = 1000 }: ChunkedBatchOptions, requestOptions?: RequestOptions): Promise<Array<BatchResponse>> {
+async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, batchSize = 1000, maxRetries = 100 }: ChunkedBatchOptions, requestOptions?: RequestOptions): Promise<Array<BatchResponse>> {
   let requests: Array<BatchRequest> = [];
   const responses: Array<BatchResponse> = [];
 
@@ -304,7 +305,7 @@ async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, bat
 
   if (waitForTasks) {
     for (const resp of responses) {
-      await this.waitForTask({indexName, taskID: resp.taskID});
+      await this.waitForTask({indexName, taskID: resp.taskID, maxRetries});
     }
   }
 
@@ -320,14 +321,15 @@ async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, bat
  * @param saveObjects.objects - The array of `objects` to store in the given Algolia `indexName`.
  * @param saveObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
  * @param saveObjects.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
+ * @param saveObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `batch` method and merged with the transporter requestOptions.
  */
 async saveObjects(
-  { indexName, objects, waitForTasks, batchSize }: SaveObjectsOptions,
+  { indexName, objects, waitForTasks, batchSize, maxRetries }: SaveObjectsOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<BatchResponse[]> {
   return await this.chunkedBatch(
-    { indexName, objects, action: 'addObject', waitForTasks, batchSize },
+    { indexName, objects, action: 'addObject', waitForTasks, batchSize, maxRetries },
     requestOptions
   );
 },
@@ -341,10 +343,11 @@ async saveObjects(
  * @param deleteObjects.objectIDs - The objectIDs to delete.
  * @param deleteObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
  * @param deleteObjects.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
+ * @param deleteObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `batch` method and merged with the transporter requestOptions.
  */
 async deleteObjects(
-  { indexName, objectIDs, waitForTasks, batchSize }: DeleteObjectsOptions,
+  { indexName, objectIDs, waitForTasks, batchSize, maxRetries }: DeleteObjectsOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<BatchResponse[]> {
   return await this.chunkedBatch(
@@ -354,6 +357,7 @@ async deleteObjects(
       action: 'deleteObject',
       waitForTasks,
       batchSize,
+      maxRetries,
     },
     requestOptions
   );
@@ -369,10 +373,11 @@ async deleteObjects(
  * @param partialUpdateObjects.createIfNotExists - To be provided if non-existing objects are passed, otherwise, the call will fail.
  * @param partialUpdateObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
  * @param partialUpdateObjects.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
+ * @param partialUpdateObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
 async partialUpdateObjects(
-  { indexName, objects, createIfNotExists, waitForTasks, batchSize }: PartialUpdateObjectsOptions,
+  { indexName, objects, createIfNotExists, waitForTasks, batchSize, maxRetries }: PartialUpdateObjectsOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<BatchResponse[]> {
   return await this.chunkedBatch(
@@ -383,7 +388,8 @@ async partialUpdateObjects(
         ? 'partialUpdateObject'
         : 'partialUpdateObjectNoCreate',
       batchSize,
-      waitForTasks
+      waitForTasks,
+      maxRetries,
     },
     requestOptions
   );
@@ -399,10 +405,11 @@ async partialUpdateObjects(
  * @param replaceAllObjects.objects - The array of `objects` to store in the given Algolia `indexName`.
  * @param replaceAllObjects.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `objects.length / batchSize`. Defaults to 1000.
  * @param replaceAllObjects.scopes - The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms'].
+ * @param replaceAllObjects.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `batch`, `operationIndex` and `getTask` method and merged with the transporter requestOptions.
  */
 async replaceAllObjects(
-  { indexName, objects, batchSize, scopes }: ReplaceAllObjectsOptions,
+  { indexName, objects, batchSize, scopes, maxRetries = 100 }: ReplaceAllObjectsOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<ReplaceAllObjectsResponse> {
   const randomSuffix = Math.floor(Math.random() * 1000000) + 100000;
@@ -426,13 +433,14 @@ async replaceAllObjects(
     );
 
     const batchResponses = await this.chunkedBatch(
-      { indexName: tmpIndexName, objects, waitForTasks: true, batchSize },
+      { indexName: tmpIndexName, objects, waitForTasks: true, batchSize, maxRetries },
       requestOptions
     );
 
     await this.waitForTask({
       indexName: tmpIndexName,
       taskID: copyOperationResponse.taskID,
+      maxRetries,
     });
 
     copyOperationResponse = await this.operationIndex(
@@ -449,6 +457,7 @@ async replaceAllObjects(
     await this.waitForTask({
       indexName: tmpIndexName,
       taskID: copyOperationResponse.taskID,
+      maxRetries,
     });
 
     const moveOperationResponse = await this.operationIndex(
@@ -461,6 +470,7 @@ async replaceAllObjects(
     await this.waitForTask({
       indexName: tmpIndexName,
       taskID: moveOperationResponse.taskID,
+      maxRetries,
     });
 
     return { copyOperationResponse, batchResponses, moveOperationResponse };

--- a/templates/javascript/clients/client/api/ingestionHelpers.mustache
+++ b/templates/javascript/clients/client/api/ingestionHelpers.mustache
@@ -9,6 +9,7 @@
  * @param chunkedPush.waitForTasks - Whether or not we should wait until every `batch` tasks has been processed, this operation may slow the total execution time of this method but is more reliable.
  * @param chunkedPush.batchSize - The size of the chunk of `objects`. The number of `batch` calls will be equal to `length(objects) / batchSize`. Defaults to 1000.
  * @param chunkedPush.referenceIndexName - This is required when targeting an index that does not have a push connector setup (e.g. a tmp index), but you wish to attach another index's transformation to it (e.g. the source index name).
+ * @param chunkedPush.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getEvent` method and merged with the transporter requestOptions.
  */
 async chunkedPush(
@@ -19,6 +20,7 @@ async chunkedPush(
     waitForTasks,
     batchSize = 1000,
     referenceIndexName,
+    maxRetries = 100,
   }: ChunkedPushOptions,
   requestOptions?: RequestOptions,
 ): Promise<Array<WatchResponse>> {
@@ -62,8 +64,8 @@ async chunkedPush(
           validate: (response) => response !== undefined,
           aggregator: () => (retryCount += 1),
           error: {
-            validate: () => retryCount >= 50,
-            message: () => `The maximum number of retries exceeded. (${retryCount}/${50})`,
+            validate: () => retryCount >= maxRetries,
+            message: () => `Stopped waiting for the task after ${maxRetries} retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries.`,
           },
           timeout: (): number => Math.min(retryCount * 1500, 5000),
         });

--- a/templates/javascript/clients/client/api/nodeHelpers.mustache
+++ b/templates/javascript/clients/client/api/nodeHelpers.mustache
@@ -46,10 +46,11 @@ generateSecuredApiKey: ({
  * @param accountCopyIndex.destinationApiKey - The API Key of the `destinationAppID` to write the index to, must have write ACLs.
  * @param accountCopyIndex.destinationIndexName - The name of the index to write the copied index to.
  * @param accountCopyIndex.batchSize - The size of the chunk of `objects`. Defaults to 1000.
+ * @param accountCopyIndex.maxRetries - The maximum number of retries when polling for task completion. 100 by default.
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `setSettings`, `saveRules`, `saveSynonyms` and `saveObjects` method and merged with the transporter requestOptions.
  */
 async accountCopyIndex(
-  { sourceIndexName, destinationAppID, destinationApiKey, destinationIndexName, batchSize }: AccountCopyIndexOptions,
+  { sourceIndexName, destinationAppID, destinationApiKey, destinationIndexName, batchSize, maxRetries = 100 }: AccountCopyIndexOptions,
   requestOptions?: RequestOptions | undefined,
 ): Promise<void> {
   const responses: Array<{ taskID: UpdatedAtResponse['taskID'] }> = [];
@@ -131,6 +132,6 @@ async accountCopyIndex(
   });
 
   for (const response of responses) {
-    await destinationClient.waitForTask({ indexName: destinationIndexName, taskID: response.taskID });
+    await destinationClient.waitForTask({ indexName: destinationIndexName, taskID: response.taskID, maxRetries });
   }
 },

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -15,8 +15,11 @@ import type { {{classname}} } from '{{filename}}';
 {{! Imports for the helpers method of the search client }}
 {{#isSearchClient}}
 import type { createSearchClient } from '../src/searchClient';
-import type { CreateIterablePromise } from '@algolia/client-common';
+import type { ChunkedHelperOptions, CreateIterablePromise } from '@algolia/client-common';
 {{/isSearchClient}}
+{{#isIngestionClient}}
+import type { ChunkedHelperOptions } from '@algolia/client-common';
+{{/isIngestionClient}}
 
 {{#operations}}
 {{#operation}}
@@ -134,7 +137,7 @@ export type SearchClientNodeHelpers = {
 };
 {{/isSearchClient}}
 
-export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'waitForTasks' | 'batchSize' | 'maxRetries'> & {
+export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'waitForTasks' | 'batchSize'> & ChunkedHelperOptions & {
   /**
    * The objectIDs to delete.
    */
@@ -143,8 +146,8 @@ export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'wait
 
 export type PartialUpdateObjectsOptions = Pick<
   ChunkedBatchOptions,
-  'indexName' | 'objects' | 'waitForTasks' | 'batchSize' | 'maxRetries'
-> & {
+  'indexName' | 'objects' | 'waitForTasks' | 'batchSize'
+> & ChunkedHelperOptions & {
   /**
    *To be provided if non-existing objects are passed, otherwise, the call will fail.
    */
@@ -153,8 +156,8 @@ export type PartialUpdateObjectsOptions = Pick<
 
 export type SaveObjectsOptions = Pick<
   ChunkedBatchOptions,
-  'indexName' | 'objects' | 'waitForTasks' | 'batchSize' | 'maxRetries'
->;
+  'indexName' | 'objects' | 'waitForTasks' | 'batchSize'
+> & ChunkedHelperOptions;
 
 export type ChunkedBatchOptions = ReplaceAllObjectsOptions & {
   /**
@@ -168,7 +171,7 @@ export type ChunkedBatchOptions = ReplaceAllObjectsOptions & {
   waitForTasks?: boolean | undefined;
 }
 
-export type ReplaceAllObjectsOptions = {
+export type ReplaceAllObjectsOptions = ChunkedHelperOptions & {
   /**
    * The `indexName` to replace `objects` in.
    */
@@ -188,14 +191,9 @@ export type ReplaceAllObjectsOptions = {
    * The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms'].
    */
   scopes?: Array<ScopeType> | undefined;
-
-  /**
-   * The maximum number of retries when polling for task completion. 100 by default.
-   */
-  maxRetries?: number | undefined;
 }
 
-export type AccountCopyIndexOptions = {
+export type AccountCopyIndexOptions = ChunkedHelperOptions & {
   /**
    * The name of the index to copy to the `destinationClient`.
    */
@@ -220,11 +218,6 @@ export type AccountCopyIndexOptions = {
    * The size of the chunk of `objects`. Defaults to 1000.
    */
   batchSize?: number | undefined;
-
-  /**
-   * The maximum number of retries when polling for task completion. 100 by default.
-   */
-  maxRetries?: number | undefined;
 };
 {{/isAlgoliasearchClient}}
 {{/isSearchClient}}
@@ -252,7 +245,7 @@ export type WaitForCompositionTaskOptions = {
 };
 {{/isCompositionClient}}
 {{#isIngestionClient}}
-export type ChunkedPushOptions = {
+export type ChunkedPushOptions = ChunkedHelperOptions & {
   /**
    * The `indexName` to replace `objects` in.
    */
@@ -282,11 +275,6 @@ export type ChunkedPushOptions = {
    * The array of `objects` to store in the given Algolia `indexName`.
    */
   objects: Array<Record<string, unknown>>;
-
-  /**
-   * The maximum number of retries when polling for task completion. 100 by default.
-   */
-  maxRetries?: number | undefined;
 }
 {{/isIngestionClient}}
 

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -134,7 +134,7 @@ export type SearchClientNodeHelpers = {
 };
 {{/isSearchClient}}
 
-export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'waitForTasks' | 'batchSize'> & {
+export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'waitForTasks' | 'batchSize' | 'maxRetries'> & {
   /**
    * The objectIDs to delete.
    */
@@ -143,7 +143,7 @@ export type DeleteObjectsOptions = Pick<ChunkedBatchOptions, 'indexName' | 'wait
 
 export type PartialUpdateObjectsOptions = Pick<
   ChunkedBatchOptions,
-  'indexName' | 'objects' | 'waitForTasks' | 'batchSize'
+  'indexName' | 'objects' | 'waitForTasks' | 'batchSize' | 'maxRetries'
 > & {
   /**
    *To be provided if non-existing objects are passed, otherwise, the call will fail.
@@ -153,7 +153,7 @@ export type PartialUpdateObjectsOptions = Pick<
 
 export type SaveObjectsOptions = Pick<
   ChunkedBatchOptions,
-  'indexName' | 'objects' | 'waitForTasks' | 'batchSize'
+  'indexName' | 'objects' | 'waitForTasks' | 'batchSize' | 'maxRetries'
 >;
 
 export type ChunkedBatchOptions = ReplaceAllObjectsOptions & {
@@ -188,6 +188,11 @@ export type ReplaceAllObjectsOptions = {
    * The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms'].
    */
   scopes?: Array<ScopeType> | undefined;
+
+  /**
+   * The maximum number of retries when polling for task completion. 100 by default.
+   */
+  maxRetries?: number | undefined;
 }
 
 export type AccountCopyIndexOptions = {
@@ -272,6 +277,11 @@ export type ChunkedPushOptions = {
    * The array of `objects` to store in the given Algolia `indexName`.
    */
   objects: Array<Record<string, unknown>>;
+
+  /**
+   * The maximum number of retries when polling for task completion. 100 by default.
+   */
+  maxRetries?: number | undefined;
 }
 {{/isIngestionClient}}
 

--- a/templates/javascript/clients/client/model/clientMethodProps.mustache
+++ b/templates/javascript/clients/client/model/clientMethodProps.mustache
@@ -220,6 +220,11 @@ export type AccountCopyIndexOptions = {
    * The size of the chunk of `objects`. Defaults to 1000.
    */
   batchSize?: number | undefined;
+
+  /**
+   * The maximum number of retries when polling for task completion. 100 by default.
+   */
+  maxRetries?: number | undefined;
 };
 {{/isAlgoliasearchClient}}
 {{/isSearchClient}}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-472](https://algolia.atlassian.net/browse/API-472)

Mirrors the C# work in #6318 for the JavaScript client: makes `maxRetries` configurable on the chunked / long-polling helpers so callers aren't stuck with the 100-retry default when they need a longer (or shorter) ceiling.

### Changes

- Adds an optional `maxRetries` field to the option bags of every helper that polls `waitForTask` under the hood:
  - `chunkedBatch`, `saveObjects`, `deleteObjects`, `partialUpdateObjects`, `replaceAllObjects`, `accountCopyIndex` (search)
  - `chunkedPush` (ingestion)
- Threads the value through to each internal `waitForTask` call so it actually takes effect (defaults to 100, unchanged behavior when omitted).
- Introduces a shared `ChunkedHelperOptions` type in `@algolia/client-common` and mixes it into each helper's options type. Name + intent matches the C# `ChunkedHelperOptions` class so the two clients stay aligned, and gives us one place to add future shared helper config without growing every option type individually.

## 🧪 Test

- CTS passes for the JS client

[API-472]: https://algolia.atlassian.net/browse/API-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ