### PR TITLE
fix(csharp): use typed constructor in oneOf to avoid duplicate signat…

### DIFF
--- a/templates/csharp/modelOneOf.mustache
+++ b/templates/csharp/modelOneOf.mustache
@@ -45,7 +45,7 @@
           /// with a {{#lambdaCref}}{{{dataType}}}{{/lambdaCref}}
           /// </summary>
           /// <param name="actualInstance">An instance of {{{dataType}}}.</param>
-          public {{classname}}(object actualInstance)
+          public {{classname}}({{{dataType}}}<T> actualInstance)
           {
               ActualInstance = actualInstance{{^model.isNullable}}{{^isPrimitiveType}}{{^allowableValues}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/allowableValues}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isArray}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isArray}}{{#isFreeFormObject}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isFreeFormObject}}{{#isString}} ?? throw new ArgumentException("Invalid instance found. Must not be null."){{/isString}}{{/isPrimitiveType}}{{/model.isNullable}};
           }


### PR DESCRIPTION
## 🧭 What and Why

Fixes the C# build failure on #6350, which adds `SearchResponsePartial<T>` as a third `oneOf` branch in `SearchResult`.

The `modelOneOf` template emitted `public {{classname}}(object actualInstance)` for every branch flagged `x-has-child-generic`. With two generic branches in `SearchResult<T>`, the template wrote two identical constructors — CS0111. Latent until now: only one generic branch ever existed, so the `(object)` shortcut was always distinguishable from its siblings.

### Changes included

- `templates/csharp/modelOneOf.mustache`: generic-branch constructor now uses `({{{dataType}}}<T> actualInstance)` so each branch gets a uniquely-typed constructor