### PR TITLE
fix(specs): improve Agent Studio API docs metadata

### DIFF
--- a/specs/agent-studio/spec.yml
+++ b/specs/agent-studio/spec.yml
@@ -8,7 +8,7 @@ info:
 
     ## Beta
 
-    The Agent Studio API is in beta and may change before general availability.
+    The Agent Studio API is a **beta feature** according to [Algolia's Terms of Service ("Beta Services")](https://www.algolia.com/policies/terms/).
 
     ## Client libraries
 

--- a/specs/agent-studio/spec.yml
+++ b/specs/agent-studio/spec.yml
@@ -2,10 +2,11 @@ openapi: 3.0.2
 info:
   title: Agent Studio API
   description: |-
-    Algolia's GenAI Toolkit API, building blocks for your dynamic LLM-enabled experiences.
+    The Agent Studio API lets you build and operate generative AI agents that use Algolia data, tools, and your chosen LLM provider.
 
-    Build generative AI experiences with your Algolia data. Combine large language models with Algolia’s Search API using Retrieval Augmented Generation (RAG) techniques.
+    Create, configure, publish, and update agents, then generate chat completions grounded in live data from your Algolia indices. Use the API to manage providers, tools, conversations, feedback, secret keys, user data, caching, and application settings for Agent Studio experiences.
   version: 0.1.0
+x-beta: true
 components:
   securitySchemes:
     appId:

--- a/specs/agent-studio/spec.yml
+++ b/specs/agent-studio/spec.yml
@@ -1,10 +1,53 @@
 openapi: 3.0.2
 info:
   title: Agent Studio API
-  description: |-
+  description: |
     The Agent Studio API lets you build and operate generative AI agents that use Algolia data, tools, and your chosen LLM provider.
 
-    Create, configure, publish, and update agents, then generate chat completions grounded in live data from your Algolia indices. Use the API to manage providers, tools, conversations, feedback, secret keys, user data, caching, and application settings for Agent Studio experiences.
+    Use it to create, configure, publish, and update agents, then generate chat completions grounded in live data from your Algolia indices. You can manage LLM providers, Agent Studio tools, conversations, feedback, secret keys, user data, caching, and application settings for your AI experiences.
+
+    ## Beta
+
+    The Agent Studio API is in beta and may change before general availability.
+
+    ## Client libraries
+
+    Use Algolia's API clients and libraries to reliably integrate Algolia's APIs with your apps.
+
+    For more information, see [Algolia's ecosystem](https://www.algolia.com/doc/guides/getting-started/how-algolia-works/in-depth/ecosystem).
+
+    ## Base URL
+
+    Base URL for the Agent Studio API:
+
+    - `https://{APPLICATION_ID}.algolia.net/agent-studio`
+
+    **All requests must use HTTPS.**
+
+    ## Authentication
+
+    Add these headers to authenticate requests:
+
+    - `x-algolia-application-id`. Your Algolia application ID.
+    - `x-algolia-api-key`. An API key with the necessary permissions to make the request.
+      The required access control list (ACL) to make a request is listed in each endpoint's reference.
+
+    You can find your application ID and API key in the [Algolia dashboard](https://dashboard.algolia.com/account/api-keys).
+
+    ## Request format
+
+    Request bodies must be JSON objects.
+
+    ## Response status and errors
+
+    The Agent Studio API returns JSON responses. Since JSON doesn't guarantee any specific ordering, don't rely on the order of attributes in the API response.
+
+    Successful responses return `2xx` statuses. Client errors return `4xx` statuses. Server errors return `5xx` statuses.
+    Error responses have a `message` property with more information.
+
+    ## Version
+
+    The current version of the Agent Studio API is version 1, indicated by the `/1/` in each endpoint's URL.
   version: 0.1.0
 x-beta: true
 components:

--- a/specs/agent-studio/spec.yml
+++ b/specs/agent-studio/spec.yml
@@ -14,7 +14,7 @@ info:
 
     Use Algolia's API clients and libraries to reliably integrate Algolia's APIs with your apps.
 
-    For more information, see [Algolia's ecosystem](https://www.algolia.com/doc/guides/getting-started/how-algolia-works/in-depth/ecosystem).
+    For more information, see [Algolia's ecosystem](https://www.algolia.com/doc/libraries).
 
     ## Base URL
 


### PR DESCRIPTION
## Summary
- Replace the stale Agent Studio API description that referenced the old GenAI Toolkit name
- Add root `x-beta: true` to the Agent Studio source spec for docs beta-banner metadata