### PR TITLE
fix(python): pin release workflow to Python 3.13.x

### DIFF
--- a/.agents/skills/renovate/SKILL.md
+++ b/.agents/skills/renovate/SKILL.md
@@ -148,6 +148,7 @@ Close (do not merge) PRs that update these packages, and add them to the "Abando
 
 - **Dart `json_serializable`**: Updating `json_serializable` requires updating `json_annotation`, which in turn requires bumping the minimum Dart SDK version. This is a breaking change for customers on older Dart versions. Close the PR.
 - **`@redocly/cli` beyond v2.27.0**: v2.27.1 introduces breaking changes (renaming components) that break our spec bundling. Pinned at v2.27.0 for now. Close the PR.
+- **Python runtime ≥ 3.14**: The release toolchain for PyPI (poetry/twine) is not compatible with Python 3.14+. The `python-version` in `clients/algoliasearch-client-python/.github/workflows/release.yml` must stay on the 3.13.x line. If a PR bumps it to 3.14 or above, revert to the latest 3.13.x patch and close the PR.
 
 **Step 4.7 — Dart caret versioning.**
 

--- a/clients/algoliasearch-client-python/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-python/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-python@v6
       with:
-        python-version: 3.14.5
+        python-version: 3.13.13
 
     - name: install poetry
       shell: bash


### PR DESCRIPTION
## What

Reverts #6388 (Renovate bump to Python 3.14.5) and upgrades to the latest 3.13.x patch instead.

The PyPI release toolchain (poetry/twine) is not compatible with Python 3.14+, so the release workflow must stay on the 3.13.x line.

## Changes

- `clients/algoliasearch-client-python/.github/workflows/release.yml`: python-version 3.14.5 → 3.13.13 (latest 3.13.x patch)
- `.agents/skills/renovate/SKILL.md`: added Python ≥ 3.14 to the "Known blocked updates" list so future Renovate runs will auto-close these PRs

## Verification

- `release.yml` is hand-written (marked with `!` in `generation.config.mjs` line 15), so this change won't be overwritten by code generation
- Python 3.13.13 was released April 7, 2026 — well past the 3-day minimum age gate