### PR TITLE
fix(cts): add query to getRankingInfo snippet

### DIFF
--- a/tests/CTS/requests/search/searchSingleIndex.json
+++ b/tests/CTS/requests/search/searchSingleIndex.json
@@ -865,6 +865,7 @@
     "parameters": {
       "indexName": "indexName",
       "searchParams": {
+        "query": "test",
         "getRankingInfo": true
       }
     },
@@ -872,6 +873,7 @@
       "path": "/1/indexes/indexName/query",
       "method": "POST",
       "body": {
+        "query": "test",
         "getRankingInfo": true
       }
     }


### PR DESCRIPTION
## 🧭 What and Why

Add a `query` to the CTS for `searchSingleIndex`/`getRankingInfo`.

The snippet generated from this is used in the docs where we tell users to use this param for troubleshooting queries. So, it's better if the snippet would should an actual query.

🎟 JIRA Ticket:

### Changes included:

- Add an example `query` to the test.

## 🧪 Test
