### PR TITLE
feat(swift): expose maximum number of retries

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/ChunkedHelperOptions.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/ChunkedHelperOptions.swift
@@ -1,0 +1,22 @@
+//
+//  ChunkedHelperOptions.swift
+//  AlgoliaSearchClient
+//
+//  Created by Algolia on 27/05/2026.
+//
+
+import Foundation
+
+/// Options for tuning the behaviour of the chunked / long-polling search helpers
+/// (`chunkedBatch`, `saveObjects`, `deleteObjects`, `partialUpdateObjects`,
+/// `replaceAllObjects`). Designed to grow — single field today; future shared
+/// helper configuration (e.g. `pollInterval`, `batchSize` defaults) can be added
+/// without changing every helper signature.
+public struct ChunkedHelperOptions {
+    /// Maximum number of retries when polling for task completion. Defaults to 100.
+    public var maxRetries: Int
+
+    public init(maxRetries: Int = 100) {
+        self.maxRetries = maxRetries
+    }
+}

--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -22,7 +22,7 @@ public extension SearchClient {
     func waitForTask(
         indexName: String,
         taskID: Int64,
-        maxRetries: Int = 50,
+        maxRetries: Int = 100,
         timeout: (Int) -> TimeInterval = { count in
             min(TimeInterval(count) * 0.2, 5)
         },
@@ -48,7 +48,7 @@ public extension SearchClient {
                     retryCount >= maxRetries
                 },
                 message: { _ in
-                    "The maximum number of retries exceeded. (\(retryCount)/\(maxRetries))"
+                    "Stopped waiting for the task after \(maxRetries) retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries."
                 }
             )
         )
@@ -63,7 +63,7 @@ public extension SearchClient {
     @discardableResult
     func waitForAppTask(
         taskID: Int64,
-        maxRetries: Int = 50,
+        maxRetries: Int = 100,
         timeout: (Int) -> TimeInterval = { count in
             min(TimeInterval(count) * 0.2, 5)
         },
@@ -89,7 +89,7 @@ public extension SearchClient {
                     retryCount >= maxRetries
                 },
                 message: { _ in
-                    "The maximum number of retries exceeded. (\(retryCount)/\(maxRetries))"
+                    "Stopped waiting for the task after \(maxRetries) retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries."
                 }
             )
         )
@@ -108,7 +108,7 @@ public extension SearchClient {
         key: String,
         operation: ApiKeyOperation,
         apiKey: ApiKey? = nil,
-        maxRetries: Int = 50,
+        maxRetries: Int = 100,
         timeout: (Int) -> TimeInterval = { retryCount in
             min(TimeInterval(retryCount) * 0.2, 5)
         },
@@ -177,7 +177,7 @@ public extension SearchClient {
                         retryCount >= maxRetries
                     },
                     message: { _ in
-                        "The maximum number of retries exceeded. (\(retryCount)/\(maxRetries))"
+                        "Stopped waiting for the task after \(maxRetries) retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries."
                     }
                 )
             )
@@ -220,7 +220,7 @@ public extension SearchClient {
                     retryCount >= maxRetries
                 },
                 message: { _ in
-                    "The maximum number of retries exceeded. (\(retryCount)/\(maxRetries))"
+                    "Stopped waiting for the task after \(maxRetries) retries. This does not mean the operation failed; it may still complete. If you need to keep polling, retry with a higher maxRetries."
                 }
             )
         )
@@ -432,6 +432,7 @@ public extension SearchClient {
     /// - parameter waitForTasks: If we should wait for the batch task to be finished before processing the next one
     /// - parameter batchSize: The maximum number of objects to include in a batch
     /// - parameter requestOptions: The request options
+    /// - parameter chunkedOptions: Options for tuning the chunked helper (e.g. polling budget)
     /// - returns: [BatchResponse]
     func chunkedBatch(
         indexName: String,
@@ -439,8 +440,10 @@ public extension SearchClient {
         action: SearchAction = .addObject,
         waitForTasks: Bool = false,
         batchSize: Int = 1000,
-        requestOptions: RequestOptions? = nil
+        requestOptions: RequestOptions? = nil,
+        chunkedOptions: ChunkedHelperOptions? = nil
     ) async throws -> [BatchResponse] {
+        let maxRetries = chunkedOptions?.maxRetries ?? 100
         let batches = stride(from: 0, to: objects.count, by: batchSize).map {
             Array(objects[$0 ..< min($0 + batchSize, objects.count)])
         }
@@ -465,6 +468,7 @@ public extension SearchClient {
                 try await self.waitForTask(
                     indexName: indexName,
                     taskID: batchResponse.taskID,
+                    maxRetries: maxRetries,
                     requestOptions: requestOptions
                 )
             }
@@ -480,13 +484,15 @@ public extension SearchClient {
     /// - parameter waitForTasks: If we should wait for the batch task to be finished before processing the next one
     /// - parameter batchSize: The maximum number of objects to include in a batch
     /// - parameter requestOptions: The request options
+    /// - parameter chunkedOptions: Options for tuning the chunked helper (e.g. polling budget)
     /// - returns: [BatchResponse]
     func saveObjects(
         indexName: String,
         objects: [some Encodable],
         waitForTasks: Bool = false,
         batchSize: Int = 1000,
-        requestOptions: RequestOptions? = nil
+        requestOptions: RequestOptions? = nil,
+        chunkedOptions: ChunkedHelperOptions? = nil
     ) async throws -> [BatchResponse] {
         try await self.chunkedBatch(
             indexName: indexName,
@@ -494,7 +500,8 @@ public extension SearchClient {
             action: .addObject,
             waitForTasks: waitForTasks,
             batchSize: batchSize,
-            requestOptions: requestOptions
+            requestOptions: requestOptions,
+            chunkedOptions: chunkedOptions
         )
     }
 
@@ -505,13 +512,15 @@ public extension SearchClient {
     /// - parameter waitForTasks: If we should wait for the batch task to be finished before processing the next one
     /// - parameter batchSize: The maximum number of objects to include in a batch
     /// - parameter requestOptions: The request options
+    /// - parameter chunkedOptions: Options for tuning the chunked helper (e.g. polling budget)
     /// - returns: [BatchResponse]
     func deleteObjects(
         indexName: String,
         objectIDs: [String],
         waitForTasks: Bool = false,
         batchSize: Int = 1000,
-        requestOptions: RequestOptions? = nil
+        requestOptions: RequestOptions? = nil,
+        chunkedOptions: ChunkedHelperOptions? = nil
     ) async throws -> [BatchResponse] {
         try await self.chunkedBatch(
             indexName: indexName,
@@ -519,7 +528,8 @@ public extension SearchClient {
             action: .deleteObject,
             waitForTasks: waitForTasks,
             batchSize: batchSize,
-            requestOptions: requestOptions
+            requestOptions: requestOptions,
+            chunkedOptions: chunkedOptions
         )
     }
 
@@ -532,6 +542,7 @@ public extension SearchClient {
     /// - parameter waitForTasks: If we should wait for the batch task to be finished before processing the next one
     /// - parameter batchSize: The maximum number of objects to include in a batch
     /// - parameter requestOptions: The request options
+    /// - parameter chunkedOptions: Options for tuning the chunked helper (e.g. polling budget)
     /// - returns: [BatchResponse]
     func partialUpdateObjects(
         indexName: String,
@@ -539,7 +550,8 @@ public extension SearchClient {
         createIfNotExists: Bool = false,
         waitForTasks: Bool = false,
         batchSize: Int = 1000,
-        requestOptions: RequestOptions? = nil
+        requestOptions: RequestOptions? = nil,
+        chunkedOptions: ChunkedHelperOptions? = nil
     ) async throws -> [BatchResponse] {
         try await self.chunkedBatch(
             indexName: indexName,
@@ -547,7 +559,8 @@ public extension SearchClient {
             action: createIfNotExists ? .partialUpdateObject : .partialUpdateObjectNoCreate,
             waitForTasks: waitForTasks,
             batchSize: batchSize,
-            requestOptions: requestOptions
+            requestOptions: requestOptions,
+            chunkedOptions: chunkedOptions
         )
     }
 
@@ -560,6 +573,7 @@ public extension SearchClient {
     /// - parameter batchSize: The maximum number of objects to include in a batch
     /// - parameter scopes: The `scopes` to keep from the index. Defaults to ['settings', 'rules', 'synonyms']
     /// - parameter requestOptions: The request options
+    /// - parameter chunkedOptions: Options for tuning the chunked helper (e.g. polling budget)
     /// - returns: ReplaceAllObjectsResponse
     @discardableResult
     func replaceAllObjects(
@@ -567,8 +581,10 @@ public extension SearchClient {
         objects: [some Encodable],
         batchSize: Int = 1000,
         scopes: [ScopeType] = [.settings, .rules, .synonyms],
-        requestOptions: RequestOptions? = nil
+        requestOptions: RequestOptions? = nil,
+        chunkedOptions: ChunkedHelperOptions? = nil
     ) async throws -> ReplaceAllObjectsResponse {
+        let maxRetries = chunkedOptions?.maxRetries ?? 100
         let tmpIndexName = "\(indexName)_tmp_\(Int.random(in: 1_000_000 ..< 10_000_000))"
 
         do {
@@ -587,9 +603,14 @@ public extension SearchClient {
                 objects: objects,
                 waitForTasks: true,
                 batchSize: batchSize,
-                requestOptions: requestOptions
+                requestOptions: requestOptions,
+                chunkedOptions: chunkedOptions
             )
-            try await self.waitForTask(indexName: tmpIndexName, taskID: copyOperationResponse.taskID)
+            try await self.waitForTask(
+                indexName: tmpIndexName,
+                taskID: copyOperationResponse.taskID,
+                maxRetries: maxRetries
+            )
 
             copyOperationResponse = try await operationIndex(
                 indexName: indexName,
@@ -600,7 +621,11 @@ public extension SearchClient {
                 ),
                 requestOptions: requestOptions
             )
-            try await self.waitForTask(indexName: tmpIndexName, taskID: copyOperationResponse.taskID)
+            try await self.waitForTask(
+                indexName: tmpIndexName,
+                taskID: copyOperationResponse.taskID,
+                maxRetries: maxRetries
+            )
 
             let moveOperationResponse = try await self.operationIndex(
                 indexName: tmpIndexName,
@@ -610,7 +635,11 @@ public extension SearchClient {
                 ),
                 requestOptions: requestOptions
             )
-            try await self.waitForTask(indexName: tmpIndexName, taskID: moveOperationResponse.taskID)
+            try await self.waitForTask(
+                indexName: tmpIndexName,
+                taskID: moveOperationResponse.taskID,
+                maxRetries: maxRetries
+            )
 
             return ReplaceAllObjectsResponse(
                 copyOperationResponse: copyOperationResponse,


### PR DESCRIPTION
## 🧭 What and Why

Mirrors #6318 (csharp), #6353 (javascript), #6401 (php), #6404 (python), and #6406 (go) for the Swift client: makes `maxRetries` configurable on every chunked / long-polling helper so callers aren't stuck with the default ceiling when they need a longer (or shorter) one.

### Changes included:

- New `ChunkedHelperOptions` struct (`public var maxRetries: Int = 100`). One field for now; designed to grow so future shared helper config can be added without ballooning each helper's signature. Name matches the C# / PHP / Python / JS types so the clients stay aligned.
- Added an optional trailing `chunkedOptions: ChunkedHelperOptions? = nil` parameter to `chunkedBatch`, `saveObjects`, `deleteObjects`, `partialUpdateObjects`, and `replaceAllObjects` (search). Threads the resolved value through every inner `waitForTask` call.
- **Default polling budget bumped 50 → 100** on `waitForTask`, `waitForAppTask`, and `waitForApiKey` (kept as a scalar parameter on these primitives — matches the csharp / php / python pattern). Brings Swift in line with the defaults already in csharp / php / python / go / js.
- Harmonized the poll-exhausted `IterableError` wording to match the friendlier message used in the sibling clients.

### Usage

```swift
try await client.replaceAllObjects(
    indexName: indexName,
    objects: objects,
    chunkedOptions: ChunkedHelperOptions(maxRetries: 200)
)
```

Existing call sites are unaffected — the new parameter is optional and trailing.