### PR TITLE
docs(guides): add gzip compression guide for all 11 languages

### DIFF
--- a/templates/csharp/guides/search/compression.mustache
+++ b/templates/csharp/guides/search/compression.mustache
@@ -1,0 +1,29 @@
+namespace Algolia;
+
+using System;
+{{> snippets/import}}
+using Algolia.Search.Models.Common;
+
+class Compression
+{
+    async Task Main(string[] args)
+    {
+        // Initialize the client with gzip compression enabled
+        // Compression reduces the size of request bodies sent to Algolia
+        var client = new {{client}}(new {{clientPrefix}}Config("ALGOLIA_APPLICATION_ID", "ALGOLIA_API_KEY")
+        {
+            Compression = CompressionType.Gzip
+        });
+
+        // Search with compressed request body
+        try
+        {
+            var result = {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}};
+            Console.WriteLine(result);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+}

--- a/templates/dart/guides/search/compression.mustache
+++ b/templates/dart/guides/search/compression.mustache
@@ -1,0 +1,19 @@
+{{> snippets/import}}
+
+void compression() async {
+    // Initialize the client with gzip compression enabled
+    // Compression reduces the size of request bodies sent to Algolia
+    final client = {{client}}(
+        appId: 'ALGOLIA_APPLICATION_ID',
+        apiKey: 'ALGOLIA_API_KEY',
+        options: ClientOptions(compression: 'gzip'),
+    );
+
+    try {
+        // Search with compressed request body
+        final result = await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}};
+        print(result);
+    } catch (e) {
+        print("Error: ${e.toString()}");
+    }
+}

--- a/templates/go/guides/search/compression.mustache
+++ b/templates/go/guides/search/compression.mustache
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 )
 
 {{> snippets/import}}
-import "github.com/algolia/algoliasearch-client-go/v4/algolia/compression"
-import "github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
 
-func compression() {
+func enableCompression() {
 	// Initialize the client with gzip compression enabled
 	// Compression reduces the size of request bodies sent to Algolia
 	cfg := {{clientPrefix}}.{{clientName}}Configuration{
@@ -29,5 +30,6 @@ func compression() {
 		panic(err)
 	}
 
-	fmt.Printf("Found %d hits\n", len(result.Hits))
+	_ = result
+	fmt.Println("Search with compression completed successfully")
 }

--- a/templates/go/guides/search/compression.mustache
+++ b/templates/go/guides/search/compression.mustache
@@ -15,7 +15,7 @@ func enableCompression() {
 	cfg := {{clientPrefix}}.{{clientName}}Configuration{
 		Configuration: transport.Configuration{
 			AppID:       "ALGOLIA_APPLICATION_ID",
-			ApiKey:      "ALGOLIA_API_KEY", //nolint:gosec
+			ApiKey:      "ALGOLIA_API_KEY", // #nosec G101 -- credentials are placeholders
 			Compression: compression.GZIP,
 		},
 	}

--- a/templates/go/guides/search/compression.mustache
+++ b/templates/go/guides/search/compression.mustache
@@ -15,7 +15,7 @@ func enableCompression() {
 	cfg := {{clientPrefix}}.{{clientName}}Configuration{
 		Configuration: transport.Configuration{
 			AppID:       "ALGOLIA_APPLICATION_ID",
-			ApiKey:      "ALGOLIA_API_KEY",
+			ApiKey:      "ALGOLIA_API_KEY", //nolint:gosec
 			Compression: compression.GZIP,
 		},
 	}

--- a/templates/go/guides/search/compression.mustache
+++ b/templates/go/guides/search/compression.mustache
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+)
+
+{{> snippets/import}}
+import "github.com/algolia/algoliasearch-client-go/v4/algolia/compression"
+import "github.com/algolia/algoliasearch-client-go/v4/algolia/transport"
+
+func compression() {
+	// Initialize the client with gzip compression enabled
+	// Compression reduces the size of request bodies sent to Algolia
+	cfg := {{clientPrefix}}.{{clientName}}Configuration{
+		Configuration: transport.Configuration{
+			AppID:       "ALGOLIA_APPLICATION_ID",
+			ApiKey:      "ALGOLIA_API_KEY",
+			Compression: compression.GZIP,
+		},
+	}
+	client, err := {{clientPrefix}}.NewClientWithConfig(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	// Search with compressed request body
+	result, err := {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Found %d hits\n", len(result.Hits))
+}

--- a/templates/go/snippets/.golangci.mustache
+++ b/templates/go/snippets/.golangci.mustache
@@ -21,7 +21,6 @@ linters:
     - maintidx
     - mnd
     - noctx
-    - nolintlint
     - paralleltest
     - tagliatelle
     - testpackage

--- a/templates/go/snippets/.golangci.mustache
+++ b/templates/go/snippets/.golangci.mustache
@@ -21,6 +21,7 @@ linters:
     - maintidx
     - mnd
     - noctx
+    - nolintlint
     - paralleltest
     - tagliatelle
     - testpackage

--- a/templates/java/guides/search/compression.mustache
+++ b/templates/java/guides/search/compression.mustache
@@ -1,0 +1,20 @@
+package com.algolia;
+
+{{> snippets/import}}
+
+public class compression {
+  public static void main(String[] args) throws Exception {
+    // Initialize the client with gzip compression enabled
+    // Compression reduces the size of request bodies sent to Algolia
+    {{client}} client = new {{client}}(
+      "ALGOLIA_APPLICATION_ID",
+      "ALGOLIA_API_KEY",
+      ClientOptions.builder().setCompressionType(CompressionType.GZIP).build()
+    );
+
+    // Search with compressed request body
+    var result = {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}};
+    System.out.println(result.getHits());
+    client.close();
+  }
+}

--- a/templates/javascript/guides/search/compression.mustache
+++ b/templates/javascript/guides/search/compression.mustache
@@ -1,0 +1,17 @@
+{{> snippets/import}}
+
+// Initialize the client with gzip compression enabled
+// Compression reduces the size of request bodies sent to Algolia
+const client = {{{clientName}}}('ALGOLIA_APPLICATION_ID', 'ALGOLIA_API_KEY', {
+  compression: 'gzip',
+});
+
+// Search with compressed request body
+const searchCompression = async () => {
+  const result = await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}};
+  console.log(result.hits);
+};
+
+searchCompression()
+  .then(() => console.log('Done!'))
+  .catch((err) => console.error(err));

--- a/templates/kotlin/guides/search/compression.mustache
+++ b/templates/kotlin/guides/search/compression.mustache
@@ -1,0 +1,20 @@
+package org.example
+{{> snippets/import}}
+
+suspend fun main() {
+    // Initialize the client with gzip compression enabled
+    // Compression reduces the size of request bodies sent to Algolia
+    val client = {{client}}(
+        appId = "ALGOLIA_APPLICATION_ID",
+        apiKey = "ALGOLIA_API_KEY",
+        options = ClientOptions(compressionType = CompressionType.GZIP),
+    )
+
+    // Search with compressed request body
+    try {
+        val result = client.{{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+        println(result.hits)
+    } catch (e: Exception) {
+        println(e.message)
+    }
+}

--- a/templates/kotlin/guides/search/compression.mustache
+++ b/templates/kotlin/guides/search/compression.mustache
@@ -1,5 +1,6 @@
 package org.example
 {{> snippets/import}}
+import com.algolia.client.model.search.*
 
 suspend fun main() {
     // Initialize the client with gzip compression enabled

--- a/templates/php/guides/search/compression.mustache
+++ b/templates/php/guides/search/compression.mustache
@@ -1,0 +1,15 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+{{> snippets/import}}
+use Algolia\AlgoliaSearch\Configuration\{{clientPrefix}}Config;
+
+// Initialize the client with gzip compression enabled
+// Compression reduces the size of request bodies sent to Algolia
+$config = {{clientPrefix}}Config::create('ALGOLIA_APPLICATION_ID', 'ALGOLIA_API_KEY')
+  ->setCompressionType('gzip');
+$client = {{client}}::createWithConfig($config);
+
+// Search with compressed request body
+$result = {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}};
+var_dump($result);

--- a/templates/python/guides/search/compression.mustache
+++ b/templates/python/guides/search/compression.mustache
@@ -1,0 +1,12 @@
+from algoliasearch.search.config import SearchConfig
+{{> snippets/import}}
+
+
+# Initialize the client with gzip compression enabled
+# Compression reduces the size of request bodies sent to Algolia
+_config = SearchConfig("ALGOLIA_APPLICATION_ID", "ALGOLIA_API_KEY")
+_config.compression_type = "gzip"
+_client = {{#lambda.pascalcase}}{{{client}}}Sync{{/lambda.pascalcase}}.create_with_config(config=_config)
+
+# Search with compressed request body
+{{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}

--- a/templates/ruby/guides/search/compression.mustache
+++ b/templates/ruby/guides/search/compression.mustache
@@ -1,0 +1,13 @@
+{{> snippets/import}}
+
+# Initialize the client with gzip compression enabled
+# Compression reduces the size of request bodies sent to Algolia
+client = Algolia::{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}.create(
+  'ALGOLIA_APPLICATION_ID',
+  'ALGOLIA_API_KEY',
+  compression_type: 'gzip'
+)
+
+# Search with compressed request body
+result = {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+puts(result)

--- a/templates/scala/guides/search/compression.mustache
+++ b/templates/scala/guides/search/compression.mustache
@@ -1,0 +1,26 @@
+{{> snippets/import}}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    implicit val ec: scala.concurrent.ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+
+    // Initialize the client with gzip compression enabled
+    // Compression reduces the size of request bodies sent to Algolia
+    val client = {{client}}(
+      appId = "ALGOLIA_APPLICATION_ID",
+      apiKey = "ALGOLIA_API_KEY",
+      clientOptions = ClientOptions().withCompressionType(CompressionType.Gzip)
+    )
+
+    // Search with compressed request body
+    try {
+      val result = scala.concurrent.Await.result(
+        {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}},
+        scala.concurrent.duration.Duration(100, "sec")
+      )
+      println(result)
+    } catch {
+      case e: Exception => println(e)
+    }
+  }
+}

--- a/templates/scala/guides/search/compression.mustache
+++ b/templates/scala/guides/search/compression.mustache
@@ -1,4 +1,5 @@
 {{> snippets/import}}
+import algoliasearch.search.SearchParamsObject
 
 object Compression {
   def main(args: Array[String]): Unit = {

--- a/templates/scala/guides/search/compression.mustache
+++ b/templates/scala/guides/search/compression.mustache
@@ -1,6 +1,6 @@
 {{> snippets/import}}
 
-object Main {
+object Compression {
   def main(args: Array[String]): Unit = {
     implicit val ec: scala.concurrent.ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 
@@ -9,7 +9,10 @@ object Main {
     val client = {{client}}(
       appId = "ALGOLIA_APPLICATION_ID",
       apiKey = "ALGOLIA_API_KEY",
-      clientOptions = ClientOptions().withCompressionType(CompressionType.Gzip)
+      clientOptions = ClientOptions
+        .builder()
+        .withCompressionType(CompressionType.Gzip)
+        .build()
     )
 
     // Search with compressed request body

--- a/templates/swift/guides/search/compression.mustache
+++ b/templates/swift/guides/search/compression.mustache
@@ -1,4 +1,5 @@
 import Foundation
+import AlgoliaCore
 {{> snippets/import}}
 
 func compression() async throws {
@@ -13,8 +14,8 @@ func compression() async throws {
 
     do {
         // Search with compressed request body
-        let result = try await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
-        print(result)
+        let response: SearchResponse<Hit> = try await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+        print(response)
     } catch {
         print(error.localizedDescription)
     }

--- a/templates/swift/guides/search/compression.mustache
+++ b/templates/swift/guides/search/compression.mustache
@@ -1,0 +1,21 @@
+import Foundation
+{{> snippets/import}}
+
+func compression() async throws {
+    // Initialize the client with gzip compression enabled
+    // Compression reduces the size of request bodies sent to Algolia
+    let configuration = try {{client}}Configuration(
+        appID: "ALGOLIA_APPLICATION_ID",
+        apiKey: "ALGOLIA_API_KEY",
+        compression: .gzip
+    )
+    let client = {{client}}(configuration: configuration)
+
+    do {
+        // Search with compressed request body
+        let result = try await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+        print(result)
+    } catch {
+        print(error.localizedDescription)
+    }
+}

--- a/tests/CTS/guides/search.json
+++ b/tests/CTS/guides/search.json
@@ -158,5 +158,14 @@
       "objectID": "$var: objectID",
       "rule": "$var: rule"
     }
+  },
+  "searchWithCompression": {
+    "method": "searchSingleIndex",
+    "parameters": {
+      "indexName": "movies_index",
+      "searchParams": {
+        "query": "comedy"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Add a compression guide across all 11 API client languages showing how to enable gzip compression from imports to result.

## Changes

### New dynamic snippet entry
- `tests/CTS/guides/search.json` — added `searchWithCompression` mapping to `searchSingleIndex` with sample parameters

### New guide templates (11 files)
- `templates/{lang}/guides/search/compression.mustache` for JavaScript, Python, Java, Go, Ruby, PHP, Kotlin, Scala, Swift, Dart, C#

Each guide demonstrates:
1. **Imports** — standard client imports + compression type imports where needed
2. **Client initialization with compression** — language-specific gzip configuration
3. **API call** — a `searchSingleIndex` call via `{{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}`
4. **Result handling** — language-idiomatic output

### Per-language compression APIs used

| Language | Configuration |
|---|---|
| JavaScript | `{ compression: 'gzip' }` option |
| Python | `SearchConfig` + `compression_type = "gzip"` |
| Java | `ClientOptions.builder().setCompressionType(CompressionType.GZIP)` |
| Go | `transport.Configuration{ Compression: compression.GZIP }` |
| Ruby | `compression_type: 'gzip'` |
| PHP | `->setCompressionType('gzip')` on config |
| Kotlin | `ClientOptions(compressionType = CompressionType.GZIP)` |
| Scala | `ClientOptions().withCompressionType(CompressionType.Gzip)` |
| Swift | `SearchClientConfiguration(compression: .gzip)` |
| Dart | `ClientOptions(compression: 'gzip')` |
| C# | `SearchConfig { Compression = CompressionType.Gzip }` |

## How to verify

```bash
yarn cli guides          # Generate all languages
yarn cli build guides    # Compile/type-check the generated output
```