### PR TITLE
fix(swift): return generic type from getObject

### DIFF
--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -738,36 +738,4 @@ public extension SearchClient {
         )
         return try helper.mergeResponses(responses)
     }
-
-    /// Retrieves one record by its object ID as an untyped `AnyCodable`.
-    ///
-    /// Backward-compatible overload of the generic `getObject`: a bare
-    /// `let record = try await client.getObject(...)` resolves here and returns `AnyCodable`.
-    /// Annotate the result to decode into your own type instead, e.g.
-    /// `let record: MyRecord = try await client.getObject(indexName: ..., objectID: ...)`.
-    ///
-    /// - parameter indexName: (path) Name of the index on which to perform the operation.
-    /// - parameter objectID: (path) Unique record identifier.
-    /// - parameter attributesToRetrieve: (query) Attributes to include with the records in the response. (optional)
-    /// - parameter requestOptions: Request options to merge with the transporter requestOptions.
-    /// - returns: AnyCodable
-    func getObject(
-        indexName: String,
-        objectID: String,
-        attributesToRetrieve: [String]? = nil,
-        requestOptions: RequestOptions? = nil
-    ) async throws -> AnyCodable {
-        let response: Response<AnyCodable> = try await self.getObjectWithHTTPInfo(
-            indexName: indexName,
-            objectID: objectID,
-            attributesToRetrieve: attributesToRetrieve,
-            requestOptions: requestOptions
-        )
-
-        guard let body = response.body else {
-            throw AlgoliaError.missingData
-        }
-
-        return body
-    }
 }

--- a/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
+++ b/clients/algoliasearch-client-swift/Sources/Search/Extra/SearchClientExtension.swift
@@ -738,4 +738,36 @@ public extension SearchClient {
         )
         return try helper.mergeResponses(responses)
     }
+
+    /// Retrieves one record by its object ID as an untyped `AnyCodable`.
+    ///
+    /// Backward-compatible overload of the generic `getObject`: a bare
+    /// `let record = try await client.getObject(...)` resolves here and returns `AnyCodable`.
+    /// Annotate the result to decode into your own type instead, e.g.
+    /// `let record: MyRecord = try await client.getObject(indexName: ..., objectID: ...)`.
+    ///
+    /// - parameter indexName: (path) Name of the index on which to perform the operation.
+    /// - parameter objectID: (path) Unique record identifier.
+    /// - parameter attributesToRetrieve: (query) Attributes to include with the records in the response. (optional)
+    /// - parameter requestOptions: Request options to merge with the transporter requestOptions.
+    /// - returns: AnyCodable
+    func getObject(
+        indexName: String,
+        objectID: String,
+        attributesToRetrieve: [String]? = nil,
+        requestOptions: RequestOptions? = nil
+    ) async throws -> AnyCodable {
+        let response: Response<AnyCodable> = try await self.getObjectWithHTTPInfo(
+            indexName: indexName,
+            objectID: objectID,
+            attributesToRetrieve: attributesToRetrieve,
+            requestOptions: requestOptions
+        )
+
+        guard let body = response.body else {
+            throw AlgoliaError.missingData
+        }
+
+        return body
+    }
 }

--- a/templates/swift/api.mustache
+++ b/templates/swift/api.mustache
@@ -76,14 +76,14 @@ import Foundation
      {{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{{description}}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}
-     - returns: {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}
+     - returns: {{#vendorExtensions.x-return-is-generic}}T{{/vendorExtensions.x-return-is-generic}}{{^vendorExtensions.x-return-is-generic}}{{{returnType}}}{{/vendorExtensions.x-return-is-generic}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}
      */
     {{#isDeprecated}}
     @available(*, deprecated, message: "This operation is deprecated.")
     {{/isDeprecated}}
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}{{#vendorExtensions.x-is-generic}}<T: Codable>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions: RequestOptions? = nil) async throws{{#returnType}} -> {{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
-    {{#returnType}}let response: Response<{{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}> = {{/returnType}}try await {{operationId}}WithHTTPInfo({{#allParams}}{{paramName}}: {{paramName}}, {{/allParams}}requestOptions: requestOptions)
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}{{#vendorExtensions.x-is-generic}}<T: Codable>{{/vendorExtensions.x-is-generic}}{{#vendorExtensions.x-return-is-generic}}<T: Codable>{{/vendorExtensions.x-return-is-generic}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions: RequestOptions? = nil) async throws{{#returnType}} -> {{#vendorExtensions.x-return-is-generic}}T{{/vendorExtensions.x-return-is-generic}}{{^vendorExtensions.x-return-is-generic}}{{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{/vendorExtensions.x-return-is-generic}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}} {
+    {{#returnType}}let response: Response<{{#vendorExtensions.x-return-is-generic}}T{{/vendorExtensions.x-return-is-generic}}{{^vendorExtensions.x-return-is-generic}}{{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{/vendorExtensions.x-return-is-generic}}> = {{/returnType}}try await {{operationId}}WithHTTPInfo({{#allParams}}{{paramName}}: {{paramName}}, {{/allParams}}requestOptions: requestOptions)
     {{#returnType}}
 
         guard let body = response.body else {
@@ -104,13 +104,13 @@ import Foundation
      {{/vendorExtensions}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{{description}}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}
-     - returns: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{{description}}}
+     - returns: RequestBuilder<{{#vendorExtensions.x-return-is-generic}}T{{/vendorExtensions.x-return-is-generic}}{{^vendorExtensions.x-return-is-generic}}{{{returnType}}}{{/vendorExtensions.x-return-is-generic}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{{description}}}
      */
     {{#isDeprecated}}
     @available(*, deprecated, message: "This operation is deprecated.")
     {{/isDeprecated}}
     {{^returnType}}@discardableResult{{/returnType}}
-    {{#vendorExtensions}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}WithHTTPInfo{{#vendorExtensions.x-is-generic}}<T: Codable>{{/vendorExtensions.x-is-generic}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions userRequestOptions: RequestOptions? = nil) async throws -> Response<{{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}AnyCodable{{/returnType}}> {
+    {{#vendorExtensions}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}WithHTTPInfo{{#vendorExtensions.x-is-generic}}<T: Codable>{{/vendorExtensions.x-is-generic}}{{#vendorExtensions.x-return-is-generic}}<T: Codable>{{/vendorExtensions.x-return-is-generic}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions userRequestOptions: RequestOptions? = nil) async throws -> Response<{{#vendorExtensions.x-return-is-generic}}T{{/vendorExtensions.x-return-is-generic}}{{^vendorExtensions.x-return-is-generic}}{{{returnType}}}{{#vendorExtensions.x-is-generic}}<T>{{/vendorExtensions.x-is-generic}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}AnyCodable{{/returnType}}{{/vendorExtensions.x-return-is-generic}}> {
         {{#pathParams}}{{#isString}}{{#required}}guard !{{{paramName}}}.isEmpty else {
           throw AlgoliaError.invalidArgument("{{{paramName}}}", "{{{operationId}}}")
         }

--- a/templates/swift/api.mustache
+++ b/templates/swift/api.mustache
@@ -160,6 +160,92 @@ import Foundation
           useReadTransporter: true{{/vendorExtensions.x-use-read-transporter}}
         )
     }{{/vendorExtensions}}
+{{#vendorExtensions.x-return-is-generic}}
+
+    /**
+     {{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{{description}}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     {{/allParams}}
+     - returns: {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}
+     */
+    @available(*, deprecated, message: "This untyped `AnyCodable` overload is deprecated. Annotate the result with a `Codable` type to use the generic `{{operationId}}` instead, e.g. `let object: MyType = try await client.{{operationId}}(...)`. It will be removed in a future version.")
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions: RequestOptions? = nil) async throws{{#returnType}} -> {{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{/returnType}} {
+    {{#returnType}}let response: Response<{{{returnType}}}> = {{/returnType}}try await {{operationId}}WithHTTPInfo({{#allParams}}{{paramName}}: {{paramName}}, {{/allParams}}requestOptions: requestOptions)
+    {{#returnType}}
+
+        guard let body = response.body else {
+            throw AlgoliaError.missingData
+        }
+
+      return body{{/returnType}}
+    }
+
+    /**
+     {{#notes}}{{{.}}}{{/notes}}
+     {{#vendorExtensions}}
+     {{#x-acl.0}}
+     Required API Key ACLs:{{/x-acl.0}}
+     {{#x-acl}}
+       - {{.}}
+     {{/x-acl}}
+     {{/vendorExtensions}}{{#allParams}}
+     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{{description}}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     {{/allParams}}
+     - returns: RequestBuilder<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{{description}}}
+     */
+    @available(*, deprecated, message: "This untyped `AnyCodable` overload is deprecated. Annotate the result with a `Codable` type to use the generic `{{operationId}}WithHTTPInfo` instead, e.g. `let response: Response<MyType> = try await client.{{operationId}}WithHTTPInfo(...)`. It will be removed in a future version.")
+    {{#vendorExtensions}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} func {{operationId}}WithHTTPInfo({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}[{{enumName}}_{{operationId}}]{{/isContainer}}{{^isContainer}}{{enumName}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{#lambda.to-codable}}{{{dataType}}}{{/lambda.to-codable}}{{/isEnum}}{{^required}}? = nil{{/required}}, {{/allParams}}requestOptions userRequestOptions: RequestOptions? = nil) async throws -> Response<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}AnyCodable{{/returnType}}> {
+        {{#pathParams}}{{#isString}}{{#required}}guard !{{{paramName}}}.isEmpty else {
+          throw AlgoliaError.invalidArgument("{{{paramName}}}", "{{{operationId}}}")
+        }
+
+        {{/required}}{{/isString}}{{/pathParams}}{{#queryParams}}{{#isString}}{{#required}}guard !{{{paramName}}}.isEmpty else {
+          throw AlgoliaError.invalidArgument("{{{paramName}}}", "{{{operationId}}}")
+        }
+
+        {{/required}}{{/isString}}{{/queryParams}}
+        {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{#-first}}var{{/-first}}{{/pathParams}} resourcePath = "{{{serverPathSuffix}}}{{{path}}}"{{#pathParams}}
+        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}){{/isEnum}})"{{^x-is-custom-request}}
+        let {{paramName}}PostEscape = {{paramName}}PreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAlgoliaAllowed) ?? ""{{/x-is-custom-request}}
+        resourcePath = resourcePath.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{^x-is-custom-request}}{{paramName}}PostEscape{{/x-is-custom-request}}{{#x-is-custom-request}}{{paramName}}PreEscape{{/x-is-custom-request}}, options: .literal, range: nil){{/pathParams}}
+        {{#bodyParam}}
+        let body = {{paramName}}
+        {{/bodyParam}}
+        {{^bodyParam}}
+          let body: AnyCodable? = nil
+        {{/bodyParam}}
+        {{#hasQueryParams}}
+        let queryParameters{{#x-is-custom-request}}: [String: AnyCodable]? = parameters{{/x-is-custom-request}}{{^x-is-custom-request}}: [String: Any?] = [{{^queryParams}}:{{/queryParams}}
+            {{#queryParams}}
+            {{> _param}},
+            {{/queryParams}}
+        ]{{/x-is-custom-request}}
+        {{/hasQueryParams}}
+        {{^hasQueryParams}}
+          let queryParameters: [String: Any?]? = nil
+        {{/hasQueryParams}}
+
+        let nillableHeaders: [String: Any?]? = {{^headerParams}}nil{{/headerParams}}{{#headerParams}}{{#-first}}[{{/-first}}
+            {{> _param}},
+        {{#-last}}]{{/-last}}{{/headerParams}}
+
+        let headers = APIHelper.rejectNilHeaders(nillableHeaders)
+
+        return try await self.transporter.send(
+          method: "{{httpMethod}}",
+          path: resourcePath,
+          data: body{{#bodyParam}}{{^required}} ?? AnyCodable(){{/required}}{{/bodyParam}},
+          requestOptions: RequestOptions(
+            headers: headers,
+            queryParameters: queryParameters{{#vendorExtensions.x-timeouts}},
+            readTimeout: {{#lambda.toSeconds}}{{{read}}}{{/lambda.toSeconds}},
+            writeTimeout: {{#lambda.toSeconds}}{{{write}}}{{/lambda.toSeconds}}{{/vendorExtensions.x-timeouts}}
+          ) + userRequestOptions{{#vendorExtensions.x-use-read-transporter}},
+          useReadTransporter: true{{/vendorExtensions.x-use-read-transporter}}
+        )
+    }{{/vendorExtensions}}
+{{/vendorExtensions.x-return-is-generic}}
 {{/operation}}
 
 {{#isAgentStudioClient}}

--- a/templates/swift/snippets/method.mustache
+++ b/templates/swift/snippets/method.mustache
@@ -17,7 +17,7 @@ final class {{client}}Snippet {
     {{> snippets/init}}
 
     // Call the API
-    {{#hasResponse}}let response{{#isGeneric}}: {{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{/isGeneric}} = {{/hasResponse}}try {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}({{#hasParams}}{{#parametersWithDataType}}{{> tests/generateParams }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}{{/hasParams}}{{#hasRequestOptions}}, requestOptions: RequestOptions({{#requestOptions.headers}}
+    {{#hasResponse}}let response{{#isGeneric}}: {{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{/isGeneric}}{{#isReturnGeneric}}: [String: AnyCodable]{{/isReturnGeneric}} = {{/hasResponse}}try {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}({{#hasParams}}{{#parametersWithDataType}}{{> tests/generateParams }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}{{/hasParams}}{{#hasRequestOptions}}, requestOptions: RequestOptions({{#requestOptions.headers}}
       headers: [{{#parametersWithDataType}}"{{key}}": {{> tests/paramValue }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}]{{/requestOptions.headers}}
       {{#requestOptions.headers}}{{#requestOptions.queryParameters}},{{/requestOptions.queryParameters}}{{/requestOptions.headers}}{{#requestOptions.queryParameters}}
       queryParameters: [{{#parametersWithDataType}}"{{key}}": {{> tests/paramValue }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}]{{/requestOptions.queryParameters}}

--- a/templates/swift/tests/client/method.mustache
+++ b/templates/swift/tests/client/method.mustache
@@ -1,4 +1,4 @@
-{{#hasResponse}}let response{{#isGeneric}}: {{#useEchoRequester}}Response<{{/useEchoRequester}}{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{#useEchoRequester}}>{{/useEchoRequester}}{{/isGeneric}} = {{> tests/method}}{{/hasResponse}}
+{{#hasResponse}}let response{{#isGeneric}}: {{#useEchoRequester}}Response<{{/useEchoRequester}}{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{#useEchoRequester}}>{{/useEchoRequester}}{{/isGeneric}}{{#isReturnGeneric}}: {{#useEchoRequester}}Response<{{/useEchoRequester}}[String: AnyCodable]{{#useEchoRequester}}>{{/useEchoRequester}}{{/isReturnGeneric}} = {{> tests/method}}{{/hasResponse}}
 {{^hasResponse}}let _ = {{> tests/method}}{{/hasResponse}}
 {{^isHelper}}
 {{^isBenchmark}}

--- a/templates/swift/tests/e2e/e2e.mustache
+++ b/templates/swift/tests/e2e/e2e.mustache
@@ -61,7 +61,7 @@ final class {{client}}RequestsTestsE2E: XCTestCase {
         }
 
         {{#response}}
-          let response{{#isGeneric}}: Response<{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>>{{/isGeneric}} = {{> tests/method}}
+          let response{{#isGeneric}}: Response<{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>>{{/isGeneric}}{{#isReturnGeneric}}: Response<[String: AnyCodable]>{{/isReturnGeneric}} = {{> tests/method}}
           {{#body}}
             try XCTLenientAssertEqual(received: XCTUnwrap(response.body), expected: "{{#lambda.escapeJSON}}{{{body}}}{{/lambda.escapeJSON}}")
           {{/body}}

--- a/templates/swift/tests/requests/requests.mustache
+++ b/templates/swift/tests/requests/requests.mustache
@@ -21,7 +21,7 @@ final class {{client}}RequestsTests: XCTestCase {
         let transporter: Transporter = Transporter(configuration: configuration, requestBuilder: EchoRequestBuilder())
         let client: {{client}} = {{client}}(configuration: configuration, transporter: transporter)
 
-        let response{{#isGeneric}}: Response<{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>>{{/isGeneric}} = {{> tests/method}}
+        let response{{#isGeneric}}: Response<{{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>>{{/isGeneric}}{{#isReturnGeneric}}: Response<[String: AnyCodable]>{{/isReturnGeneric}} = {{> tests/method}}
         let responseBodyData = try XCTUnwrap(response.bodyData)
         let echoResponse = try CodableHelper.jsonDecoder.decode(EchoResponse.self, from: responseBodyData)
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: N/A — Fixes [algolia/algoliasearch-client-swift#891](https://github.com/algolia/algoliasearch-client-swift/issues/891)

`SearchClient.getObject(indexName:objectID:attributesToRetrieve:requestOptions:)` returned `AnyCodable`, while every other search/get method returns a generic type (`getObjects<T>`, `searchSingleIndex<T>`, …). With `AnyCodable` there is no typed result: callers had to hand-walk an `Any` tree or do a lossy re-encode/re-decode round-trip, so the reporter fell back to `getObjects` to get a faithful typed decode.

### Root cause

`getObject`'s `200` response is an **inline** `type: object` schema flagged `x-is-generic: true`. For inline-return generics, `GenericPropagator` deliberately sets `x-return-is-generic` (not `x-is-generic`) so only templates that explicitly opt in apply the generic. Only the JavaScript template honored `x-return-is-generic`; the Swift template checked `x-is-generic` only, so `getObject` fell back to `AnyCodable`. (Named-model generics like `getObjects` → `GetObjectsResponse<T>` use `x-is-generic`, which Swift already handled — which is why those were generic and `getObject` was not.)

### Changes included (template-only)

For `x-return-is-generic` operations, the Swift template now generates **four** methods, giving a typed API with **zero breaking change**:

```swift
// new, recommended — faithful single-pass decode via transporter.send<T>
open func getObject<T: Codable>(...) async throws -> T
open func getObjectWithHTTPInfo<T: Codable>(...) async throws -> Response<T>

// kept for back-compat, deprecated
@available(*, deprecated, message: "… use the generic getObject …")
open func getObject(...) async throws -> AnyCodable
@available(*, deprecated, message: "… use the generic getObjectWithHTTPInfo …")
open func getObjectWithHTTPInfo(...) async throws -> Response<AnyCodable>
```

- **`templates/swift/api.mustache`** — handle `x-return-is-generic`: emit the generic pair, plus the deprecated `AnyCodable` pair (a faithful copy of the original methods + `@available(deprecated)`).
- **`templates/swift/tests/{requests,e2e,client}/*.mustache`** and **`templates/swift/snippets/method.mustache`** — annotate `isReturnGeneric` call sites (`Response<[String: AnyCodable]>` / `[String: AnyCodable]`) so generated tests and snippets exercise the **generic** overload (no deprecation warnings in generated code, and the snippet demonstrates the typed form).

The deprecated `AnyCodable` overloads are **generated, not hand-written**, because they're the transport leaf — they must call `self.transporter.send(...)`, and `transporter` is `private` (unreachable from a hand-written extension), and a non-generic overload can't delegate to the generic one without infinite recursion.

```swift
// Typed (new, recommended):
let movie: Movie = try await client.getObject(indexName: "movies", objectID: "1")
// Untyped (still compiles, now deprecated — nudges you to annotate):
let any = try await client.getObject(indexName: "movies", objectID: "1") // -> AnyCodable
```

## ✅ Backward compatibility

**No breaking change.** Swift has no default generic parameters, so a bare `getObject(...)` can't infer `T`; the deprecated non-generic overload covers exactly that case:

- ✅ `let x = try await client.getObject(...)` → resolves to the deprecated `AnyCodable` overload (compiles, works, emits a deprecation warning nudging you to annotate).
- ✅ `let x: AnyCodable = try await client.getObject(...)` → unchanged behavior (deprecated overload).
- ✅ `let x: MyType = try await client.getObject(...)` → the generic overload, faithfully decoded.
- Same for `getObjectWithHTTPInfo`.

The deprecation is cleanly removable in a future major version (the `AnyCodable` overloads are an isolated, gated template block).

## 🧪 Test

Verified locally (Swift 5.9) — all three Swift packages build clean after regeneration:

- `clients/algoliasearch-client-swift` → `swift build` ✅ — the four overloads coexist with **no ambiguity**, and **no internal deprecation warning** (Swift suppresses the deprecated→deprecated call from the AnyCodable `getObject` into the AnyCodable `getObjectWithHTTPInfo`).
- `docs/snippets/swift` → `swift build` ✅ — the annotated snippet resolves to the generic overload (no deprecation warning).
- `tests/output/swift` → `swift build --build-tests` ✅ — the annotated `getObjectWithHTTPInfo` request/e2e sites resolve to the generic overload.

Typed decoding flows through `transporter.send<T>` — the same proven path used by `getObjects<T>` / `searchSingleIndex<T>`.

> Source-only PR per repo convention — the generated client/tests/snippets are produced and pushed by CI. Local generated edits were used only to verify compilation and are not committed.
