### PR TITLE
fix(javascript): improve caching performance

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -27,7 +27,7 @@
     "files": [
       {
         "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-        "maxSize": "14.8KB"
+        "maxSize": "14.9KB"
       },
       {
         "path": "packages/algoliasearch/dist/lite/builds/browser.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/cache/browser-local-storage-cache.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/cache/browser-local-storage-cache.test.ts
@@ -103,7 +103,7 @@ describe('browser local storage cache', () => {
 
     expect(missMock.mock.calls.length).toBe(1);
 
-    expect(localStorage.getItem(`algolia-client-js-${version}`)).toEqual('{}');
+    expect(localStorage.getItem(`algolia-client-js-${version}`)).toBeNull();
   });
 
   test('do throws localstorage exceptions on access', async () => {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
@@ -21,32 +21,28 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     getStorage().setItem(namespaceKey, JSON.stringify(namespace));
   }
 
-  function removeOutdatedCacheItems(): void {
+  function yieldToMain(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  function getFilteredNamespace(): Record<string, BrowserLocalStorageCacheItem> {
     const timeToLive = options.timeToLive ? options.timeToLive * 1000 : null;
     const namespace = getNamespace<BrowserLocalStorageCacheItem>();
+    const currentTime = new Date().getTime();
 
-    const filteredNamespaceWithoutOldFormattedCacheItems = Object.fromEntries(
+    return Object.fromEntries(
       Object.entries(namespace).filter(([, cacheItem]) => {
-        return cacheItem.timestamp !== undefined;
+        if (!cacheItem || cacheItem.timestamp === undefined) {
+          return false;
+        }
+
+        if (!timeToLive) {
+          return true;
+        }
+
+        return cacheItem.timestamp + timeToLive >= currentTime;
       }),
     );
-
-    setNamespace(filteredNamespaceWithoutOldFormattedCacheItems);
-
-    if (!timeToLive) {
-      return;
-    }
-
-    const filteredNamespaceWithoutExpiredItems = Object.fromEntries(
-      Object.entries(filteredNamespaceWithoutOldFormattedCacheItems).filter(([, cacheItem]) => {
-        const currentTimestamp = new Date().getTime();
-        const isExpired = cacheItem.timestamp + timeToLive < currentTimestamp;
-
-        return !isExpired;
-      }),
-    );
-
-    setNamespace(filteredNamespaceWithoutExpiredItems);
   }
 
   return {
@@ -57,23 +53,23 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
         miss: () => Promise.resolve(),
       },
     ): Promise<TValue> {
-      return Promise.resolve()
-        .then(() => {
-          removeOutdatedCacheItems();
+      return yieldToMain().then(() => {
+        const namespace = getFilteredNamespace();
+        const keyAsString = JSON.stringify(key);
+        const cachedItem = namespace[keyAsString];
 
-          return getNamespace<Promise<BrowserLocalStorageCacheItem>>()[JSON.stringify(key)];
-        })
-        .then((value) => {
-          return Promise.all([value ? value.value : defaultValue(), value !== undefined]);
-        })
-        .then(([value, exists]) => {
-          return Promise.all([value, exists || events.miss(value)]);
-        })
-        .then(([value]) => value);
+        setNamespace(namespace);
+
+        if (cachedItem) {
+          return cachedItem.value as TValue;
+        }
+
+        return defaultValue().then((value) => events.miss(value).then(() => value));
+      });
     },
 
     set<TValue>(key: Record<string, any> | string, value: TValue): Promise<TValue> {
-      return Promise.resolve().then(() => {
+      return yieldToMain().then(() => {
         const namespace = getNamespace();
 
         namespace[JSON.stringify(key)] = {
@@ -88,7 +84,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     },
 
     delete(key: Record<string, any> | string): Promise<void> {
-      return Promise.resolve().then(() => {
+      return yieldToMain().then(() => {
         const namespace = getNamespace();
 
         delete namespace[JSON.stringify(key)];

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
@@ -55,8 +55,7 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     ): Promise<TValue> {
       return yieldToMain().then(() => {
         const namespace = getFilteredNamespace();
-        const keyAsString = JSON.stringify(key);
-        const cachedItem = namespace[keyAsString];
+        const cachedItem = namespace[JSON.stringify(key)];
 
         setNamespace(namespace);
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/cache/createBrowserLocalStorageCache.ts
@@ -25,14 +25,19 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
     return new Promise((resolve) => setTimeout(resolve, 0));
   }
 
-  function getFilteredNamespace(): Record<string, BrowserLocalStorageCacheItem> {
+  function getFilteredNamespace(): {
+    namespace: Record<string, BrowserLocalStorageCacheItem>;
+    changed: boolean;
+  } {
     const timeToLive = options.timeToLive ? options.timeToLive * 1000 : null;
     const namespace = getNamespace<BrowserLocalStorageCacheItem>();
     const currentTime = new Date().getTime();
+    let changed = false;
 
-    return Object.fromEntries(
+    const filtered = Object.fromEntries(
       Object.entries(namespace).filter(([, cacheItem]) => {
         if (!cacheItem || cacheItem.timestamp === undefined) {
+          changed = true;
           return false;
         }
 
@@ -40,9 +45,16 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
           return true;
         }
 
-        return cacheItem.timestamp + timeToLive >= currentTime;
+        if (cacheItem.timestamp + timeToLive < currentTime) {
+          changed = true;
+          return false;
+        }
+
+        return true;
       }),
     );
+
+    return { namespace: filtered, changed };
   }
 
   return {
@@ -54,10 +66,12 @@ export function createBrowserLocalStorageCache(options: BrowserLocalStorageOptio
       },
     ): Promise<TValue> {
       return yieldToMain().then(() => {
-        const namespace = getFilteredNamespace();
+        const { namespace, changed } = getFilteredNamespace();
         const cachedItem = namespace[JSON.stringify(key)];
 
-        setNamespace(namespace);
+        if (changed) {
+          setNamespace(namespace);
+        }
 
         if (cachedItem) {
           return cachedItem.value as TValue;


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-308](https://algolia.atlassian.net/browse/API-308)

Ports the v4 caching performance fix ([algoliasearch-client-javascript#1604](https://github.com/algolia/algoliasearch-client-javascript/pull/1604)) to v5. The browser `localStorage` cache was blocking the main thread on every `get()` / `set()` / `delete()`, hurting INP in apps that point `responsesCache` at this cache (e.g. Luxottica, [CR-10399](https://algolia.atlassian.net/browse/CR-10399)) — keystroke handlers couldn't paint until all cache work drained.

### Changes included:

- `get()`: replace `removeOutdatedCacheItems` (two filter passes + two `setItem` writes) with a single-pass `getFilteredNamespace` that returns the filtered namespace without writing; the caller writes once. Drops a `get()` from 2 reads + 2 writes (with TTL) to 1 read + 1 write.
- `get()` / `set()` / `delete()`: swap the opening `Promise.resolve().then(...)` for `yieldToMain()` (= `setTimeout(resolve, 0)`). Cache work runs as a macrotask (browser can paint and process input between ops) instead of as a microtask (blocks until drained).
- `clear()` unchanged — no heavy work to defer; matches v4 PR.
- **v5 divergence from v4 PR**: `get()` further skips its `setNamespace()` write when `getFilteredNamespace` reports no items were filtered out (tracked via a `changed` flag). Happy-path `get()` becomes 1 read + 0 writes; the 1-write case only kicks in when items are actually being purged. The v4 PR always writes on every `get()`.

## 🧪 Test

- Validated visually via a side-by-side A/B harness (old vs new impl, toggleable, with CPU throttling): under realistic conditions (~3 MB namespace, TTL on, 3 cache ops/keystroke, 6× CPU throttle), keystroke-to-paint drops dramatically and long-task count collapses.

[API-308]: https://algolia.atlassian.net/browse/API-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CR-10399]: https://algolia.atlassian.net/browse/CR-10399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ