### PR TITLE
fix(javascript): expose Node search helpers on `Algoliasearch` type under `bundler` module resolution

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/browser.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/browser.ts
@@ -29,6 +29,7 @@ import type {
   ReplaceAllObjectsOptions,
   ReplaceAllObjectsWithTransformationResponse,
   SaveObjectsOptions,
+  SearchClientNodeHelpers,
 } from '@algolia/client-search';
 import type { WatchResponse } from '@algolia/ingestion';
 
@@ -46,7 +47,10 @@ import type {
 
 export * from './models';
 
-export type Algoliasearch = SearchClient & {
+// `SearchClientNodeHelpers` is intersected explicitly: depending on the consumer's `moduleResolution`
+// (e.g. `bundler`), `@algolia/client-search` can resolve to its browser build where `SearchClient`
+// omits the Node-only helpers, which would otherwise drop `generateSecuredApiKey` & co. from this type.
+export type Algoliasearch = SearchClient & SearchClientNodeHelpers & {
   initAbtesting: (initOptions: InitClientOptions & AbtestingRegionOptions) => AbtestingClient;
   initAbtestingV3: (initOptions: InitClientOptions & AbtestingV3RegionOptions) => AbtestingV3Client;
   initAnalytics: (initOptions: InitClientOptions & AnalyticsRegionOptions) => AnalyticsClient;

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/fetch.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/fetch.ts
@@ -29,6 +29,7 @@ import type {
   ReplaceAllObjectsOptions,
   ReplaceAllObjectsWithTransformationResponse,
   SaveObjectsOptions,
+  SearchClientNodeHelpers,
 } from '@algolia/client-search';
 import type { WatchResponse } from '@algolia/ingestion';
 
@@ -46,7 +47,10 @@ import type {
 
 export * from './models';
 
-export type Algoliasearch = SearchClient & {
+// `SearchClientNodeHelpers` is intersected explicitly: depending on the consumer's `moduleResolution`
+// (e.g. `bundler`), `@algolia/client-search` can resolve to its browser build where `SearchClient`
+// omits the Node-only helpers, which would otherwise drop `generateSecuredApiKey` & co. from this type.
+export type Algoliasearch = SearchClient & SearchClientNodeHelpers & {
   initAbtesting: (initOptions: InitClientOptions & AbtestingRegionOptions) => AbtestingClient;
   initAbtestingV3: (initOptions: InitClientOptions & AbtestingV3RegionOptions) => AbtestingV3Client;
   initAnalytics: (initOptions: InitClientOptions & AnalyticsRegionOptions) => AnalyticsClient;

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/node.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/node.ts
@@ -29,6 +29,7 @@ import type {
   ReplaceAllObjectsOptions,
   ReplaceAllObjectsWithTransformationResponse,
   SaveObjectsOptions,
+  SearchClientNodeHelpers,
 } from '@algolia/client-search';
 import type { WatchResponse } from '@algolia/ingestion';
 
@@ -46,7 +47,10 @@ import type {
 
 export * from './models';
 
-export type Algoliasearch = SearchClient & {
+// `SearchClientNodeHelpers` is intersected explicitly: depending on the consumer's `moduleResolution`
+// (e.g. `bundler`), `@algolia/client-search` can resolve to its browser build where `SearchClient`
+// omits the Node-only helpers, which would otherwise drop `generateSecuredApiKey` & co. from this type.
+export type Algoliasearch = SearchClient & SearchClientNodeHelpers & {
   initAbtesting: (initOptions: InitClientOptions & AbtestingRegionOptions) => AbtestingClient;
   initAbtestingV3: (initOptions: InitClientOptions & AbtestingV3RegionOptions) => AbtestingV3Client;
   initAnalytics: (initOptions: InitClientOptions & AnalyticsRegionOptions) => AnalyticsClient;

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/worker.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/builds/worker.ts
@@ -29,6 +29,7 @@ import type {
   ReplaceAllObjectsOptions,
   ReplaceAllObjectsWithTransformationResponse,
   SaveObjectsOptions,
+  SearchClientNodeHelpers,
 } from '@algolia/client-search';
 import type { WatchResponse } from '@algolia/ingestion';
 
@@ -46,7 +47,10 @@ import type {
 
 export * from './models';
 
-export type Algoliasearch = SearchClient & {
+// `SearchClientNodeHelpers` is intersected explicitly: depending on the consumer's `moduleResolution`
+// (e.g. `bundler`), `@algolia/client-search` can resolve to its browser build where `SearchClient`
+// omits the Node-only helpers, which would otherwise drop `generateSecuredApiKey` & co. from this type.
+export type Algoliasearch = SearchClient & SearchClientNodeHelpers & {
   initAbtesting: (initOptions: InitClientOptions & AbtestingRegionOptions) => AbtestingClient;
   initAbtestingV3: (initOptions: InitClientOptions & AbtestingV3RegionOptions) => AbtestingV3Client;
   initAnalytics: (initOptions: InitClientOptions & AnalyticsRegionOptions) => AnalyticsClient;

--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -9,7 +9,7 @@ import type { {{#lambda.titlecase}}{{{dependencyName}}}{{/lambda.titlecase}}Clie
 {{/dependencies}}
 
 import type { ChunkedBatchOptions, ReplaceAllObjectsOptions, ReplaceAllObjectsWithTransformationResponse } from '@algolia/client-search';
-import type { PartialUpdateObjectsOptions, SaveObjectsOptions } from '@algolia/client-search';
+import type { PartialUpdateObjectsOptions, SaveObjectsOptions, SearchClientNodeHelpers } from '@algolia/client-search';
 import type { WatchResponse } from '@algolia/ingestion';
 
 import type {
@@ -24,7 +24,10 @@ import type {
 
 export * from './models';
 
-export type Algoliasearch = SearchClient & {
+// `SearchClientNodeHelpers` is intersected explicitly: depending on the consumer's `moduleResolution`
+// (e.g. `bundler`), `@algolia/client-search` can resolve to its browser build where `SearchClient`
+// omits the Node-only helpers, which would otherwise drop `generateSecuredApiKey` & co. from this type.
+export type Algoliasearch = SearchClient & SearchClientNodeHelpers & {
   {{#dependencies}}
   {{#withInitMethod}}
   init{{#lambda.titlecase}}{{{dependencyName}}}{{/lambda.titlecase}}: (initOptions{{^dependencyHasRegionalHosts}}?{{/dependencyHasRegionalHosts}}: InitClientOptions {{#dependencyHasRegionalHosts}}& {{#lambda.titlecase}}{{{dependencyName}}}RegionOptions{{/lambda.titlecase}}{{/dependencyHasRegionalHosts}}) => {{#lambda.titlecase}}{{{dependencyName}}}{{/lambda.titlecase}}Client;


### PR DESCRIPTION
## 🧭 What and Why

🎟 fixes algolia/algoliasearch-client-javascript#1611

The reporter notes that `SearchClientNodeHelpers` is not part of the `algoliasearch` client typing, so `generateSecuredApiKey` (and the other Node-only helpers) are missing from the `Algoliasearch` type, even though they work at runtime. Their workaround was `algoliasearch(...) as (Algoliasearch & SearchClientNodeHelpers)`.

### Root cause

The umbrella `algoliasearch` package declares its public type as:

```ts
import type { SearchClient } from '@algolia/client-search';
export type Algoliasearch = SearchClient & { /* init* methods + *WithTransformation helpers */ };
```

The helper surface of `Algoliasearch` is therefore inherited entirely from however the consumer's TypeScript resolves `@algolia/client-search`. But that package exposes a **different `SearchClient` per build**:

- `client-search` **node**/**fetch** build → `ReturnType<…> & SearchClientNodeHelpers` (has `generateSecuredApiKey`, `getSecuredApiKeyRemainingValidity`, `accountCopyIndex`)
- `client-search` **worker** build → `… & SearchClientWorkerHelpers`
- `client-search` **browser** build → `ReturnType<…>` (no helpers)

Under `moduleResolution: "bundler"` (the modern default for Vite and many TS setups), TypeScript does **not** apply the `node` export condition, so both `algoliasearch` and the nested `@algolia/client-search` resolve through the `default` (browser) condition → `SearchClient` without helpers → `Algoliasearch` without `generateSecuredApiKey`. Classic `node`/`node16`/`nodenext` resolution apply the `node` condition (or fall back to the root `index.d.ts` which re-exports `./dist/node`), so they happen to work — which is why this only bites a subset of users.

I reproduced this in isolation with faithful `exports`/`.d.ts` shapes:

| `moduleResolution` | `generateSecuredApiKey` visible on `Algoliasearch`? |
| --- | --- |
| `node` | ✅ |
| `node16` | ✅ |
| `nodenext` | ✅ |
| `bundler` | ❌ `Property 'generateSecuredApiKey' does not exist on type 'Algoliasearch'` |

### Tradeoff / discussion

This is the minimal change that matches the existing design (all four umbrella builds are intentionally generated from a single, identical template). The one consequence is that the `algoliasearch` **browser** type now also advertises the Node helpers, even though they aren't present in a browser runtime. These are server-only operations (e.g. `generateSecuredApiKey` requires the parent/admin key and `node:crypto`), so this is unlikely to affect real browser apps. If maintainers prefer to keep the browser type clean, the alternative is to split `definition.mustache` into per-build templates (node/fetch → `SearchClientNodeHelpers`, worker → `SearchClientWorkerHelpers`, browser → none) — but note that would **not** fix the reported case, because `bundler` resolution always lands on the browser `.d.ts`. The standalone `@algolia/client-search` package has the same class of `bundler`-resolution gap for direct `SearchClient` consumers; that's intentionally left out of scope here.

<div><a href="https://cursor.com/agents/bc-a0f0256f-757b-4177-9b9e-9fe17b385820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f0256f-757b-4177-9b9e-9fe17b385820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

