### PR TITLE
fix(swift): searchResult fallback failures

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -370,6 +370,8 @@ public extension SearchClient {
                 acc.append(searchResponse)
             case .searchForFacetValuesResponse:
                 break
+            case .searchResponsePartial:
+                break
             }
         }
     }
@@ -391,6 +393,8 @@ public extension SearchClient {
             case let .searchResponse(searchResponse):
                 acc.append(contentsOf: searchResponse.hits)
             case .searchForFacetValuesResponse:
+                break
+            case .searchResponsePartial:
                 break
             }
         }
@@ -414,6 +418,8 @@ public extension SearchClient {
                 break
             case let .searchForFacetValuesResponse(searchForFacet):
                 acc.append(searchForFacet)
+            case .searchResponsePartial:
+                break
             }
         }
     }

--- a/templates/swift/modelObject.mustache
+++ b/templates/swift/modelObject.mustache
@@ -75,7 +75,7 @@
           throw GenericError(description: "Failed to cast")
         }
         self.{{{name}}} = {{{name}}}{{/required}}{{^required}}
-        self.{{{name}}} = dictionary["{{{name}}}"]?.value as? {{{datatype}}}
+        self.{{{name}}} = dictionary["{{{name}}}"]?.value as? {{> generic_type}}
         {{/required}}
       {{/vars}}
 


### PR DESCRIPTION
## 🧭 What and Why

Fixes the Swift Linux build failure on #6350, which adds `SearchResponsePartial<T>` as a third `oneOf` branch in `SearchResult`.

The Swift `modelObject` template used raw `{{{datatype}}}` for the **optional-path** dictionary cast in `init(from dictionary:)`, producing `as? [Hit]` against a field declared `[T]?`. The required-path cast already used the generic-aware `{{> generic_type}}` partial — line 78 was the only place still on the raw type.

Latent until now: `SearchResponse<T>.hits` is required and took the required-path branch. `SearchResponsePartial<T>.hits` is optional, so it surfaced the bug for the first time.

### Changes included

- `templates/swift/modelObject.mustache`: optional-path cast now uses `{{> generic_type}}`