### PR TITLE
fix(dart): add missing version tests and publish agent-studio

### DIFF
--- a/clients/algoliasearch-client-dart/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-dart/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           - packages/client_insights
           - packages/client_recommend
           - packages/client_composition
+          - packages/client_agent_studio
     permissions:
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/clients/algoliasearch-client-dart/packages/client_agent_studio/test/version_test.dart
+++ b/clients/algoliasearch-client-dart/packages/client_agent_studio/test/version_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:algolia_client_agent_studio/src/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  if (Directory.current.path.endsWith('/test')) {
+    Directory.current = Directory.current.parent;
+  }
+  test('package version matches pubspec', () {
+    final pubspecPath = '${Directory.current.path}/pubspec.yaml';
+    final pubspec = File(pubspecPath).readAsStringSync();
+    final regex = RegExp('version:s*(.*)');
+    final match = regex.firstMatch(pubspec);
+    expect(match, isNotNull);
+    expect(packageVersion, match?.group(1)?.trim());
+  });
+}

--- a/clients/algoliasearch-client-dart/packages/client_ingestion/test/version_test.dart
+++ b/clients/algoliasearch-client-dart/packages/client_ingestion/test/version_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:algolia_client_ingestion/src/version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  if (Directory.current.path.endsWith('/test')) {
+    Directory.current = Directory.current.parent;
+  }
+  test('package version matches pubspec', () {
+    final pubspecPath = '${Directory.current.path}/pubspec.yaml';
+    final pubspec = File(pubspecPath).readAsStringSync();
+    final regex = RegExp('version:s*(.*)');
+    final match = regex.firstMatch(pubspec);
+    expect(match, isNotNull);
+    expect(packageVersion, match?.group(1)?.trim());
+  });
+}


### PR DESCRIPTION
## Problem

The Dart release CI ([run #27349026067](https://github.com/algolia/api-clients-automation/actions/runs/27349026067/job/80822531351)) failed because `melos test` runs `dart test` across all packages, and two packages lack a `test/` directory:

- `algolia_client_agent_studio` (new package)
- `algolia_client_ingestion`

Both fail with exit code 65: *"No test files were passed and the default test/ directory doesn't exist."*

## Fix

1. **Add `test/version_test.dart`** to `client_agent_studio` and `client_ingestion` — same pattern as all other Dart packages (imports `version.dart` and verifies it matches `pubspec.yaml`)
2. **Add `packages/client_agent_studio`** to the `publish_clients` matrix in `release.yml` so it gets published to pub.dev