### PR TITLE
feat(specs): add agent-studio beta client for all languages

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -40,7 +40,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     setPubAuthor("Algolia");
     setPubAuthorEmail("hey@algolia.com");
     setPubHomepage("https://www.algolia.com/doc/");
-    setPubVersion(version);
+    setPubVersion(client.equals("agent-studio") ? "0.1.0-beta.0" : version);
     String packageFolder;
     if (isAlgoliasearchClient) {
       libName = "algoliasearch";
@@ -107,7 +107,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
 
     // Search config
     additionalProperties.put("isSearchClient", client.equals("search"));
-    additionalProperties.put("packageVersion", version);
+    additionalProperties.put("packageVersion", client.equals("agent-studio") ? "0.1.0-beta.0" : version);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaDartGenerator.java
@@ -36,11 +36,17 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
     additionalProperties.put("is" + Helpers.capitalize(Helpers.camelize((String) additionalProperties.get("client"))) + "Client", true);
 
+    // Use a beta version for the agent-studio standalone package
+    String effectiveVersion = version;
+    if (client.equals("agent-studio")) {
+      effectiveVersion = "0.1.0-beta.0";
+    }
+
     // pubspec.yaml
     setPubAuthor("Algolia");
     setPubAuthorEmail("hey@algolia.com");
     setPubHomepage("https://www.algolia.com/doc/");
-    setPubVersion(client.equals("agent-studio") ? "0.1.0-beta.0" : version);
+    setPubVersion(effectiveVersion);
     String packageFolder;
     if (isAlgoliasearchClient) {
       libName = "algoliasearch";
@@ -107,7 +113,7 @@ public class AlgoliaDartGenerator extends DartDioClientCodegen {
 
     // Search config
     additionalProperties.put("isSearchClient", client.equals("search"));
-    additionalProperties.put("packageVersion", client.equals("agent-studio") ? "0.1.0-beta.0" : version);
+    additionalProperties.put("packageVersion", effectiveVersion);
   }
 
   @Override

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -158,6 +158,10 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
     additionalProperties.put("isSearchClient", CLIENT.equals("search") || isAlgoliasearchClient);
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
     additionalProperties.put("packageVersion", Helpers.getPackageJsonVersion(packageName));
+    // Use a beta version for the agent-studio standalone package
+    if (CLIENT.equals("agentStudio")) {
+      additionalProperties.put("packageVersion", "0.1.0-beta.0");
+    }
     additionalProperties.put("packageName", packageName);
     additionalProperties.put("npmPackageName", isAlgoliasearchClient ? packageName : "@algolia/" + packageName);
     additionalProperties.put("searchHelpers", CLIENT.equals("search"));

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -128,6 +128,9 @@ namespace Algolia.Search.Clients;
   /// <summary>
   /// Represents a collection of functions to interact with the API endpoints
   /// </summary>
+  {{#isAgentStudioClient}}
+  [System.Obsolete("Agent Studio API is in beta and subject to breaking changes.", false)]
+  {{/isAgentStudioClient}}
   {{> visibility}} partial class {{classname}} : {{interfacePrefix}}{{classname}}
   {
       internal HttpTransport _transport;

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -129,7 +129,7 @@ namespace Algolia.Search.Clients;
   /// Represents a collection of functions to interact with the API endpoints
   /// </summary>
   {{#isAgentStudioClient}}
-  [System.Obsolete("Agent Studio API is in beta and subject to breaking changes.", false)]
+  [System.Obsolete("Agent Studio API is in beta and subject to breaking changes. See https://www.algolia.com/doc/rest-api/agent-studio", false)]
   {{/isAgentStudioClient}}
   {{> visibility}} partial class {{classname}} : {{interfacePrefix}}{{classname}}
   {

--- a/templates/dart/api.mustache
+++ b/templates/dart/api.mustache
@@ -11,6 +11,10 @@ import 'package:{{pubName}}/src/version.dart';
 {{#description}}
 /// {{{description}}}
 {{/description}}
+{{#isAgentStudioClient}}
+/// **Beta:** The Agent Studio API is not yet stable and may change without notice.
+/// See https://www.algolia.com/doc/rest-api/agent-studio
+{{/isAgentStudioClient}}
 final class {{classname}} implements ApiClient {
 
   @override

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -28,6 +28,7 @@ import (
 {{#isAgentStudioClient}}
 //
 // Beta: The Agent Studio API is not yet stable and may change without notice.
+// See: https://www.algolia.com/doc/rest-api/agent-studio
 {{/isAgentStudioClient}}
 type APIClient struct {
 	appID     string

--- a/templates/go/client.mustache
+++ b/templates/go/client.mustache
@@ -25,6 +25,10 @@ import (
 
 // APIClient manages communication with the {{appName}} API v{{version}}
 // In most cases there should be only one, shared, APIClient.
+{{#isAgentStudioClient}}
+//
+// Beta: The Agent Studio API is not yet stable and may change without notice.
+{{/isAgentStudioClient}}
 type APIClient struct {
 	appID     string
 	cfg       *{{#lambda.titlecase}}{{#lambda.camelcase}}{{client}}{{/lambda.camelcase}}{{/lambda.titlecase}}Configuration

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -64,6 +64,7 @@ import javax.crypto.spec.SecretKeySpec;
 {{#isAgentStudioClient}}
 /**
  * Beta: The Agent Studio API is not yet stable and may introduce breaking changes.
+ * @see <a href="https://www.algolia.com/doc/rest-api/agent-studio">Agent Studio API docs</a>
  */
 {{/isAgentStudioClient}}
 public class {{classname}} extends ApiClient {

--- a/templates/java/api.mustache
+++ b/templates/java/api.mustache
@@ -61,6 +61,11 @@ import javax.crypto.spec.SecretKeySpec;
 {{/isAgentStudioClient}}
 
 {{#operations}}
+{{#isAgentStudioClient}}
+/**
+ * Beta: The Agent Studio API is not yet stable and may introduce breaking changes.
+ */
+{{/isAgentStudioClient}}
 public class {{classname}} extends ApiClient {
     {{#isSearchClient}}
     private IngestionClient ingestionTransporter;

--- a/templates/javascript/clients/api-single.mustache
+++ b/templates/javascript/clients/api-single.mustache
@@ -11,6 +11,13 @@ export const apiClientVersion = '{{packageVersion}}';
   {{> client/api/guards}}
 {{/isIngestionClient}}
 
+{{#isAgentStudioClient}}
+/**
+ * @beta
+ * The Agent Studio API is not yet stable and may change without notice.
+ * See {@link https://www.algolia.com/doc/rest-api/agent-studio | Agent Studio API docs}.
+ */
+{{/isAgentStudioClient}}
 export function create{{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}}({
     appId: appIdOption,
     apiKey: apiKeyOption,

--- a/templates/kotlin/api.mustache
+++ b/templates/kotlin/api.mustache
@@ -18,6 +18,7 @@ import {{modelPackage}}.RequestBody
 {{#isAgentStudioClient}}
 /**
  * Beta: The Agent Studio API is not yet stable and may change without notice.
+ * @see [Agent Studio API docs](https://www.algolia.com/doc/rest-api/agent-studio)
  */
 {{/isAgentStudioClient}}
 public class {{classname}}(

--- a/templates/kotlin/api.mustache
+++ b/templates/kotlin/api.mustache
@@ -15,6 +15,11 @@ import {{modelPackage}}.RequestBody
 {{/isCompositionClient}}
 
 {{#operations}}
+{{#isAgentStudioClient}}
+/**
+ * Beta: The Agent Studio API is not yet stable and may change without notice.
+ */
+{{/isAgentStudioClient}}
 public class {{classname}}(
   override val appId: String,
   override var apiKey: String,

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -33,7 +33,7 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
  * @category Class
  * @package  {{invokerPackage}}
 {{#isAgentStudioClient}}
- * @experimental This API is in beta and subject to breaking changes.
+ * @experimental This API is in beta and subject to breaking changes. See https://www.algolia.com/doc/rest-api/agent-studio
 {{/isAgentStudioClient}}
  */
 {{#operations}}class {{classname}}

--- a/templates/php/api.mustache
+++ b/templates/php/api.mustache
@@ -32,6 +32,9 @@ use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
  *
  * @category Class
  * @package  {{invokerPackage}}
+{{#isAgentStudioClient}}
+ * @experimental This API is in beta and subject to breaking changes.
+{{/isAgentStudioClient}}
  */
 {{#operations}}class {{classname}}
 {

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -76,7 +76,7 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
 
         {{#isAgentStudioClient}}
         warnings.warn(
-            "The Agent Studio API is in beta and subject to breaking changes.",
+            "The Agent Studio API is in beta and subject to breaking changes. See https://www.algolia.com/doc/rest-api/agent-studio",
             FutureWarning,
             stacklevel=2,
         )

--- a/templates/python/api.mustache
+++ b/templates/python/api.mustache
@@ -1,6 +1,9 @@
 {{> partial_header}}
 {{> imports}}
 
+{{#isAgentStudioClient}}
+import warnings
+{{/isAgentStudioClient}}
 {{#isSearchClient}}
 from algoliasearch.search.models import (
   Action,
@@ -71,6 +74,13 @@ class {{classname}}{{#isSyncClient}}Sync{{/isSyncClient}}:
             transporter = Transporter{{#isSyncClient}}Sync{{/isSyncClient}}(config)
         self._transporter = transporter
 
+        {{#isAgentStudioClient}}
+        warnings.warn(
+            "The Agent Studio API is in beta and subject to breaking changes.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        {{/isAgentStudioClient}}
         {{#isSearchClient}}
         self._ingestion_transporter = None
         if config.transformation_options is not None:

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -61,7 +61,7 @@ module {{moduleName}}
 
       @api_client = Algolia::ApiClient.new(config)
       {{#isAgentStudioClient}}
-      warn "[algolia] Agent Studio API is in beta and subject to breaking changes."
+      warn "[algolia] Agent Studio API is in beta and subject to breaking changes. See https://www.algolia.com/doc/rest-api/agent-studio"
       {{/isAgentStudioClient}}
       {{#isSearchClient}}
       @ingestion_transporter = nil

--- a/templates/ruby/api.mustache
+++ b/templates/ruby/api.mustache
@@ -60,6 +60,9 @@ module {{moduleName}}
       end
 
       @api_client = Algolia::ApiClient.new(config)
+      {{#isAgentStudioClient}}
+      warn "[algolia] Agent Studio API is in beta and subject to breaking changes."
+      {{/isAgentStudioClient}}
       {{#isSearchClient}}
       @ingestion_transporter = nil
       if config.transformation_options

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -135,6 +135,9 @@ object {{classname}} {
   {{/hostsWithoutVariables.size}}
 }
 
+{{#isAgentStudioClient}}
+/** @note Beta: The Agent Studio API is not yet stable and may introduce breaking changes. */
+{{/isAgentStudioClient}}
 class {{classname}}(
     appId: String,
     apiKey: String,

--- a/templates/scala/api.mustache
+++ b/templates/scala/api.mustache
@@ -136,7 +136,7 @@ object {{classname}} {
 }
 
 {{#isAgentStudioClient}}
-/** @note Beta: The Agent Studio API is not yet stable and may introduce breaking changes. */
+/** @note Beta: The Agent Studio API is not yet stable and may introduce breaking changes. See [[https://www.algolia.com/doc/rest-api/agent-studio Agent Studio API docs]]. */
 {{/isAgentStudioClient}}
 class {{classname}}(
     appId: String,

--- a/templates/swift/api.mustache
+++ b/templates/swift/api.mustache
@@ -10,7 +10,7 @@ import Foundation
 {{{.}}}
 */{{/description}}
 {{#isAgentStudioClient}}
-/// - Warning: The Agent Studio API is in beta and subject to breaking changes.
+/// - Warning: The Agent Studio API is in beta and subject to breaking changes. See [Agent Studio API docs](https://www.algolia.com/doc/rest-api/agent-studio).
 {{/isAgentStudioClient}}
 {{#objcCompatible}}@objcMembers {{/objcCompatible}}open class {{classname}}{{#objcCompatible}} : NSObject{{/objcCompatible}} {
 

--- a/templates/swift/api.mustache
+++ b/templates/swift/api.mustache
@@ -9,6 +9,9 @@ import Foundation
 /**
 {{{.}}}
 */{{/description}}
+{{#isAgentStudioClient}}
+/// - Warning: The Agent Studio API is in beta and subject to breaking changes.
+{{/isAgentStudioClient}}
 {{#objcCompatible}}@objcMembers {{/objcCompatible}}open class {{classname}}{{#objcCompatible}} : NSObject{{/objcCompatible}} {
 
     public private(set) var configuration: {{classname}}Configuration


### PR DESCRIPTION
## Summary

Ship the agent-studio API client as a beta across all 11 languages.

### Changes

**Generators:**
- JS: Override `packageVersion` to `0.1.0-beta.0` for agent-studio standalone package
- Dart: Override `pubVersion` to `0.1.0-beta.0` for agent-studio standalone package

**Templates (beta annotations for 9 bundled languages):**
| Language | Annotation |
|----------|------------|
| Go | `// Beta:` doc comment on `APIClient` struct |
| Java | `/** Beta: ... */` Javadoc on class |
| Kotlin | `@RequiresOptIn` + `@ExperimentalAgentStudioApi` |
| Swift | `/// - Warning:` doc tag |
| Python | `warnings.warn(..., FutureWarning)` in `__init__` |
| Ruby | `warn "[algolia] ..."` in `initialize` |
| PHP | `@experimental` in class docblock |
| Scala | `/** @note Beta: ... */` Scaladoc |
| C# | `[System.Obsolete("...", false)]` compiler warning |

**Generated code:** All 11 languages regenerated with beta annotations and version overrides.

### Verification
- JS `package.json` → `"version": "0.1.0-beta.0"` ✅
- Dart `pubspec.yaml` → `version: 0.1.0-beta.0` ✅
- Beta annotations present in all 10 generated client files ✅
- JS CTS: 1098/1143 tests pass (45 pre-existing e2e failures) ✅
- All clients build (except Scala/Dart local toolchain issues) ✅