### PR TITLE
feat(specs): add /semanticSearch/settings endpoint to Search API spec

### DIFF
--- a/specs/search/common/enums.yml
+++ b/specs/search/common/enums.yml
@@ -37,3 +37,23 @@ logType:
   type: string
   enum: [all, query, build, error]
   default: all
+
+neuralSearchMode:
+  type: string
+  enum: [inactive, active, preview]
+  description: |
+    Whether NeuralSearch is active for the index.
+    - `inactive`: keyword-only search is returned for live traffic.
+    - `active`: NeuralSearch (keyword + semantic) is returned for live traffic.
+    - `preview`: NeuralSearch runs alongside keyword search for comparison without affecting live results.
+
+neuralSearchPreset:
+  type: string
+  enum: [conservative, expanded_reach, append_only, default, custom]
+  description: |
+    Controls how keyword and semantic results are blended.
+    - `conservative`: semantic search activates only for zero-result keyword queries.
+    - `expanded_reach`: semantic search activates when keyword result counts are low.
+    - `append_only`: semantic results appear after all keyword results.
+    - `default`: semantic search runs on every query and blends with keyword results, giving keyword results higher priority.
+    - `custom`: unlocks `semanticBlendWeight`, `minHitsForSemantic`, and `enableNeuralSearchSortBy` for manual control.

--- a/specs/search/paths/settings/semanticSearchSettings.yml
+++ b/specs/search/paths/settings/semanticSearchSettings.yml
@@ -3,16 +3,7 @@ SemanticSearchSettings:
   description: Configuration for the NeuralSearch Semantic Settings API.
   properties:
     neuralSearchMode:
-      type: string
-      description: |
-        Whether NeuralSearch is active for the index.
-        - `inactive`: keyword-only search is returned for live traffic.
-        - `active`: NeuralSearch (keyword + semantic) is returned for live traffic.
-        - `preview`: NeuralSearch runs alongside keyword search for comparison without affecting live results.
-      enum:
-        - inactive
-        - active
-        - preview
+      $ref: '../../common/enums.yml#/neuralSearchMode'
     eventSources:
       type: array
       items:
@@ -38,20 +29,7 @@ SemanticSearchSettings:
       description: The language model used to generate embeddings. Set automatically during training.
       example: "external://algolia-large-multilang-generic-v2410"
     neuralSearchPreset:
-      type: string
-      description: |
-        Controls how keyword and semantic results are blended.
-        - `conservative`: semantic search activates only for zero-result keyword queries.
-        - `expanded_reach`: semantic search activates when keyword result counts are low.
-        - `append_only`: semantic results appear after all keyword results.
-        - `default`: semantic search runs on every query and blends with keyword results, giving keyword results higher priority.
-        - `custom`: unlocks `semanticBlendWeight`, `minHitsForSemantic`, and `enableNeuralSearchSortBy` for manual control.
-      enum:
-        - conservative
-        - expanded_reach
-        - append_only
-        - default
-        - custom
+      $ref: '../../common/enums.yml#/neuralSearchPreset'
     semanticBlendWeight:
       type: number
       format: float

--- a/specs/search/paths/settings/semanticSearchSettings.yml
+++ b/specs/search/paths/settings/semanticSearchSettings.yml
@@ -1,0 +1,118 @@
+SemanticSearchSettings:
+  type: object
+  description: Configuration for the NeuralSearch Semantic Settings API.
+  properties:
+    neuralSearchMode:
+      type: string
+      description: |
+        Whether NeuralSearch is active for the index.
+        - `inactive`: keyword-only search is returned for live traffic.
+        - `active`: NeuralSearch (keyword + semantic) is returned for live traffic.
+        - `preview`: NeuralSearch runs alongside keyword search for comparison without affecting live results.
+      enum:
+        - inactive
+        - active
+        - preview
+    eventSources:
+      type: array
+      items:
+        type: string
+      description: |
+        Indices to use as event sources for training.
+        Defaults to the current index if not provided.
+    neuralExpression:
+      type: object
+      description: |
+        Key-value pairs of record attributes and their weights used in the vectorization process.
+        Generated automatically during training.
+      additionalProperties:
+        type: number
+        format: float
+      example:
+        brand: 0.587878
+        category: 0.683043
+        description: 0.39828
+        name: 1
+    vectorModelId:
+      type: string
+      description: The language model used to generate embeddings. Set automatically during training.
+      example: "external://algolia-large-multilang-generic-v2410"
+    neuralSearchPreset:
+      type: string
+      description: |
+        Controls how keyword and semantic results are blended.
+        - `conservative`: semantic search activates only for zero-result keyword queries.
+        - `expanded_reach`: semantic search activates when keyword result counts are low.
+        - `append_only`: semantic results appear after all keyword results.
+        - `default`: semantic search runs on every query and blends with keyword results, giving keyword results higher priority.
+        - `custom`: unlocks `semanticBlendWeight`, `minHitsForSemantic`, and `enableNeuralSearchSortBy` for manual control.
+      enum:
+        - conservative
+        - expanded_reach
+        - append_only
+        - default
+        - custom
+    semanticBlendWeight:
+      type: number
+      format: float
+      minimum: 0.0001
+      maximum: 0.999
+      default: 0.2
+      description: |
+        Relative weight given to semantic results when blending with keyword results.
+        Only use with the `custom` preset.
+    minHitsForSemantic:
+      type: integer
+      minimum: 0
+      maximum: 20
+      default: 0
+      description: |
+        Minimum number of keyword results required before semantic results are included.
+        Only use with the `custom` preset.
+    enableNeuralSearchSortBy:
+      type: boolean
+      default: true
+      description: |
+        When `true`, your index's ranking and sorting settings apply to the full NeuralSearch result set.
+        When `false`, semantic results are ranked by similarity score only.
+        Only use with the `custom` preset.
+    dynamicThreshold:
+      $ref: '#/DynamicThreshold'
+    usePositionalSemanticRanking:
+      type: boolean
+      default: false
+      description: |
+        When `true`, vector results are ranked using Algolia's standard tie-breaking algorithm rather than cosine similarity alone.
+        Enables custom ranking attributes, optional filters, and geo distance for semantic results.
+
+DynamicThreshold:
+  type: object
+  description: |
+    Configures Semantic Precision filtering. Filters low-quality vector results using a dynamically
+    calculated relevance threshold at query time.
+  properties:
+    enabled:
+      type: boolean
+      description: Enables or disables Semantic Precision filtering.
+    aggression:
+      type: number
+      format: float
+      default: 0.3
+      description: |
+        Controls filtering strictness. Lower values keep more results; higher values filter more aggressively.
+        Formula: `threshold = mean - (aggression * stddev)`.
+    upperLimit:
+      type: number
+      format: float
+      default: 0.85
+      description: Maximum cosine similarity threshold. Prevents over-filtering on high-confidence queries.
+    lowerLimit:
+      type: number
+      format: float
+      default: 0.64
+      description: Minimum cosine similarity threshold. Prevents the threshold from dropping too low.
+  example:
+    enabled: true
+    aggression: 0.3
+    upperLimit: 0.85
+    lowerLimit: 0.64

--- a/specs/search/paths/settings/semanticSearchSettingsPath.yml
+++ b/specs/search/paths/settings/semanticSearchSettingsPath.yml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - NeuralSearch
+    - Indices
   operationId: getSemanticSearchSettings
   x-acl:
     - settings
@@ -26,7 +26,7 @@ get:
 
 put:
   tags:
-    - NeuralSearch
+    - Indices
   operationId: setSemanticSearchSettings
   x-acl:
     - editSettings

--- a/specs/search/paths/settings/semanticSearchSettingsPath.yml
+++ b/specs/search/paths/settings/semanticSearchSettingsPath.yml
@@ -1,0 +1,76 @@
+get:
+  tags:
+    - NeuralSearch
+  operationId: getSemanticSearchSettings
+  x-acl:
+    - settings
+  summary: Retrieve NeuralSearch semantic settings
+  description: Retrieves the NeuralSearch semantic settings for an index.
+  parameters:
+    - $ref: '../../../common/parameters.yml#/IndexName'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './semanticSearchSettings.yml#/SemanticSearchSettings'
+    '400':
+      $ref: '../../../common/responses/BadRequest.yml'
+    '401':
+      $ref: '../../../common/responses/Unauthorized.yml'
+    '404':
+      $ref: '../../../common/responses/IndexNotFound.yml'
+    '408':
+      $ref: '../../../common/responses/Timeout.yml'
+    '500':
+      $ref: '../../../common/responses/InternalError.yml'
+
+put:
+  tags:
+    - NeuralSearch
+  operationId: setSemanticSearchSettings
+  x-acl:
+    - editSettings
+  summary: Update NeuralSearch semantic settings
+  description: |
+    Updates the NeuralSearch semantic settings for an index.
+    Changes take effect immediately. No reindexing is required unless you change `neuralExpression` or `vectorModelId`.
+  parameters:
+    - $ref: '../../../common/parameters.yml#/IndexName'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './semanticSearchSettings.yml#/SemanticSearchSettings'
+        example:
+          neuralSearchMode: active
+          eventSources:
+            - mx-products
+          neuralSearchPreset: custom
+          semanticBlendWeight: 0.5
+          dynamicThreshold:
+            enabled: true
+            aggression: 0.3
+            lowerLimit: 0.64
+            upperLimit: 0.85
+  responses:
+    '200':
+      $ref: '../../../common/responses/UpdatedAt.yml'
+    '201':
+      description: Settings created.
+      content:
+        application/json:
+          schema:
+            $ref: '../../../common/responses/UpdatedAt.yml'
+    '400':
+      $ref: '../../../common/responses/BadRequest.yml'
+    '401':
+      $ref: '../../../common/responses/Unauthorized.yml'
+    '404':
+      $ref: '../../../common/responses/IndexNotFound.yml'
+    '408':
+      $ref: '../../../common/responses/Timeout.yml'
+    '500':
+      $ref: '../../../common/responses/InternalError.yml'

--- a/specs/search/paths/settings/semanticSearchSettingsPath.yml
+++ b/specs/search/paths/settings/semanticSearchSettingsPath.yml
@@ -21,8 +21,6 @@ get:
       $ref: '../../../common/responses/Unauthorized.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
-    '408':
-      $ref: '../../../common/responses/Timeout.yml'
     '500':
       $ref: '../../../common/responses/InternalError.yml'
 
@@ -58,19 +56,11 @@ put:
   responses:
     '200':
       $ref: '../../../common/responses/UpdatedAt.yml'
-    '201':
-      description: Settings created.
-      content:
-        application/json:
-          schema:
-            $ref: '../../../common/responses/UpdatedAt.yml'
     '400':
       $ref: '../../../common/responses/BadRequest.yml'
     '401':
       $ref: '../../../common/responses/Unauthorized.yml'
     '404':
       $ref: '../../../common/responses/IndexNotFound.yml'
-    '408':
-      $ref: '../../../common/responses/Timeout.yml'
     '500':
       $ref: '../../../common/responses/InternalError.yml'

--- a/specs/search/spec.yml
+++ b/specs/search/spec.yml
@@ -254,6 +254,9 @@ paths:
   /1/indexes/{indexName}/settings:
     $ref: 'paths/settings/settings.yml'
 
+  /1/indexes/{indexName}/semanticSearch/settings:
+    $ref: 'paths/settings/semanticSearchSettingsPath.yml'
+
   # ##########################
   # ### Synonyms Endpoints ###
   # ##########################

--- a/tests/CTS/requests/search/getSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/getSemanticSearchSettings.json
@@ -1,6 +1,6 @@
 [
   {
-    "testName": "minimal parameters",
+    "testName": "get minimal parameters",
     "parameters": {
       "indexName": "cts_e2e_settings"
     },

--- a/tests/CTS/requests/search/getSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/getSemanticSearchSettings.json
@@ -7,9 +7,6 @@
     "request": {
       "path": "/1/indexes/cts_e2e_settings/semanticSearch/settings",
       "method": "GET"
-    },
-    "response": {
-      "statusCode": 200
     }
   }
 ]

--- a/tests/CTS/requests/search/getSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/getSemanticSearchSettings.json
@@ -1,0 +1,15 @@
+[
+  {
+    "testName": "minimal parameters",
+    "parameters": {
+      "indexName": "cts_e2e_settings"
+    },
+    "request": {
+      "path": "/1/indexes/cts_e2e_settings/semanticSearch/settings",
+      "method": "GET"
+    },
+    "response": {
+      "statusCode": 200
+    }
+  }
+]

--- a/tests/CTS/requests/search/setSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/setSemanticSearchSettings.json
@@ -1,0 +1,21 @@
+[
+  {
+    "testName": "minimal parameters",
+    "parameters": {
+      "indexName": "cts_e2e_settings",
+      "semanticSearchSettings": {
+        "neuralSearchPreset": "default"
+      }
+    },
+    "request": {
+      "path": "/1/indexes/cts_e2e_settings/semanticSearch/settings",
+      "method": "PUT",
+      "body": {
+        "neuralSearchPreset": "default"
+      }
+    },
+    "response": {
+      "statusCode": 200
+    }
+  }
+]

--- a/tests/CTS/requests/search/setSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/setSemanticSearchSettings.json
@@ -13,9 +13,6 @@
       "body": {
         "neuralSearchPreset": "default"
       }
-    },
-    "response": {
-      "statusCode": 200
     }
   }
 ]

--- a/tests/CTS/requests/search/setSemanticSearchSettings.json
+++ b/tests/CTS/requests/search/setSemanticSearchSettings.json
@@ -1,6 +1,6 @@
 [
   {
-    "testName": "minimal parameters",
+    "testName": "set minimal parameters",
     "parameters": {
       "indexName": "cts_e2e_settings",
       "semanticSearchSettings": {


### PR DESCRIPTION
## Summary

Adds the NeuralSearch Semantic Settings API to the Search API spec.

- New path: `GET /1/indexes/{indexName}/semanticSearch/settings`
- New path: `PUT /1/indexes/{indexName}/semanticSearch/settings`
- New schema: `SemanticSearchSettings` and `DynamicThreshold`

## Parameters

| Parameter | Type | Description |
|-----------|------|-------------|
| `neuralSearchMode` | `string` | `active`, `preview`, or `inactive` |
| `eventSources` | `string[]` | Indices to use as event sources |
| `neuralExpression` | `object` | Attribute-to-weight map for vectorization |
| `vectorModelId` | `string` | Embedding model ID |
| `neuralSearchPreset` | `string` | `conservative`, `expanded_reach`, `append_only`, `default`, or `custom` |
| `semanticBlendWeight` | `float` | Blend weight for semantic results (`custom` preset only) |
| `minHitsForSemantic` | `integer` | Min keyword results before semantic kicks in (`custom` preset only) |
| `enableNeuralSearchSortBy` | `boolean` | Apply ranking/sorting settings to full result set (`custom` preset only) |
| `dynamicThreshold` | `object` | Semantic Precision filter config |
| `usePositionalSemanticRanking` | `boolean` | Apply geo/optional filters/custom ranking to vector results |

## Context

This endpoint was previously documented as a standalone guide page in `algolia/docs-new`. Per feedback from Kai Welke, the API reference is the right home for this — the guide page has been removed and will link to this reference once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)