### PR TITLE
feat(go): enforce required field presence in UnmarshalJSON

### DIFF
--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -24,10 +24,6 @@ type {{classname}} struct {
 {{/isAdditionalPropertiesTrue}}
 }
 
-{{#isAdditionalPropertiesTrue}}
-type _{{{classname}}} {{{classname}}}
-
-{{/isAdditionalPropertiesTrue}}
 {{#hasOptional}}
 type {{{classname}}}Option func(f *{{{classname}}})
 

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -309,10 +309,6 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
-	// Use case-sensitive raw map parsing to avoid Go's encoding/json
-	// case-insensitive field matching, which can overwrite reserved fields
-	// (e.g. objectID) with user-defined properties of a different casing
-	// (e.g. ObjectID), leading to data loss or type-mismatch panics.
 	raw := make(map[string]json.RawMessage)
 	if err := json.Unmarshal(bytes, &raw); err != nil {
 		return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
@@ -320,7 +316,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 
 {{#parent}}
 {{^isMap}}
-	// Extract own fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -330,7 +325,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	}
 	{{/vars}}
 
-	// Extract parent fields by reflecting over its JSON tags.
 	parentBytes, err := json.Marshal(raw)
 	if err != nil {
 		return fmt.Errorf("failed to remarshal parent fields of {{{classname}}}: %w", err)
@@ -339,7 +333,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 		return fmt.Errorf("failed to unmarshal parent {{{parent}}} of {{{classname}}}: %w", err)
 	}
 
-	// Remove parent fields from raw to isolate additional properties.
 	reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
 	for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
 		t := reflect{{{parent}}}.Type().Field(i)
@@ -357,7 +350,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	}
 {{/isMap}}
 {{#isMap}}
-	// Extract own fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -369,7 +361,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 {{/isMap}}
 {{/parent}}
 {{^parent}}
-	// Extract known fields by exact JSON key.
 	{{#vars}}
 	if v, ok := raw["{{{baseName}}}"]; ok {
 		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
@@ -380,7 +371,6 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 	{{/vars}}
 {{/parent}}
 
-	// Remaining keys are additional properties (preserved with original casing and types).
 	o.AdditionalProperties = make(map[string]any)
 	for key, val := range raw {
 		var parsed any

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -322,7 +322,9 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
 		}
 		delete(raw, "{{{baseName}}}")
-	}
+	}{{#required}} else {
+		return fmt.Errorf("required field {{{baseName}}} not found in {{{classname}}}")
+	}{{/required}}
 	{{/vars}}
 
 	parentBytes, err := json.Marshal(raw)
@@ -356,7 +358,9 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
 		}
 		delete(raw, "{{{baseName}}}")
-	}
+	}{{#required}} else {
+		return fmt.Errorf("required field {{{baseName}}} not found in {{{classname}}}")
+	}{{/required}}
 	{{/vars}}
 {{/isMap}}
 {{/parent}}
@@ -367,7 +371,9 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
 			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
 		}
 		delete(raw, "{{{baseName}}}")
-	}
+	}{{#required}} else {
+		return fmt.Errorf("required field {{{baseName}}} not found in {{{classname}}}")
+	}{{/required}}
 	{{/vars}}
 {{/parent}}
 

--- a/templates/go/model_simple.mustache
+++ b/templates/go/model_simple.mustache
@@ -313,126 +313,88 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) error {
-{{#parent}}
-{{^isMap}}
-	type {{classname}}WithoutEmbeddedStruct struct {
-	{{#vars}}
-	{{^-first}}
-	{{/-first}}
-	{{#description}}
-		// {{{.}}}
-	{{/description}}
-	{{#deprecated}}
-		// Deprecated
-	{{/deprecated}}
-		{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"`
-	{{/vars}}
-	}
-
-	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
-
-	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
-	if err == nil {
-		var{{{classname}}} := _{{{classname}}}{}
-		{{#vars}}
-		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
-		{{/vars}}
-		*o = {{{classname}}}(var{{{classname}}})
-	} else {
-		return fmt.Errorf("failed to unmarshal {{{classname}}}WithoutEmbeddedStruct: %w", err)
-	}
-
-	var{{{classname}}} := _{{{classname}}}{}
-
-	err = json.Unmarshal(bytes, &var{{{classname}}})
-	if err == nil {
-		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
-	} else {
+	// Use case-sensitive raw map parsing to avoid Go's encoding/json
+	// case-insensitive field matching, which can overwrite reserved fields
+	// (e.g. objectID) with user-defined properties of a different casing
+	// (e.g. ObjectID), leading to data loss or type-mismatch panics.
+	raw := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(bytes, &raw); err != nil {
 		return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
 	}
 
-	additionalProperties := make(map[string]any)
+{{#parent}}
+{{^isMap}}
+	// Extract own fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
 
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
+	// Extract parent fields by reflecting over its JSON tags.
+	parentBytes, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("failed to remarshal parent fields of {{{classname}}}: %w", err)
+	}
+	if err := json.Unmarshal(parentBytes, &o.{{{parent}}}); err != nil {
+		return fmt.Errorf("failed to unmarshal parent {{{parent}}} of {{{classname}}}: %w", err)
+	}
 
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-
-  // remove fields from embedded structs
-  reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
-  for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
-    t := reflect{{{parent}}}.Type().Field(i)
-
-    if jsonTag := t.Tag.Get("json"); jsonTag != "" {
-      fieldName := ""
-      if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
-        fieldName = jsonTag[:commaIdx]
-      } else {
-        fieldName = jsonTag
-      }
-      if fieldName != "AdditionalProperties" {
-        delete(additionalProperties, fieldName)
-      }
-    }
-  }
-
-  o.AdditionalProperties = additionalProperties
-
-  return nil
+	// Remove parent fields from raw to isolate additional properties.
+	reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+	for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+		t := reflect{{{parent}}}.Type().Field(i)
+		if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+			fieldName := ""
+			if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+				fieldName = jsonTag[:commaIdx]
+			} else {
+				fieldName = jsonTag
+			}
+			if fieldName != "AdditionalProperties" {
+				delete(raw, fieldName)
+			}
+		}
+	}
 {{/isMap}}
 {{#isMap}}
-	var{{{classname}}} := _{{{classname}}}{}
-
-  err := json.Unmarshal(bytes, &var{{{classname}}})
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
-
-	*o = {{{classname}}}(var{{{classname}}})
-
-	additionalProperties := make(map[string]any)
-
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal additionalProperties in {{{classname}}}: %w", err)
-  }
-
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-  o.AdditionalProperties = additionalProperties
-
-	return nil
+	// Extract own fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
 {{/isMap}}
 {{/parent}}
 {{^parent}}
-	var{{{classname}}} := _{{{classname}}}{}
+	// Extract known fields by exact JSON key.
+	{{#vars}}
+	if v, ok := raw["{{{baseName}}}"]; ok {
+		if err := json.Unmarshal(v, &o.{{{name}}}); err != nil {
+			return fmt.Errorf("failed to unmarshal field {{{baseName}}} of {{{classname}}}: %w", err)
+		}
+		delete(raw, "{{{baseName}}}")
+	}
+	{{/vars}}
+{{/parent}}
 
-  err := json.Unmarshal(bytes, &var{{{classname}}})
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal {{{classname}}}: %w", err)
-  }
+	// Remaining keys are additional properties (preserved with original casing and types).
+	o.AdditionalProperties = make(map[string]any)
+	for key, val := range raw {
+		var parsed any
+		if err := json.Unmarshal(val, &parsed); err != nil {
+			return fmt.Errorf("failed to unmarshal additionalProperties of {{{classname}}}: %w", err)
+		}
+		o.AdditionalProperties[key] = parsed
+	}
 
-	*o = {{{classname}}}(var{{{classname}}})
-
-	additionalProperties := make(map[string]any)
-
-	err = json.Unmarshal(bytes, &additionalProperties)
-  if err != nil {
-    return fmt.Errorf("failed to unmarshal additionalProperties in {{{classname}}}: %w", err)
-  }
-
-  {{#vars}}
-  delete(additionalProperties, "{{{baseName}}}")
-  {{/vars}}
-  o.AdditionalProperties = additionalProperties
-	
-  return nil
-  {{/parent}}
+	return nil
 }
 
 {{/isAdditionalPropertiesTrue}}


### PR DESCRIPTION
## Context

Stacked on top of #6494 (case-sensitive JSON key matching fix).

## Problem

Go's `UnmarshalJSON` for models with `additionalProperties` silently accepts missing required fields, leaving them at their zero value (e.g. `""` for `objectID`). This is inconsistent with 5 of our other client languages.

## Current behavior across languages

| Language | Missing required field | Behavior |
|---|---|---|
| **Python** | Hard fail | Pydantic `ValidationError` |
| **Swift** | Hard fail | `DecodingError` thrown |
| **Kotlin** | Hard fail | `NoSuchElementException` |
| **Dart** | Hard fail | Exception thrown |
| **Scala** | Hard fail | Extraction fails |
| **Java** | Silent | Field set to `null` |
| **Ruby** | Silent | Field set to `nil` |
| **PHP** | Silent | Field not set, manual validation |
| **JavaScript** | Silent | `undefined` |
| **Go (before)** | Silent | Zero value (`""`, `0`, etc.) |

## Solution

In the `UnmarshalJSON` template, required fields now return an error when their exact JSON key is absent:

```go
if v, ok := raw["objectID"]; ok {
    // decode...
} else {
    return fmt.Errorf("required field objectID not found in Hit")
}
```

Optional fields remain unchanged — missing keys are silently accepted.

## Affected models

~11 models with `additionalProperties` + required fields, including:
- `search/Hit`, `composition/Hit`, `recommend/RecommendHit` (`objectID`)
- `search/SearchResponse` (~35 fields, many required)
- `search/SearchSynonymsResponse` (`hits`, `nbHits`)
- `search/DictionaryEntry` (`objectID`)
- `ingestion/PushTaskRecords` (`objectID`)

## Checklist

- [x] Template change in `templates/go/model_simple.mustache`
- [ ] Regenerate Go clients: `yarn cli generate go`
- [ ] Run CTS: `yarn cli cts run go`
- [ ] Verify no CTS regressions from stricter validation
