### PR TITLE
test(clients): test chunked push polling mechanism

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ClientTestData.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ClientTestData.java
@@ -7,6 +7,7 @@ public class ClientTestData {
   public String testName;
   public boolean autoCreateClient = true;
   public List<Step> steps;
+  public List<String> skipLanguages;
 
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
@@ -70,6 +70,10 @@ public class TestsClient extends TestsGenerator {
       List<Object> tests = new ArrayList<>();
       int testIndex = 0;
       skipTest: for (ClientTestData test : blockEntry.getValue()) {
+        if (test.skipLanguages != null && test.skipLanguages.contains(language)) {
+          System.out.println("Skipping client test " + (test.testName == null ? client : test.testName) + " for language " + language);
+          continue skipTest;
+        }
         try {
           Map<String, Object> testOut = new HashMap<>();
           List<Map<String, Object>> steps = new ArrayList<>();

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -7,6 +7,7 @@ import type { Language } from '../types.ts';
 
 import { assertValidAccountCopyIndex } from './testServer/accountCopyIndex.ts';
 import { printBenchmarkReport } from './testServer/benchmark.ts';
+import { assertValidChunkedPushWait } from './testServer/chunkedPushWait.ts';
 import { assertChunkWrapperValid } from './testServer/chunkWrapper.ts';
 import { assertNeverCalledServerWasNotCalled, assertValidErrors } from './testServer/error.ts';
 import { startTestServer } from './testServer/index.ts';
@@ -199,6 +200,21 @@ export async function runCts(
     assertValidReplaceAllObjectsScopes(languages.length - skip('dart'));
     assertValidWaitForApiKey(languages.length - skip('dart'));
     assertPushMockValid(
+      only('javascript') +
+        only('go') +
+        only('python') +
+        only('java') +
+        only('php') +
+        only('csharp') +
+        only('scala') +
+        only('ruby') +
+        only('kotlin'),
+    );
+    // chunkedPush waitForTasks: every transformation-capable language is expected to poll each
+    // pushed task exactly once. Languages with the offset over-advance bug will fail this. Once the
+    // failing languages are identified in CI, exclude them via `skipLanguages` in the CTS spec and
+    // drop them from this sum, tracking each with a ticket.
+    assertValidChunkedPushWait(
       only('javascript') +
         only('go') +
         only('python') +

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -210,10 +210,8 @@ export async function runCts(
         only('ruby') +
         only('kotlin'),
     );
-    // dart/swift don't expose the helper; go/php/javascript are excluded via `skipLanguages` in the CTS spec
-    assertValidChunkedPushWait(
-      languages.length - skip('dart') - skip('swift') - skip('go') - skip('php') - skip('javascript'),
-    );
+    // dart/swift don't expose the helper
+    assertValidChunkedPushWait(languages.length - skip('dart') - skip('swift'));
   }
   if (withBenchmarkServer) {
     printBenchmarkReport();

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -210,8 +210,10 @@ export async function runCts(
         only('ruby') +
         only('kotlin'),
     );
-    // dart/swift don't expose the helper
-    assertValidChunkedPushWait(languages.length - skip('dart') - skip('swift'));
+    // dart/swift don't expose the helper; go/php/javascript are excluded via `skipLanguages` in the CTS spec
+    assertValidChunkedPushWait(
+      languages.length - skip('dart') - skip('swift') - skip('go') - skip('php') - skip('javascript'),
+    );
   }
   if (withBenchmarkServer) {
     printBenchmarkReport();

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -210,20 +210,9 @@ export async function runCts(
         only('ruby') +
         only('kotlin'),
     );
-    // chunkedPush waitForTasks: every transformation-capable language is expected to poll each
-    // pushed task exactly once. Languages with the offset over-advance bug will fail this. Once the
-    // failing languages are identified in CI, exclude them via `skipLanguages` in the CTS spec and
-    // drop them from this sum, tracking each with a ticket.
+    // dart/swift don't expose the helper; go/php/javascript are excluded via `skipLanguages` in the CTS spec
     assertValidChunkedPushWait(
-      only('javascript') +
-        only('go') +
-        only('python') +
-        only('java') +
-        only('php') +
-        only('csharp') +
-        only('scala') +
-        only('ruby') +
-        only('kotlin'),
+      languages.length - skip('dart') - skip('swift') - skip('go') - skip('php') - skip('javascript'),
     );
   }
   if (withBenchmarkServer) {

--- a/scripts/cts/testServer/chunkedPushWait.ts
+++ b/scripts/cts/testServer/chunkedPushWait.ts
@@ -6,7 +6,8 @@ import express from 'express';
 
 import { setupServer } from './index.ts';
 
-const chunkedPushWaitState: Record<string, { pushCount: number; getEventCount: number }> = {};
+const chunkedPushWaitState: Record<string, { pushCount: number; getEventCount: number; polledEventIDs: Set<string> }> =
+  {};
 
 // every pushed task must be polled exactly once; a poll cursor that over-advances polls fewer.
 export function assertValidChunkedPushWait(expectedCount: number): void {
@@ -15,6 +16,10 @@ export function assertValidChunkedPushWait(expectedCount: number): void {
     // at least 3 (25 objects / batchSize 10), not exactly: python runs the scenario twice (sync + async)
     expect(chunkedPushWaitState[lang].pushCount, `pushCount for ${lang}`).to.be.at.least(3);
     expect(chunkedPushWaitState[lang].getEventCount, `getEventCount for ${lang}`).to.equal(
+      chunkedPushWaitState[lang].pushCount,
+    );
+    // distinct events polled == events pushed: rules out polling one task twice while skipping another
+    expect(chunkedPushWaitState[lang].polledEventIDs.size, `distinct polled eventIDs for ${lang}`).to.equal(
       chunkedPushWaitState[lang].pushCount,
     );
   }
@@ -34,7 +39,7 @@ function addRoutes(app: Express): void {
     expect(req.body.action).to.equal('addObject');
 
     if (!chunkedPushWaitState[lang]) {
-      chunkedPushWaitState[lang] = { pushCount: 0, getEventCount: 0 };
+      chunkedPushWaitState[lang] = { pushCount: 0, getEventCount: 0, polledEventIDs: new Set() };
     }
     chunkedPushWaitState[lang].pushCount++;
 
@@ -52,6 +57,7 @@ function addRoutes(app: Express): void {
     expect(chunkedPushWaitState, `getEvent before any push for ${lang}`).to.include.keys(lang);
 
     chunkedPushWaitState[lang].getEventCount++;
+    chunkedPushWaitState[lang].polledEventIDs.add(req.params.eventID);
 
     res.json({
       status: 'succeeded',

--- a/scripts/cts/testServer/chunkedPushWait.ts
+++ b/scripts/cts/testServer/chunkedPushWait.ts
@@ -6,24 +6,13 @@ import express from 'express';
 
 import { setupServer } from './index.ts';
 
-// Per-language counters for the chunkedPush "waitForTasks" flow.
-// `pushCount`     = number of `push` requests the client made (one per batch).
-// `getEventCount` = number of `getEvent` polls the client made (must be one per pushed task).
 const chunkedPushWaitState: Record<string, { pushCount: number; getEventCount: number }> = {};
 
-// This test drives `saveObjectsWithTransformation` with batchSize=10 over 25 objects and
-// `waitForTasks: true`, which produces 3 batches (10/10/5) and a poll window of 1
-// (`waitBatchSize = batchSize / 10`). A correct helper polls `getEvent` exactly once per pushed
-// task (getEventCount === pushCount === 3). A helper whose poll cursor over-advances on non-push
-// iterations polls fewer tasks (getEventCount < pushCount), and a strongly-typed one that slices
-// past the end of its response list crashes instead — so this assertion fails for buggy clients.
+// every pushed task must be polled exactly once; a poll cursor that over-advances polls fewer.
 export function assertValidChunkedPushWait(expectedCount: number): void {
   expect(Object.keys(chunkedPushWaitState)).to.have.length(expectedCount);
   for (const lang in chunkedPushWaitState) {
-    // 25 objects at batchSize 10 => 3 batches per client variant. A language may run this twice
-    // (sync + async), so pushCount is a positive multiple of 3; we only require the triggering
-    // scenario ran at least once. The discriminator is the invariant below: every pushed task
-    // must be polled exactly once. A client whose poll cursor over-advances polls fewer.
+    // at least 3 (25 objects / batchSize 10), not exactly: python runs the scenario twice (sync + async)
     expect(chunkedPushWaitState[lang].pushCount, `pushCount for ${lang}`).to.be.at.least(3);
     expect(chunkedPushWaitState[lang].getEventCount, `getEventCount for ${lang}`).to.equal(
       chunkedPushWaitState[lang].pushCount,
@@ -76,7 +65,5 @@ function addRoutes(app: Express): void {
 }
 
 export function chunkedPushWaitServer(): Promise<Server> {
-  // simulates the ingestion `push` + `getEvent` endpoints to verify that the chunkedPush helper
-  // polls every pushed task when waitForTasks is true. See assertValidChunkedPushWait for details.
   return setupServer('chunkedPushWaitServer', 6692, addRoutes);
 }

--- a/scripts/cts/testServer/chunkedPushWait.ts
+++ b/scripts/cts/testServer/chunkedPushWait.ts
@@ -1,0 +1,82 @@
+import type { Server } from 'http';
+
+import { expect } from 'chai';
+import type { Express } from 'express';
+import express from 'express';
+
+import { setupServer } from './index.ts';
+
+// Per-language counters for the chunkedPush "waitForTasks" flow.
+// `pushCount`     = number of `push` requests the client made (one per batch).
+// `getEventCount` = number of `getEvent` polls the client made (must be one per pushed task).
+const chunkedPushWaitState: Record<string, { pushCount: number; getEventCount: number }> = {};
+
+// This test drives `saveObjectsWithTransformation` with batchSize=10 over 25 objects and
+// `waitForTasks: true`, which produces 3 batches (10/10/5) and a poll window of 1
+// (`waitBatchSize = batchSize / 10`). A correct helper polls `getEvent` exactly once per pushed
+// task (getEventCount === pushCount === 3). A helper whose poll cursor over-advances on non-push
+// iterations polls fewer tasks (getEventCount < pushCount), and a strongly-typed one that slices
+// past the end of its response list crashes instead — so this assertion fails for buggy clients.
+export function assertValidChunkedPushWait(expectedCount: number): void {
+  expect(Object.keys(chunkedPushWaitState)).to.have.length(expectedCount);
+  for (const lang in chunkedPushWaitState) {
+    // 25 objects at batchSize 10 => 3 batches per client variant. A language may run this twice
+    // (sync + async), so pushCount is a positive multiple of 3; we only require the triggering
+    // scenario ran at least once. The discriminator is the invariant below: every pushed task
+    // must be polled exactly once. A client whose poll cursor over-advances polls fewer.
+    expect(chunkedPushWaitState[lang].pushCount, `pushCount for ${lang}`).to.be.at.least(3);
+    expect(chunkedPushWaitState[lang].getEventCount, `getEventCount for ${lang}`).to.equal(
+      chunkedPushWaitState[lang].pushCount,
+    );
+  }
+}
+
+function addRoutes(app: Express): void {
+  app.use(express.urlencoded({ extended: true }));
+  app.use(
+    express.json({
+      type: ['application/json', 'text/plain'], // the js client sends the body as text/plain
+    }),
+  );
+
+  app.post('/1/push/:indexName', (req, res) => {
+    const lang = req.params.indexName.match(/^cts_e2e_chunked_push_wait_(.*)$/)?.[1] as string;
+    expect(lang, `unexpected index name ${req.params.indexName}`).to.not.equal(undefined);
+    expect(req.body.action).to.equal('addObject');
+
+    if (!chunkedPushWaitState[lang]) {
+      chunkedPushWaitState[lang] = { pushCount: 0, getEventCount: 0 };
+    }
+    chunkedPushWaitState[lang].pushCount++;
+
+    res.json({
+      runID: `b1b7a982-524c-40d2-bb7f-48aab075abda_${lang}`,
+      // a distinct eventID per push so the client polls a distinct task each time
+      eventID: `113b2068-6337-4c85-b5c2-e7b213d8292${chunkedPushWaitState[lang].pushCount}`,
+      message: 'OK',
+      createdAt: '2022-05-12T06:24:30.049Z',
+    });
+  });
+
+  app.get('/1/runs/:runID/events/:eventID', (req, res) => {
+    const lang = req.params.runID.match(/^b1b7a982-524c-40d2-bb7f-48aab075abda_(.*)$/)?.[1] as string;
+    expect(chunkedPushWaitState, `getEvent before any push for ${lang}`).to.include.keys(lang);
+
+    chunkedPushWaitState[lang].getEventCount++;
+
+    res.json({
+      status: 'succeeded',
+      eventID: req.params.eventID,
+      runID: req.params.runID,
+      type: 'fetch',
+      batchSize: 1,
+      publishedAt: '2022-05-12T06:24:30.049Z',
+    });
+  });
+}
+
+export function chunkedPushWaitServer(): Promise<Server> {
+  // simulates the ingestion `push` + `getEvent` endpoints to verify that the chunkedPush helper
+  // polls every pushed task when waitForTasks is true. See assertValidChunkedPushWait for details.
+  return setupServer('chunkedPushWaitServer', 6692, addRoutes);
+}

--- a/scripts/cts/testServer/index.ts
+++ b/scripts/cts/testServer/index.ts
@@ -11,6 +11,7 @@ import { accountCopyIndexServer } from './accountCopyIndex.ts';
 import { algoliaMockServer } from './algoliaMock.ts';
 import { apiKeyServer } from './apiKey.ts';
 import { benchmarkServer } from './benchmark.ts';
+import { chunkedPushWaitServer } from './chunkedPushWait.ts';
 import { chunkWrapperServer } from './chunkWrapper.ts';
 import { errorServer, errorServerRetriedOnce, errorServerRetriedTwice, neverCalledServer } from './error.ts';
 import { gzipServer } from './gzip.ts';
@@ -49,6 +50,7 @@ export async function startTestServer(suites: Record<CTSType, boolean>): Promise
       pushMockServer(),
       pushMockServerRetriedOnce(),
       replaceAllObjectsWithTransformationServer(),
+      chunkedPushWaitServer(),
     );
   }
   if (suites.benchmark) {

--- a/tests/CTS/client/search/saveObjectsWithTransformation.json
+++ b/tests/CTS/client/search/saveObjectsWithTransformation.json
@@ -104,6 +104,11 @@
           ],
           "waitForTasks": true,
           "batchSize": 10
+        },
+        "requestOptions": {
+          "headers": {
+            "x-algolia-user-id": "test-user"
+          }
         }
       }
     ]

--- a/tests/CTS/client/search/saveObjectsWithTransformation.json
+++ b/tests/CTS/client/search/saveObjectsWithTransformation.json
@@ -57,6 +57,7 @@
   {
     "testName": "saveObjectsWithTransformation polls every task when waitForTasks is true",
     "autoCreateClient": false,
+    "skipLanguages": ["go", "php", "javascript"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/search/saveObjectsWithTransformation.json
+++ b/tests/CTS/client/search/saveObjectsWithTransformation.json
@@ -53,5 +53,59 @@
         }
       }
     ]
+  },
+  {
+    "testName": "saveObjectsWithTransformation polls every task when waitForTasks is true",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [{ "port": 6692 }],
+          "transformationOptions": {
+            "region": "us",
+            "customHosts": [{ "port": 6692 }]
+          }
+        }
+      },
+      {
+        "type": "method",
+        "method": "saveObjectsWithTransformation",
+        "parameters": {
+          "indexName": "cts_e2e_chunked_push_wait_${{language}}",
+          "objects": [
+            { "objectID": "1", "name": "r1" },
+            { "objectID": "2", "name": "r2" },
+            { "objectID": "3", "name": "r3" },
+            { "objectID": "4", "name": "r4" },
+            { "objectID": "5", "name": "r5" },
+            { "objectID": "6", "name": "r6" },
+            { "objectID": "7", "name": "r7" },
+            { "objectID": "8", "name": "r8" },
+            { "objectID": "9", "name": "r9" },
+            { "objectID": "10", "name": "r10" },
+            { "objectID": "11", "name": "r11" },
+            { "objectID": "12", "name": "r12" },
+            { "objectID": "13", "name": "r13" },
+            { "objectID": "14", "name": "r14" },
+            { "objectID": "15", "name": "r15" },
+            { "objectID": "16", "name": "r16" },
+            { "objectID": "17", "name": "r17" },
+            { "objectID": "18", "name": "r18" },
+            { "objectID": "19", "name": "r19" },
+            { "objectID": "20", "name": "r20" },
+            { "objectID": "21", "name": "r21" },
+            { "objectID": "22", "name": "r22" },
+            { "objectID": "23", "name": "r23" },
+            { "objectID": "24", "name": "r24" },
+            { "objectID": "25", "name": "r25" }
+          ],
+          "waitForTasks": true,
+          "batchSize": 10
+        }
+      }
+    ]
   }
 ]

--- a/tests/CTS/client/search/saveObjectsWithTransformation.json
+++ b/tests/CTS/client/search/saveObjectsWithTransformation.json
@@ -57,7 +57,6 @@
   {
     "testName": "saveObjectsWithTransformation polls every task when waitForTasks is true",
     "autoCreateClient": false,
-    "skipLanguages": ["go", "php", "javascript"],
     "steps": [
       {
         "type": "createClient",


### PR DESCRIPTION
## 🧭 What and Why

Adds a CTS client test that locks in the `chunkedPush` task-polling contract: with `waitForTasks: true`, every pushed task must be polled via `getEvent` exactly once. The bug this guards against — the poll cursor over-advancing and silently skipping tasks — is invisible to client-side assertions, because the returned `WatchResponse` list is identical whether or not polling happened. The test therefore asserts server-side, by counting the requests the client actually makes. Full cross-language analysis: [Confluence: Chunked Push Task-Polling Bug (waitForTasks)](https://algolia.atlassian.net/wiki/spaces/APIC/pages/7227441368/Chunked+Push+Task-Polling+Bug+waitForTasks).

### Changes included:

- **`chunkedPushWait` mock server** (`scripts/cts/testServer/chunkedPushWait.ts`): simulates the ingestion `push` and `getEvent` endpoints on port 6692, counting both per language. Each push returns a distinct `eventID`, and `getEvent` answers `status: succeeded`, so a correct client polls exactly once per pushed task.
- **CTS client test** (`tests/CTS/client/search/saveObjectsWithTransformation.json`): drives `saveObjectsWithTransformation` with 25 objects, `batchSize: 10`, `waitForTasks: true` — producing 3 pushes (10/10/5) and a poll window of 1 (`waitBatchSize = batchSize / 10`), the smallest configuration that triggers the cursor bug.
- **Post-run assertion** (`scripts/cts/runCts.ts`): `assertValidChunkedPushWait` requires `pushCount >= 3` and `getEventCount == pushCount` for every participating language, and verifies the participant count itself, so a test that silently stops being generated fails loudly instead of passing vacuously.
- **New `skipLanguages` field on CTS client tests** (`generators/.../ClientTestData.java`, `TestsClient.java`): excludes a test per language at generation time. Go, PHP, and JavaScript are skipped here because they currently fail the polling contract — Go panics on an out-of-range slice, PHP silently under-polls, and JavaScript additionally never forwards `batchSize` through `saveObjectsWithTransformation`, so it needs both defects fixed before it can participate. Dart and Swift don't expose the helper and are excluded automatically.

## 🧪 Test

- An unfiltered run of this branch serves as the cross-language proof: go, php, and javascript fail exactly as documented in the Confluence page, while java, csharp, kotlin, ruby, and scala pass.
- Python participates and passes thanks to the fix in #6486 (this branch's base).
- With the `skipLanguages` filter in place, all client CI jobs are green.
