### PR TITLE
chore(ci): use GitHub App client ID

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
 
       - uses: marocchino/sticky-pull-request-comment@v3
@@ -531,17 +531,17 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      ALGOLIA_BOT_APP_ID: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+      ALGOLIA_BOT_CLIENT_ID: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
       generatedCommit: ${{ steps.pushGeneratedCode.outputs.GENERATED_COMMIT || github.event.pull_request.head.ref }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        if: ${{ env.ALGOLIA_BOT_APP_ID != '' }}
+        if: ${{ env.ALGOLIA_BOT_CLIENT_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -695,7 +695,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
           # Here, we push to most of the allowed repo, so no need to scope
           owner: algolia

--- a/.github/workflows/push-to-repository.yml
+++ b/.github/workflows/push-to-repository.yml
@@ -34,7 +34,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
           owner: algolia
           repositories: ${{ inputs.name }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
 
       - name: Renovate Automatic Branch

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ALGOLIA_BOT_APP_ID }}
+          client-id: ${{ vars.ALGOLIA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.ALGOLIA_BOT_PRIVATE_KEY }}
 
       - run: yarn cli release


### PR DESCRIPTION
## Summary
- Use `client-id` for `actions/create-github-app-token` in CI workflows.
- Read the value from `vars.ALGOLIA_BOT_CLIENT_ID` instead of the deprecated App ID input/secret.
- Update the `check.yml` GitHub App token guard to check the new client ID variable.