### PR TITLE
fix(templates): correct compression guide templates

### DIFF
--- a/docs/guides/scala/src/main/scala/compression.scala
+++ b/docs/guides/scala/src/main/scala/compression.scala
@@ -3,10 +3,12 @@ import algoliasearch.config.*
 import algoliasearch.extension.SearchClientExtensions
 
 import algoliasearch.search.SearchParamsObject
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContextExecutor}
 
 object Compression {
   def main(args: Array[String]): Unit = {
-    implicit val ec: scala.concurrent.ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+    implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 
     // Initialize the client with gzip compression enabled
     // Compression reduces the size of request bodies sent to Algolia
@@ -21,7 +23,7 @@ object Compression {
 
     // Search with compressed request body
     try {
-      val result = scala.concurrent.Await.result(
+      val result = Await.result(
         client.searchSingleIndex(
           indexName = "<YOUR_INDEX_NAME>",
           searchParams = Some(
@@ -30,7 +32,7 @@ object Compression {
             )
           )
         ),
-        scala.concurrent.duration.Duration(100, "sec")
+        Duration(100, "sec")
       )
       println(result)
     } catch {

--- a/docs/guides/swift/Sources/compression.swift
+++ b/docs/guides/swift/Sources/compression.swift
@@ -14,7 +14,7 @@ func compression() async throws {
 
     do {
         // Search with compressed request body
-        let response: SearchResponse<Hit> = try await try await client.searchSingleIndex(
+        let response: SearchResponse<Hit> = try await client.searchSingleIndex(
             indexName: "<YOUR_INDEX_NAME>",
             searchParams: SearchSearchParams.searchSearchParamsObject(SearchSearchParamsObject(query: "comedy"))
         )

--- a/templates/scala/guides/search/compression.mustache
+++ b/templates/scala/guides/search/compression.mustache
@@ -1,9 +1,11 @@
 {{> snippets/import}}
 import algoliasearch.search.SearchParamsObject
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContextExecutor}
 
 object Compression {
   def main(args: Array[String]): Unit = {
-    implicit val ec: scala.concurrent.ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+    implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
 
     // Initialize the client with gzip compression enabled
     // Compression reduces the size of request bodies sent to Algolia
@@ -18,9 +20,9 @@ object Compression {
 
     // Search with compressed request body
     try {
-      val result = scala.concurrent.Await.result(
+      val result = Await.result(
         {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}},
-        scala.concurrent.duration.Duration(100, "sec")
+        Duration(100, "sec")
       )
       println(result)
     } catch {

--- a/templates/swift/guides/search/compression.mustache
+++ b/templates/swift/guides/search/compression.mustache
@@ -14,7 +14,7 @@ func compression() async throws {
 
     do {
         // Search with compressed request body
-        let response: SearchResponse<Hit> = try await {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
+        let response: SearchResponse<Hit> = {{#dynamicSnippet}}searchWithCompression{{/dynamicSnippet}}
         print(response)
     } catch {
         print(error.localizedDescription)


### PR DESCRIPTION
## Summary
- remove the duplicate Swift `try await` in the compression guide template and rendered guide
- import Scala concurrency helpers in the compression guide template and rendered guide, then use `Await.result` and `Duration` directly