### PR TITLE
feat(specs): add abtesting configuration metadata

### DIFF
--- a/specs/abtesting-v3/common/schemas/ABTest.yml
+++ b/specs/abtesting-v3/common/schemas/ABTest.yml
@@ -60,6 +60,10 @@ ABTestConfiguration:
   type: object
   description: A/B test configuration.
   properties:
+    metadata:
+      type: object
+      description: Product-owned metadata for the A/B test.
+      additionalProperties: true
     minimumDetectableEffect:
       $ref: '#/MinimumDetectableEffect'
     filters:


### PR DESCRIPTION
## Summary
- Add `configuration.metadata` to the public abtesting-v3 `ABTestConfiguration` schema.
- Model it as a free-form object so product-owned metadata like `{ "feature": "advancedPersonalization" }` can be represented in generated clients.

## Context
- Runtime API/storage support is in algolia/go#25890.
- Dashboard usage is in algolia/AlgoliaWeb#28769.
- This is the public client/spec counterpart; `cmd/abtests/api/docs/admin-openapi.yaml` in `algolia/go` only documents internal dark-test admin endpoints.

## Test plan
- `yarn install --immutable`
- `yarn cli build specs abtesting-v3`
- `yarn specs:lint specs/abtesting-v3/common/schemas/ABTest.yml specs/bundled/abtesting-v3.yml`
- `git diff --check`

## Notes
- `yarn cli generate javascript abtesting-v3` was attempted locally but blocked because the Docker daemon was not running while assembling custom generators.
