### PR TITLE
fix(go): case-sensitive JSON key matching in UnmarshalJSON for models with additionalProperties

### DIFF
--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -24,10 +24,6 @@ type {{classname}} struct {
 {{/isAdditionalPropertiesTrue}}
 }
 
-{{#isAdditionalPropertiesTrue}}
-type _{{{classname}}} {{{classname}}}
-
-{{/isAdditionalPropertiesTrue}}
 {{#hasOptional}}
 type {{{classname}}}Option func(f *{{{classname}}})
 

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -309,10 +309,6 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
-	// Use case-sensitive raw map parsing to avoid Go's encoding/json
-	// case-insensitive field matching, which can overwrite reserved fields
-	// (e.g. objectID) with user-defined properties of a different casing
-	// (e.g. ObjectID), leading to data loss or type-mismatch panics.
 	raw := make(map[string]json.RawMessage)
 	if err := json.Unmarshal(bytes, &raw); err != nil {
 		return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
@@ -320,7 +316,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 
 {{#parent}}
 {{^isMap}}
-	// Extract own fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -330,7 +325,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	}
 	{{/vars}}
 
-	// Extract parent fields by reflecting over its JSON tags.
 	parentBytes, err := json.Marshal(raw)
 	if err != nil {
 		return fmt.Errorf("failed to remarshal parent fields of {{{classname}}}: %w", err)
@@ -339,7 +333,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 		return fmt.Errorf("failed to unmarshal parent {{{parent}}} of {{{classname}}}: %w", err)
 	}
 
-	// Remove parent fields from raw to isolate additional properties.
 	reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
 	for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
 		t := reflect{{{parent}}}.Type().Field(i)
@@ -357,7 +350,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	}
 {{/isMap}}
 {{#isMap}}
-	// Extract own fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -369,7 +361,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 {{/isMap}}
 {{/parent}}
 {{^parent}}
-	// Extract known fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -380,7 +371,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	{{/vars}}
 {{/parent}}
 
-	// Remaining keys are additional properties (preserved with original casing and types).
 	o.AdditionalProperties = make(map[string]any)
 	for key, val := range raw {
 		var parsed any

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -313,126 +313,88 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
-{{#parent}}
-{{^isMap}}
-	type {{classname}}WithoutEmbeddedStruct struct {
-	{{#vars}}
-	{{^-first}}
-	{{/-first}}
-	{{#description}}
-		// {{{.}}}
-	{{/description}}
-	{{#deprecated}}
-		// Deprecated
-	{{/deprecated}}
-		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"`
-	{{/vars}}
-	}
-
-	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
-
-	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
-	if err == nil {
-		var{{{classname}}} := _{{{classname}}}{}
-		{{#vars}}
-		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
-		{{/vars}}
-		*o = {{{classname}}}(var{{{classname}}})
-	} else {
-		return fmt.Errorf("failed to unmarshal {{{classname}}}WithoutEmbeddedStruct: %w", err)
-	}
-
-	var{{{classname}}} := _{{{classname}}}{}
-
-	err = json.Unmarshal(bytes, &var{{{classname}}})
-	if err == nil {
-		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
-	} else {
+	// Use case-sensitive raw map parsing to avoid Go's encoding/json
+	// case-insensitive field matching, which can overwrite reserved fields
+	// (e.g. objectID) with user-defined properties of a different casing
+	// (e.g. ObjectID), leading to data loss or type-mismatch panics.
+	raw := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(bytes, &raw); err != nil {
 		return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
 	}
 
-	additionalProperties := make(map[string]any)
+{{#parent}}
+{{^isMap}}
+	// Extract own fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
 
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
+	// Extract parent fields by reflecting over its JSON tags.
+	parentBytes, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("failed to remarshal parent fields of {{{classname}}}: %w", err)
+	}
+	if err := json.Unmarshal(parentBytes, &o.{{{parent}}}); err != nil {
+		return fmt.Errorf("failed to unmarshal parent {{{parent}}} of {{{classname}}}: %w", err)
+	}
 
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-
-  // remove fields from embedded structs
-  reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
-  for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
-    t := reflect{{{parent}}}.Type().Field(i)
-
-    if jsonTag := t.Tag.Get("json"); jsonTag != "" {
-      fieldName := ""
-      if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
-        fieldName = jsonTag[:commaIdx]
-      } else {
-        fieldName = jsonTag
-      }
-      if fieldName != "AdditionalProperties" {
-        delete(additionalProperties, fieldName)
-      }
-    }
-  }
-
-  o.AdditionalProperties = additionalProperties
-
-  return nil
+	// Remove parent fields from raw to isolate additional properties.
+	reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+	for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+		t := reflect{{{parent}}}.Type().Field(i)
+		if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+			fieldName := ""
+			if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+				fieldName = jsonTag[:commaIdx]
+			} else {
+				fieldName = jsonTag
+			}
+			if fieldName != "AdditionalProperties" {
+				delete(raw, fieldName)
+			}
+		}
+	}
 {{/isMap}}
 {{#isMap}}
-	var{{{classname}}} := _{{{classname}}}{}
-
-  err := json.Unmarshal(bytes, &var{{{classname}}})
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
-
-	*o = {{{classname}}}(var{{{classname}}})
-
-	additionalProperties := make(map[string]any)
-
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal additionalProperties in {{{classname}}}: %w", err)
-  }
-
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-  o.AdditionalProperties = additionalProperties
-
-	return nil
+	// Extract own fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
 {{/isMap}}
 {{/parent}}
 {{^parent}}
-	var{{{classname}}} := _{{{classname}}}{}
+	// Extract known fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
+{{/parent}}
 
-  err := json.Unmarshal(bytes, &var{{{classname}}})
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
+	// Remaining keys are additional properties (preserved with original casing and types).
+	o.AdditionalProperties = make(map[string]any)
+	for key, val := range raw {
+		var parsed any
+		if err := json.Unmarshal(val, &parsed); err != nil {
+			return fmt.Errorf("failed to unmarshal additionalProperties of {{{classname}}}: %w", err)
+		}
+		o.AdditionalProperties[key] = parsed
+	}
 
-	*o = {{{classname}}}(var{{{classname}}})
-
-	additionalProperties := make(map[string]any)
-
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal additionalProperties in {{{classname}}}: %w", err)
-  }
-
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-  o.AdditionalProperties = additionalProperties
-	
-  return nil
-  {{/parent}}
+	return nil
 }
 
 {{/isAdditionalPropertiesTrue}}


### PR DESCRIPTION
## Problem

Go's `encoding/json` performs **case-insensitive** field matching during `Unmarshal`. When a customer record contains a property whose name differs from a reserved field only by casing (e.g. `ObjectID` vs the reserved `objectID`), two failure modes occur:

1. **Data loss**: if the customer's property is a string, it silently overwrites the reserved `objectID` value
2. **Crash**: if it is a non-string type (e.g. `int`), `Unmarshal` fails with a type error

This affects all Go models with `additionalProperties: true` — most critically `Hit`, `RecommendHit`, and composition `Hit`.

### Reproduction

```json
// API response where customer has an "ObjectID" field in their records
{
  "objectID": "real-id-123",
  "ObjectID": 42,
  "title": "My Record"
}
```

**Before fix**: `UnmarshalJSON` crashes with type error (or silently overwrites `objectID` if `ObjectID` is a string).

**After fix**: `hit.ObjectID == "real-id-123"`, `hit.AdditionalProperties["ObjectID"] == 42`, `hit.AdditionalProperties["title"] == "My Record"`.

## Solution

Rewrite the `UnmarshalJSON` template in `templates/go/model_simple.mustache` to parse into a `map[string]json.RawMessage` first, then extract known fields by **exact** (case-sensitive) key match. Remaining keys are preserved as additional properties with their original casing and types.

### Before (case-insensitive via `_Classname` alias)

```go
varHit := _Hit{}
json.Unmarshal(bytes, &varHit)       // case-INSENSITIVE matching
// ...
delete(additionalProperties, "objectID")  // case-SENSITIVE delete
```

### After (fully case-sensitive)

```go
raw := make(map[string]json.RawMessage)
json.Unmarshal(bytes, &raw)

if v, ok := raw["objectID"]; ok {    // case-SENSITIVE extraction
    json.Unmarshal(v, &o.ObjectID)
    delete(raw, "objectID")
}
// remaining raw keys → additionalProperties
```

## What changes

- `templates/go/model_simple.mustache`: all 3 `UnmarshalJSON` branches rewritten (no parent, parent+map, parent+non-map)
- **No breaking change** for correct usage — Algolia always returns `objectID` in exact casing
- The `_Classname` type alias is no longer used in `UnmarshalJSON` (kept for now, can be removed in follow-up)

## Cross-language impact

Only Go is affected. All other client languages (Java/Jackson, Python/Pydantic, C#/System.Text.Json, Swift/Codable, Kotlin/kotlinx.serialization, Dart/json_serializable, Ruby, PHP, Scala/json4s, JavaScript) use case-sensitive key matching by default.

## Checklist

- [x] Template change in `templates/go/model_simple.mustache`
- [x] Regenerate Go clients: `yarn cli generate go`
- [x] Run CTS: `yarn cli cts run go`
- [x] Verify `model_hit.go` output
