### PR TITLE
chore(ci): upgrade Gradle action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,9 +26,10 @@ runs:
 
     - name: Setup gradle
       if: inputs.type != 'minimal'
-      uses: gradle/actions/setup-gradle@v5.0.2
+      uses: gradle/actions/setup-gradle@v6.1.1
       with:
         validate-wrappers: true
+        cache-provider: basic
         add-job-summary: 'on-failure'
 
     - name: Download Java formatter

--- a/clients/algoliasearch-client-java/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-java/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
           java-version-file: .java-version
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.2
+        uses: gradle/actions/setup-gradle@v6.1.1
+        with:
+          cache-provider: basic
 
       - name: Upload Artifacts
         run: ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache

--- a/clients/algoliasearch-client-kotlin/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-kotlin/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5.0.2
+        uses: gradle/actions/setup-gradle@v6.1.1
+        with:
+          cache-provider: basic
 
       - name: Upload Artifacts
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache


### PR DESCRIPTION
## Summary
- upgrade all direct gradle/actions/setup-gradle usage from v5.0.2 to v6.1.1
- explicitly configure cache-provider: basic so CI uses the MIT-licensed open-source caching path
- cover the shared setup composite action plus Java and Kotlin release workflows

## Context
Gradle Actions v6 defaults to enhanced caching, which uses the proprietary gradle-actions-caching component. Per https://github.com/gradle/actions/blob/main/DISTRIBUTION.md, setting cache-provider: basic opts out and keeps caching on the MIT-licensed implementation.

## Validation
- yarn github-actions:lint
- yarn workspace scripts build:actions
- yarn eslint clients/algoliasearch-client-java/.github/workflows/release.yml clients/algoliasearch-client-kotlin/.github/workflows/release.yml
- git diff --check