### PR TITLE
fix(ci): fail spread step when pushes to client repos fail

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -738,10 +738,10 @@ jobs:
 
       - name: notify failures
         uses: slackapi/slack-github-action@v3.0.3
-        if: ${{ failure() || steps.waitForAllReleases.outputs.FAILED_RELEASES != '' || steps.spreadGeneration.outputs.FAILED_LANGUAGES != '' }}
+        if: ${{ !cancelled() && (steps.spreadGeneration.outputs.FAILED_LANGUAGES != '' || steps.waitForAllReleases.outputs.FAILED_RELEASES != '') }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":alert: Some clients failed to release :alert: \n**${{ steps.spreadGeneration.outputs.FAILED_LANGUAGES || steps.waitForAllReleases.outputs.FAILED_RELEASES }}**\n\nYou can retry the CI jobs to release them again, it will not affect already released clients."
+            text: ":alert: Some clients failed during release :alert: \nSpread generation failures: **${{ steps.spreadGeneration.outputs.FAILED_LANGUAGES || 'none' }}**\nRelease CI failures: **${{ steps.waitForAllReleases.outputs.FAILED_RELEASES || 'none' }}**\n\nYou can retry the CI jobs to release them again, it will not affect already released clients."

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -738,10 +738,10 @@ jobs:
 
       - name: notify failures
         uses: slackapi/slack-github-action@v3.0.3
-        if: ${{ steps.waitForAllReleases.outputs.FAILED_RELEASES != '' }}
+        if: ${{ failure() || steps.waitForAllReleases.outputs.FAILED_RELEASES != '' || steps.spreadGeneration.outputs.FAILED_LANGUAGES != '' }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":alert: Some clients failed to release :alert: \n**${{ steps.waitForAllReleases.outputs.FAILED_RELEASES }}**\n\nYou can retry the CI jobs to release them again, it will not affect already released clients."
+            text: ":alert: Some clients failed to release :alert: \n**${{ steps.spreadGeneration.outputs.FAILED_LANGUAGES || steps.waitForAllReleases.outputs.FAILED_RELEASES }}**\n\nYou can retry the CI jobs to release them again, it will not affect already released clients."

--- a/scripts/ci/codegen/__tests__/pushToRepository.test.ts
+++ b/scripts/ci/codegen/__tests__/pushToRepository.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { pushConfiguredRepositories } from '../pushToRepository.ts';
+import type { RepositoryConfiguration } from '../types.ts';
+
+describe('pushConfiguredRepositories', () => {
+  it('maps settled failures to the selected repository list', async () => {
+    const pushRepository = vi.fn(async (_repository: string, _config: RepositoryConfiguration): Promise<void> => {
+      throw new Error('push failed');
+    });
+
+    const failedRepositories = await pushConfiguredRepositories(['missing-repository', 'go'], pushRepository);
+
+    expect(failedRepositories).toEqual(['go']);
+    expect(pushRepository).toHaveBeenCalledTimes(1);
+    expect(pushRepository.mock.calls.map(([repository]) => repository)).toEqual(['go']);
+  });
+
+  it('continues pushing every selected repository when one fails', async () => {
+    const pushRepository = vi.fn(async (repository: string, _config: RepositoryConfiguration): Promise<void> => {
+      if (repository === 'docs-new') {
+        throw new Error('docs push failed');
+      }
+    });
+
+    const failedRepositories = await pushConfiguredRepositories(['docs-new', 'go'], pushRepository);
+
+    expect(failedRepositories).toEqual(['docs-new']);
+    expect(pushRepository.mock.calls.map(([repository]) => repository)).toEqual(['docs-new', 'go']);
+  });
+});

--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { cleanUpCommitMessage, shouldFailSpreadGeneration } from '../spreadGeneration.ts';
+import {
+  cleanUpCommitMessage,
+  summarizeSpreadGenerationResults,
+  type SpreadGenerationResult,
+} from '../spreadGeneration.ts';
 import text from '../text.ts';
 
 describe('spread generation', () => {
@@ -37,25 +41,60 @@ describe('spread generation', () => {
     });
   });
 
-  describe('shouldFailSpreadGeneration', () => {
-    it('does not fail when no language failed', () => {
-      expect(shouldFailSpreadGeneration([], ['javascript', 'python'])).toBe(false);
+  describe('summarizeSpreadGenerationResults', () => {
+    it('returns pushed and failed language outputs without failing on partial spread failures', () => {
+      const results: SpreadGenerationResult[] = [
+        { type: 'pushed', language: 'javascript' },
+        { type: 'failed-after-diff', language: 'python' },
+        { type: 'failed-before-diff', language: 'java' },
+        { type: 'skipped', language: 'go' },
+      ];
+
+      expect(summarizeSpreadGenerationResults(results)).toEqual({
+        pushed: ['javascript'],
+        failed: ['python', 'java'],
+        shouldFail: false,
+      });
     });
 
-    it('does not fail when only some languages failed', () => {
-      expect(shouldFailSpreadGeneration(['javascript'], ['javascript', 'python'])).toBe(false);
+    it('fails when every language with detected changes failed', () => {
+      const results: SpreadGenerationResult[] = [
+        { type: 'failed-before-diff', language: 'javascript' },
+        { type: 'failed-after-diff', language: 'python' },
+        { type: 'skipped', language: 'java' },
+      ];
+
+      expect(summarizeSpreadGenerationResults(results)).toEqual({
+        pushed: [],
+        failed: ['javascript', 'python'],
+        shouldFail: true,
+      });
     });
 
-    it('fails when every non-skipped language failed', () => {
-      expect(shouldFailSpreadGeneration(['javascript'], ['javascript'])).toBe(true);
+    it('does not fail when failures happened before any diff was detected', () => {
+      const results: SpreadGenerationResult[] = [
+        { type: 'failed-before-diff', language: 'javascript' },
+        { type: 'skipped', language: 'python' },
+      ];
+
+      expect(summarizeSpreadGenerationResults(results)).toEqual({
+        pushed: [],
+        failed: ['javascript'],
+        shouldFail: false,
+      });
     });
 
-    it('does not count failures outside the non-skipped language list', () => {
-      expect(shouldFailSpreadGeneration(['python'], ['javascript'])).toBe(false);
-    });
+    it('does not fail when every language was skipped', () => {
+      const results: SpreadGenerationResult[] = [
+        { type: 'skipped', language: 'javascript' },
+        { type: 'skipped', language: 'python' },
+      ];
 
-    it('does not fail for an empty language list', () => {
-      expect(shouldFailSpreadGeneration([], [])).toBe(false);
+      expect(summarizeSpreadGenerationResults(results)).toEqual({
+        pushed: [],
+        failed: [],
+        shouldFail: false,
+      });
     });
   });
 });

--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -46,8 +46,12 @@ describe('spread generation', () => {
       expect(shouldFailSpreadGeneration(['javascript'], ['javascript', 'python'])).toBe(false);
     });
 
-    it('fails when every language failed', () => {
-      expect(shouldFailSpreadGeneration(['javascript', 'python'], ['javascript', 'python'])).toBe(true);
+    it('fails when every non-skipped language failed', () => {
+      expect(shouldFailSpreadGeneration(['javascript'], ['javascript'])).toBe(true);
+    });
+
+    it('does not count failures outside the non-skipped language list', () => {
+      expect(shouldFailSpreadGeneration(['python'], ['javascript'])).toBe(false);
     });
 
     it('does not fail for an empty language list', () => {

--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -53,7 +53,7 @@ describe('spread generation', () => {
       expect(summarizeSpreadGenerationResults(results)).toEqual({
         pushed: ['javascript'],
         failed: ['python', 'java'],
-        shouldFail: false,
+        ciStepShouldFail: false,
       });
     });
 
@@ -67,11 +67,11 @@ describe('spread generation', () => {
       expect(summarizeSpreadGenerationResults(results)).toEqual({
         pushed: [],
         failed: ['javascript', 'python'],
-        shouldFail: true,
+        ciStepShouldFail: true,
       });
     });
 
-    it('does not fail when failures happened before any diff was detected', () => {
+    it('fails when failures happened before any diff was detected', () => {
       const results: SpreadGenerationResult[] = [
         { type: 'failed-before-diff', language: 'javascript' },
         { type: 'skipped', language: 'python' },
@@ -80,7 +80,7 @@ describe('spread generation', () => {
       expect(summarizeSpreadGenerationResults(results)).toEqual({
         pushed: [],
         failed: ['javascript'],
-        shouldFail: false,
+        ciStepShouldFail: true,
       });
     });
 
@@ -93,7 +93,7 @@ describe('spread generation', () => {
       expect(summarizeSpreadGenerationResults(results)).toEqual({
         pushed: [],
         failed: [],
-        shouldFail: false,
+        ciStepShouldFail: false,
       });
     });
   });

--- a/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
+++ b/scripts/ci/codegen/__tests__/spreadGeneration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { cleanUpCommitMessage } from '../spreadGeneration.ts';
+import { cleanUpCommitMessage, shouldFailSpreadGeneration } from '../spreadGeneration.ts';
 import text from '../text.ts';
 
 describe('spread generation', () => {
@@ -34,6 +34,24 @@ describe('spread generation', () => {
       expect(cleanUpCommitMessage('feat(ci): make ci push generated code (#244) (generated)', '')).toEqual(
         'feat(ci): make ci push generated code (generated)\n\nhttps://github.com/algolia/api-clients-automation/pull/244',
       );
+    });
+  });
+
+  describe('shouldFailSpreadGeneration', () => {
+    it('does not fail when no language failed', () => {
+      expect(shouldFailSpreadGeneration([], ['javascript', 'python'])).toBe(false);
+    });
+
+    it('does not fail when only some languages failed', () => {
+      expect(shouldFailSpreadGeneration(['javascript'], ['javascript', 'python'])).toBe(false);
+    });
+
+    it('fails when every language failed', () => {
+      expect(shouldFailSpreadGeneration(['javascript', 'python'], ['javascript', 'python'])).toBe(true);
+    });
+
+    it('does not fail for an empty language list', () => {
+      expect(shouldFailSpreadGeneration([], [])).toBe(false);
     });
   });
 });

--- a/scripts/ci/codegen/pushToRepository.ts
+++ b/scripts/ci/codegen/pushToRepository.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import fsp from 'fs/promises';
 import path, { resolve } from 'path';
 
@@ -176,7 +177,7 @@ async function pushToRepository(repository: string, config: RepositoryConfigurat
 
   await configureGitHubAuthor(tempGitDir);
 
-  await run(`git config --global url.https://${token}@github.com/.insteadOf https://github.com/`);
+  await run(`git config --global url.https://x-access-token:${token}@github.com/.insteadOf https://github.com/`);
 
   const shortSha = (await run('git rev-parse --short HEAD', { cwd: toAbsolutePath('.') })).trim();
 
@@ -244,11 +245,19 @@ if (import.meta.url.endsWith(process.argv[1])) {
   setVerbose(false);
   const repositories = process.argv.slice(2) as Array<string>;
 
-  await Promise.allSettled(
+  const results = await Promise.allSettled(
     Object.entries(pushToRepositoryConfiguration).map(([name, config]) => {
       if (repositories.length === 0 || repositories.includes(name)) {
         return pushToRepository(name, config);
       }
     }),
   );
+
+  const failedRepos = Object.keys(pushToRepositoryConfiguration).filter(
+    (_, i) => results[i].status === 'rejected',
+  );
+
+  if (failedRepos.length > 0) {
+    core.setFailed(`Push to repositories failed for: ${failedRepos.join(', ')}`);
+  }
 }

--- a/scripts/ci/codegen/pushToRepository.ts
+++ b/scripts/ci/codegen/pushToRepository.ts
@@ -241,21 +241,28 @@ async function pushToRepository(repository: string, config: RepositoryConfigurat
   }
 }
 
+type PushRepository = (repository: string, config: RepositoryConfiguration) => Promise<void>;
+
+export async function pushConfiguredRepositories(
+  repositories: readonly string[],
+  pushRepository: PushRepository = pushToRepository,
+): Promise<string[]> {
+  const selectedRepositories = Object.entries(pushToRepositoryConfiguration).filter(
+    ([name]) => repositories.length === 0 || repositories.includes(name),
+  );
+
+  const results = await Promise.allSettled(
+    selectedRepositories.map(([name, config]) => pushRepository(name, config)),
+  );
+
+  return selectedRepositories.flatMap(([name], index) => (results[index].status === 'rejected' ? [name] : []));
+}
+
 if (import.meta.url.endsWith(process.argv[1])) {
   setVerbose(false);
   const repositories = process.argv.slice(2) as Array<string>;
 
-  const results = await Promise.allSettled(
-    Object.entries(pushToRepositoryConfiguration).map(([name, config]) => {
-      if (repositories.length === 0 || repositories.includes(name)) {
-        return pushToRepository(name, config);
-      }
-    }),
-  );
-
-  const failedRepos = Object.keys(pushToRepositoryConfiguration).filter(
-    (_, i) => results[i].status === 'rejected',
-  );
+  const failedRepos = await pushConfiguredRepositories(repositories);
 
   if (failedRepos.length > 0) {
     core.setFailed(`Push to repositories failed for: ${failedRepos.join(', ')}`);

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -33,6 +33,8 @@ export function cleanUpCommitMessage(commitMessage: string, version: string): st
   return [`${prCommit[1]} ${text.commitEndMessage}`, `${REPO_URL}/pull/${prCommit[2]}`].join('\n\n');
 }
 
+// Failed languages count as non-skipped even if the script failed before checking the diff.
+// The before/after-diff split is only for reporting where the spread failed.
 export type SpreadGenerationResult =
   | { type: 'skipped'; language: Language }
   | { type: 'pushed'; language: Language }
@@ -42,26 +44,27 @@ export type SpreadGenerationResult =
 export type SpreadGenerationSummary = {
   pushed: Language[];
   failed: Language[];
-  shouldFail: boolean;
+  ciStepShouldFail: boolean;
 };
 
 export function summarizeSpreadGenerationResults(results: readonly SpreadGenerationResult[]): SpreadGenerationSummary {
   const pushed: Language[] = [];
   const failed: Language[] = [];
-  const spreadable: Array<Extract<SpreadGenerationResult, { type: 'pushed' | 'failed-after-diff' }>> = [];
+  const nonSkipped: Array<Exclude<SpreadGenerationResult, { type: 'skipped' }>> = [];
 
   for (const result of results) {
     switch (result.type) {
       case 'pushed':
         pushed.push(result.language);
-        spreadable.push(result);
+        nonSkipped.push(result);
         break;
       case 'failed-before-diff':
         failed.push(result.language);
+        nonSkipped.push(result);
         break;
       case 'failed-after-diff':
         failed.push(result.language);
-        spreadable.push(result);
+        nonSkipped.push(result);
         break;
       case 'skipped':
         break;
@@ -71,7 +74,7 @@ export function summarizeSpreadGenerationResults(results: readonly SpreadGenerat
   return {
     pushed,
     failed,
-    shouldFail: spreadable.length > 0 && spreadable.every((result) => result.type === 'failed-after-diff'),
+    ciStepShouldFail: nonSkipped.length > 0 && nonSkipped.every((result) => result.type !== 'pushed'),
   };
 }
 
@@ -173,7 +176,7 @@ async function spreadGeneration(): Promise<void> {
   core.setOutput('PUSHED_LANGUAGES', summary.pushed.join(' '));
   core.setOutput('FAILED_LANGUAGES', summary.failed.join(' '));
 
-  if (summary.shouldFail) {
+  if (summary.ciStepShouldFail) {
     core.setFailed(`Spread failed for every non-skipped language: ${summary.failed.join(', ')}`);
   }
 }

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -33,11 +33,46 @@ export function cleanUpCommitMessage(commitMessage: string, version: string): st
   return [`${prCommit[1]} ${text.commitEndMessage}`, `${REPO_URL}/pull/${prCommit[2]}`].join('\n\n');
 }
 
-export function shouldFailSpreadGeneration(
-  failedLanguages: readonly Language[],
-  nonSkippedLanguages: readonly Language[],
-): boolean {
-  return nonSkippedLanguages.length > 0 && nonSkippedLanguages.every((lang) => failedLanguages.includes(lang));
+export type SpreadGenerationResult =
+  | { type: 'skipped'; language: Language }
+  | { type: 'pushed'; language: Language }
+  | { type: 'failed-before-diff'; language: Language }
+  | { type: 'failed-after-diff'; language: Language };
+
+export type SpreadGenerationSummary = {
+  pushed: Language[];
+  failed: Language[];
+  shouldFail: boolean;
+};
+
+export function summarizeSpreadGenerationResults(results: readonly SpreadGenerationResult[]): SpreadGenerationSummary {
+  const pushed: Language[] = [];
+  const failed: Language[] = [];
+  const spreadable: Array<Extract<SpreadGenerationResult, { type: 'pushed' | 'failed-after-diff' }>> = [];
+
+  for (const result of results) {
+    switch (result.type) {
+      case 'pushed':
+        pushed.push(result.language);
+        spreadable.push(result);
+        break;
+      case 'failed-before-diff':
+        failed.push(result.language);
+        break;
+      case 'failed-after-diff':
+        failed.push(result.language);
+        spreadable.push(result);
+        break;
+      case 'skipped':
+        break;
+    }
+  }
+
+  return {
+    pushed,
+    failed,
+    shouldFail: spreadable.length > 0 && spreadable.every((result) => result.type === 'failed-after-diff'),
+  };
 }
 
 async function spreadGeneration(): Promise<void> {
@@ -66,11 +101,11 @@ async function spreadGeneration(): Promise<void> {
     }
   }
 
-  const pushed: Language[] = [];
-  const failed: Language[] = [];
-  const languagesToSpread: Language[] = [];
+  const results: SpreadGenerationResult[] = [];
 
   for (const lang of LANGUAGES) {
+    let failureType: 'failed-before-diff' | 'failed-after-diff' = 'failed-before-diff';
+
     try {
       const { tempGitDir } = await cloneRepository({
         lang,
@@ -90,9 +125,10 @@ async function spreadGeneration(): Promise<void> {
         })) === 0
       ) {
         console.log(`❎ Skipping ${lang} repository, because there is no change.`);
+        results.push({ type: 'skipped', language: lang });
         continue;
       } else {
-        languagesToSpread.push(lang);
+        failureType = 'failed-after-diff';
         console.log(`✅ Spreading code to the ${lang} repository.`);
       }
 
@@ -123,20 +159,22 @@ async function spreadGeneration(): Promise<void> {
         await run('git push --tags', { cwd: tempGitDir });
       }
 
-      pushed.push(lang);
+      results.push({ type: 'pushed', language: lang });
 
       console.log(`✅ Code generation successfully pushed to ${lang} repository.`);
     } catch (e) {
       console.error(`Release failed for language ${lang}: ${e}`);
-      failed.push(lang);
+      results.push({ type: failureType, language: lang });
     }
   }
 
-  core.setOutput('PUSHED_LANGUAGES', pushed.join(' '));
-  core.setOutput('FAILED_LANGUAGES', failed.join(' '));
+  const summary = summarizeSpreadGenerationResults(results);
 
-  if (shouldFailSpreadGeneration(failed, languagesToSpread)) {
-    core.setFailed(`Spread failed for every non-skipped language: ${failed.join(', ')}`);
+  core.setOutput('PUSHED_LANGUAGES', summary.pushed.join(' '));
+  core.setOutput('FAILED_LANGUAGES', summary.failed.join(' '));
+
+  if (summary.shouldFail) {
+    core.setFailed(`Spread failed for every non-skipped language: ${summary.failed.join(', ')}`);
   }
 }
 

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -35,9 +35,9 @@ export function cleanUpCommitMessage(commitMessage: string, version: string): st
 
 export function shouldFailSpreadGeneration(
   failedLanguages: readonly Language[],
-  languages: readonly Language[] = LANGUAGES,
+  nonSkippedLanguages: readonly Language[],
 ): boolean {
-  return languages.length > 0 && failedLanguages.length === languages.length;
+  return nonSkippedLanguages.length > 0 && nonSkippedLanguages.every((lang) => failedLanguages.includes(lang));
 }
 
 async function spreadGeneration(): Promise<void> {
@@ -68,6 +68,7 @@ async function spreadGeneration(): Promise<void> {
 
   const pushed: Language[] = [];
   const failed: Language[] = [];
+  const languagesToSpread: Language[] = [];
 
   for (const lang of LANGUAGES) {
     try {
@@ -91,6 +92,7 @@ async function spreadGeneration(): Promise<void> {
         console.log(`❎ Skipping ${lang} repository, because there is no change.`);
         continue;
       } else {
+        languagesToSpread.push(lang);
         console.log(`✅ Spreading code to the ${lang} repository.`);
       }
 
@@ -133,8 +135,8 @@ async function spreadGeneration(): Promise<void> {
   core.setOutput('PUSHED_LANGUAGES', pushed.join(' '));
   core.setOutput('FAILED_LANGUAGES', failed.join(' '));
 
-  if (shouldFailSpreadGeneration(failed)) {
-    core.setFailed(`Spread failed for every language: ${failed.join(', ')}`);
+  if (shouldFailSpreadGeneration(failed, languagesToSpread)) {
+    core.setFailed(`Spread failed for every non-skipped language: ${failed.join(', ')}`);
   }
 }
 

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -60,6 +60,7 @@ async function spreadGeneration(): Promise<void> {
   }
 
   const pushed: Language[] = [];
+  const failed: Language[] = [];
 
   for (const lang of LANGUAGES) {
     try {
@@ -118,13 +119,19 @@ async function spreadGeneration(): Promise<void> {
       console.log(`✅ Code generation successfully pushed to ${lang} repository.`);
     } catch (e) {
       console.error(`Release failed for language ${lang}: ${e}`);
+      failed.push(lang);
     }
   }
 
   core.setOutput('PUSHED_LANGUAGES', pushed.join(' '));
+  core.setOutput('FAILED_LANGUAGES', failed.join(' '));
+
+  if (failed.length > 0) {
+    core.setFailed(`Spread failed for: ${failed.join(', ')}`);
+  }
 }
 
 if (import.meta.url.endsWith(process.argv[1])) {
   setVerbose(false);
-  spreadGeneration();
+  await spreadGeneration();
 }

--- a/scripts/ci/codegen/spreadGeneration.ts
+++ b/scripts/ci/codegen/spreadGeneration.ts
@@ -33,6 +33,13 @@ export function cleanUpCommitMessage(commitMessage: string, version: string): st
   return [`${prCommit[1]} ${text.commitEndMessage}`, `${REPO_URL}/pull/${prCommit[2]}`].join('\n\n');
 }
 
+export function shouldFailSpreadGeneration(
+  failedLanguages: readonly Language[],
+  languages: readonly Language[] = LANGUAGES,
+): boolean {
+  return languages.length > 0 && failedLanguages.length === languages.length;
+}
+
 async function spreadGeneration(): Promise<void> {
   const githubToken = ensureGitHubToken();
 
@@ -126,8 +133,8 @@ async function spreadGeneration(): Promise<void> {
   core.setOutput('PUSHED_LANGUAGES', pushed.join(' '));
   core.setOutput('FAILED_LANGUAGES', failed.join(' '));
 
-  if (failed.length > 0) {
-    core.setFailed(`Spread failed for: ${failed.join(', ')}`);
+  if (shouldFailSpreadGeneration(failed)) {
+    core.setFailed(`Spread failed for every language: ${failed.join(', ')}`);
   }
 }
 

--- a/scripts/ci/codegen/waitForAllReleases.ts
+++ b/scripts/ci/codegen/waitForAllReleases.ts
@@ -100,18 +100,22 @@ async function waitForAllReleases(languagesReleased: Language[]): Promise<void> 
         if (!success && !ciRun.retried) {
           // retry once
           console.log(`❌ ${ciRun.language} CI failed, retrying once`);
-          await getOctokit().actions.reRunWorkflowFailedJobs({
-            owner: 'algolia',
-            repo: getClientsConfigField(ciRun.language, 'gitRepoId'),
-            run_id: ciRun.run.id,
-          });
+          try {
+            await getOctokit().actions.reRunWorkflowFailedJobs({
+              owner: 'algolia',
+              repo: getClientsConfigField(ciRun.language, 'gitRepoId'),
+              run_id: ciRun.run.id,
+            });
 
-          // sleep for a bit to let the CI start
-          await sleep(15000);
+            // sleep for a bit to let the CI start
+            await sleep(15000);
 
-          ciRun.retried = true;
+            ciRun.retried = true;
 
-          continue;
+            continue;
+          } catch (e) {
+            console.error(`Failed to retry ${ciRun.language} CI: ${e}`);
+          }
         }
         console.log(`${success ? '✅' : '❌'} ${ciRun.language} CI finished with conclusion: ${ciRun.run.conclusion}`);
         if (!success) {
@@ -140,5 +144,5 @@ async function waitForAllReleases(languagesReleased: Language[]): Promise<void> 
 
 if (import.meta.url.endsWith(process.argv[1])) {
   setVerbose(false);
-  waitForAllReleases(process.argv.slice(2) as Language[]);
+  await waitForAllReleases(process.argv.slice(2) as Language[]);
 }


### PR DESCRIPTION
## Problem

The `spreadGeneration` script caught push errors in a try/catch but only called `console.error()` — never propagating the failure. This caused the `push_and_release` job to report **green** even when **all 11 client repo pushes failed** (see [this run](https://github.com/algolia/api-clients-automation/actions/runs/27349026067/job/80809149635)).

The cascade:
1. Every `git push` fails with `GH006: Protected branch update failed`
2. Errors are caught and logged but silently swallowed
3. `PUSHED_LANGUAGES` output is empty → downstream steps no-op
4. `FAILED_RELEASES` is empty → Slack notification is skipped
5. Job reports success ✅

## Fix

**`scripts/ci/codegen/spreadGeneration.ts`**:
- Track `failed[]` languages alongside `pushed[]`
- Call `core.setFailed()` when any language fails to spread
- Output `FAILED_LANGUAGES` for downstream consumption
- `await` the async entry point (was fire-and-forget)

**`.github/workflows/check.yml`**:
- Wire the notify step to also fire on `failure()` or when `FAILED_LANGUAGES` is non-empty

## Note

The root cause of the actual push failures was missing branch protection bypass for the GitHub App on the 11 client repos — that has been fixed separately.