### PR TITLE
fix(specs): document abTest field on listIndices response

### DIFF
--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -71,6 +71,10 @@ fetchedIndex:
         - Ranking
     abTest:
       $ref: '#/fetchedIndexAbTest'
+    sourceABTest:
+      type: string
+      description: Name of the index that owns the A/B test configuration. Only present when this index participates in an A/B test configured on another index.
+      example: 'movies_dev_a'
   required:
     - name
     - createdAt
@@ -85,13 +89,25 @@ fetchedIndex:
 fetchedIndexAbTest:
   title: abTest
   type: object
-  additionalProperties: false
   description: A/B test metadata. Only present if the index is part of an active A/B test.
   properties:
     id:
       type: integer
       description: A/B test ID.
       example: 12345
+    isDark:
+      type: boolean
+      description: Whether the A/B test is a dark test (server-side measured, not user-facing). Only present when true.
+    version:
+      type: integer
+      description: A/B test schema version. Only present for v2 and later tests.
+      example: 2
+    type:
+      type: string
+      description: A/B test type. Only present for v2 and later tests. Currently always `index-configuration`.
+      example: 'index-configuration'
+    target:
+      $ref: '#/fetchedIndexAbTestTarget'
     variants:
       type: array
       description: A/B test variants.
@@ -101,15 +117,26 @@ fetchedIndexAbTest:
     - id
     - variants
 
+fetchedIndexAbTestTarget:
+  title: abTestTarget
+  type: object
+  description: A/B test target criteria. Only present for v2 and later tests.
+  properties:
+    indexName:
+      type: string
+      description: Index name to match. Use `*` to target the entire application.
+      example: 'movies'
+  required:
+    - indexName
+
 fetchedIndexAbTestVariant:
   title: abTestVariant
   type: object
-  additionalProperties: false
   description: A/B test variant for an index.
   properties:
     indexName:
       type: string
-      description: Index name of the variant.
+      description: Index name of the variant. Only present for v0/v1 tests; in v2 this moves into `payload`.
       example: 'movies'
     percentage:
       type: integer
@@ -117,7 +144,10 @@ fetchedIndexAbTestVariant:
       example: 50
     customSearchParameters:
       type: string
-      description: URL-encoded custom search parameters applied to this variant.
+      description: URL-encoded custom search parameters applied to this variant. Only present for v0/v1 tests; in v2 this moves into `payload`.
+    payload:
+      type: object
+      additionalProperties: true
+      description: Type-specific configuration. Only present for v2 and later tests. Shape depends on the parent A/B test's `type`.
   required:
-    - indexName
     - percentage

--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -69,6 +69,8 @@ fetchedIndex:
       description: Only present if the index is a [virtual replica](https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/how-to/sort-an-index-alphabetically/#virtual-replicas).
       x-categories:
         - Ranking
+    abTest:
+      $ref: '#/fetchedIndexAbTest'
   required:
     - name
     - createdAt
@@ -79,3 +81,39 @@ fetchedIndex:
     - lastBuildTimeS
     - pendingTask
     - numberOfPendingTasks
+
+fetchedIndexAbTest:
+  type: object
+  description: A/B test metadata. Only present if the index is part of an active A/B test.
+  properties:
+    id:
+      type: integer
+      description: A/B test ID.
+      example: 12345
+    variants:
+      type: array
+      description: A/B test variants.
+      items:
+        $ref: '#/fetchedIndexAbTestVariant'
+  required:
+    - id
+    - variants
+
+fetchedIndexAbTestVariant:
+  type: object
+  description: A/B test variant for an index.
+  properties:
+    indexName:
+      type: string
+      description: Index name of the variant.
+      example: 'movies'
+    percentage:
+      type: integer
+      description: Percentage of search traffic routed to this variant.
+      example: 50
+    customSearchParameters:
+      type: string
+      description: URL-encoded custom search parameters applied to this variant.
+  required:
+    - indexName
+    - percentage

--- a/specs/search/common/schemas/listIndicesResponse.yml
+++ b/specs/search/common/schemas/listIndicesResponse.yml
@@ -69,6 +69,8 @@ fetchedIndex:
       description: Only present if the index is a [virtual replica](https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/how-to/sort-an-index-alphabetically/#virtual-replicas).
       x-categories:
         - Ranking
+    abTest:
+      $ref: '#/fetchedIndexAbTest'
   required:
     - name
     - createdAt
@@ -79,3 +81,43 @@ fetchedIndex:
     - lastBuildTimeS
     - pendingTask
     - numberOfPendingTasks
+
+fetchedIndexAbTest:
+  title: abTest
+  type: object
+  additionalProperties: false
+  description: A/B test metadata. Only present if the index is part of an active A/B test.
+  properties:
+    id:
+      type: integer
+      description: A/B test ID.
+      example: 12345
+    variants:
+      type: array
+      description: A/B test variants.
+      items:
+        $ref: '#/fetchedIndexAbTestVariant'
+  required:
+    - id
+    - variants
+
+fetchedIndexAbTestVariant:
+  title: abTestVariant
+  type: object
+  additionalProperties: false
+  description: A/B test variant for an index.
+  properties:
+    indexName:
+      type: string
+      description: Index name of the variant.
+      example: 'movies'
+    percentage:
+      type: integer
+      description: Percentage of search traffic routed to this variant.
+      example: 50
+    customSearchParameters:
+      type: string
+      description: URL-encoded custom search parameters applied to this variant.
+  required:
+    - indexName
+    - percentage


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-420](https://algolia.atlassian.net/browse/API-420)

The `/1/indexes` endpoint (`listIndices`) returns A/B test metadata on entries for indices participating in an active A/B test, but the OpenAPI spec never declared any of it (reported in [algolia/algoliasearch-client-python#583](https://github.com/algolia/algoliasearch-client-python/issues/583)). All 11 generated SDKs were missing typed accessors — Python tolerated unknown fields via pydantic's `extra="allow"`, but stricter languages had no ergonomic access, and the public REST API docs didn't mention any of it.

### Changes included:

- Added on `fetchedIndex`:
  - `abTest` — A/B test metadata when this index owns the configuration.
  - `sourceABTest` — index name pointing at the owning index when this index only participates in someone else's A/B test.
- New schema `fetchedIndexAbTest` (titled `abTest`):
  - Always: `id`, `variants`.
  - v2+ only: `version`, `type`, `target`.
  - Conditional: `isDark` (when true).
- New schema `fetchedIndexAbTestTarget` (titled `abTestTarget`) — `{ indexName }`, only present for v2+ tests.
- New schema `fetchedIndexAbTestVariant` (titled `abTestVariant`):
  - Always: `percentage`.
  - v0/v1 only: `indexName`, `customSearchParameters?`.
  - v2+ only: `payload` (type-specific configuration; shape depends on parent `type`).

Schemas use `additionalProperties: true` (default) since the server explicitly plans to evolve `target` and `payload`.


[API-420]: https://algolia.atlassian.net/browse/API-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ