### PR TITLE
fix(javascript): use proper null check instead of truthiness for required params

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/validateParam.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/validateParam.ts
@@ -1,5 +1,5 @@
 export function validateRequired(field: string, method: string, value: unknown): void {
-  if (value === null || value === undefined || (typeof value === 'string' && value.length === 0)) {
+  if (value == null || (typeof value === 'string' && value.length === 0)) {
     throw new Error(`Parameter \`${field}\` is required when calling \`${method}\`.`);
   }
 }

--- a/tests/CTS/requests/search/getTask.json
+++ b/tests/CTS/requests/search/getTask.json
@@ -8,5 +8,16 @@
       "path": "/1/indexes/theIndexName/task/123",
       "method": "GET"
     }
+  },
+  {
+    "testName": "getTask with taskID 0",
+    "parameters": {
+      "indexName": "theIndexName",
+      "taskID": 0
+    },
+    "request": {
+      "path": "/1/indexes/theIndexName/task/0",
+      "method": "GET"
+    }
   }
 ]


### PR DESCRIPTION
## Problem

`searchClient.getTask({ indexName, taskID: 0 })` throws:

```
Error: Parameter `taskID` is required when calling `getTask`.
```

Because the generated validation used `if (!taskID)`, which treats `0` as falsy/missing in JavaScript. `0` is a valid `taskID` — for example, `POST /3/abtests` returns `{"abTestID":13743,"taskID":0,"index":"products-2"}`.

## What changed

The recent `validateRequired` refactor (#6496) already centralized validation into a helper that correctly checks `=== null || === undefined`. This PR:

1. **Simplifies `validateRequired`** — replaces `value === null || value === undefined` with the idiomatic `value == null` (loose equality covers both `null` and `undefined`)
2. **Adds a CTS regression test** — `getTask` with `taskID: 0` ensures this edge case stays covered

## Changes

| File | Change |
|------|--------|
| `packages/client-common/src/validateParam.ts` | `=== null \|\| === undefined` → `== null` |
| `tests/CTS/requests/search/getTask.json` | Add test: `getTask` with `taskID: 0` |
