### PR TITLE
fix(swift): preserve host URL path prefix in Transporter

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Core/Networking/Transporter.swift
+++ b/clients/algoliasearch-client-swift/Sources/Core/Networking/Transporter.swift
@@ -76,8 +76,6 @@ open class Transporter {
             body = "{}".data(using: .utf8)
         }
 
-        urlComponents.percentEncodedPath = path
-
         if let percentEncodedQueryItems = APIHelper.mapValuesToQueryItems(requestOptions?.queryParameters) {
             urlComponents.percentEncodedQueryItems = percentEncodedQueryItems
         }
@@ -86,6 +84,15 @@ open class Transporter {
             let rawTimeout =
                 requestOptions?.timeout(for: callType) ?? self.configuration.timeout(for: callType)
             let timeout = TimeInterval(host.retryCount + 1) * rawTimeout
+
+            let hostComponents = URLComponents(url: host.url, resolvingAgainstBaseURL: true)
+            let basePath = hostComponents?.percentEncodedPath ?? ""
+            if basePath.isEmpty || basePath == "/" {
+                urlComponents.percentEncodedPath = path
+            } else {
+                let trimmedBase = basePath.hasSuffix("/") ? String(basePath.dropLast()) : basePath
+                urlComponents.percentEncodedPath = trimmedBase + path
+            }
 
             guard let url = urlComponents.url(relativeTo: host.url) else {
                 throw AlgoliaError.requestError(GenericError(description: "Malformed URL"))


### PR DESCRIPTION
## Summary

[API-395]
Fixes https://github.com/algolia/algoliasearch-client-swift/issues/890

When configuring a `SearchClient` with custom hosts that include a path prefix (e.g. for routing through a reverse proxy like `https://gateway.example.com/algolia/v3`), the path component was **silently dropped**.

### Root Cause

`Transporter.swift` used `URLComponents.url(relativeTo: host.url)` to construct request URLs. Per RFC 3986, when the reference has an absolute path (starting with `/`), it **replaces** the base URL's path entirely — the host's path prefix was always lost.

### Fix

- Moved path construction **inside** the retry loop (since different hosts may have different path prefixes)
- Prepends the host's `percentEncodedPath` before the API path
- Handles edge cases: empty path, root `/`, trailing slash (trimmed to avoid `//`)
- Uses `URLComponents.percentEncodedPath` (not `URL.path`) to preserve percent-encoding correctness

### Before / After

| Host URL | API Path | Before (bug) | After (fix) |
|---|---|---|---|
| `https://APP_ID.algolia.net` | `/1/indexes/products/query` | `https://APP_ID.algolia.net/1/indexes/products/query` ✅ | Same ✅ |
| `https://gateway.example.com/algolia/v3` | `/1/indexes/products/query` | `https://gateway.example.com/1/indexes/products/query` ❌ | `https://gateway.example.com/algolia/v3/1/indexes/products/query` ✅ |
| `https://gateway.example.com/my%20proxy` | `/1/indexes/products/query` | `https://gateway.example.com/1/indexes/products/query` ❌ | `https://gateway.example.com/my%20proxy/1/indexes/products/query` ✅ |


[API-395]: https://algolia.atlassian.net/browse/API-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ