### PR TITLE
fix(specs): remove recommend query params overridden by the API

### DIFF
--- a/specs/recommend/common/schemas/IndexSettings.yml
+++ b/specs/recommend/common/schemas/IndexSettings.yml
@@ -10,8 +10,6 @@ baseRecommendIndexSettings:
   properties:
     attributesToRetrieve:
       $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/attributesToRetrieve'
-    ranking:
-      $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/ranking'
     relevancyStrictness:
       $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/relevancyStrictness'
     attributesToHighlight:
@@ -44,8 +42,6 @@ baseRecommendIndexSettings:
       $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/queryLanguages'
     decompoundQuery:
       $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/decompoundQuery'
-    enableRules:
-      $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/enableRules'
     enablePersonalization:
       $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/enablePersonalization'
     queryType:

--- a/specs/recommend/common/schemas/QueryParameters.yml
+++ b/specs/recommend/common/schemas/QueryParameters.yml
@@ -5,13 +5,18 @@ recommendSearchParams:
     - $ref: '#/baseRecommendSearchParams'
     - $ref: '../../../common/schemas/SearchParams.yml#/searchParamsQuery'
     - $ref: './IndexSettings.yml#/recommendIndexSettings'
+    - type: object
+      properties:
+        enableRules:
+          $ref: '../../../common/schemas/IndexSettings.yml#/indexSettingsAsSearchParams/properties/enableRules'
 
 fallbackParams:
   title: fallbackParameters
+  description: Search parameters to use for a fallback request if there aren't enough recommendations.
   allOf:
-    - $ref: './QueryParameters.yml#/recommendSearchParams'
-    - type: object
-      description: Search parameters to use for a fallback request if there aren't enough recommendations.
+    - $ref: '#/baseRecommendSearchParams'
+    - $ref: '../../../common/schemas/SearchParams.yml#/searchParamsQuery'
+    - $ref: './IndexSettings.yml#/recommendIndexSettings'
 
 baseRecommendSearchParams:
   type: object
@@ -21,8 +26,6 @@ baseRecommendSearchParams:
       $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/similarQuery'
     filters:
       $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/filters'
-    facetFilters:
-      $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/facetFilters'
     optionalFilters:
       $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/optionalFilters'
     numericFilters:
@@ -71,5 +74,3 @@ baseRecommendSearchParams:
       $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/analyticsTags'
     percentileComputation:
       $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/percentileComputation'
-    enableABTest:
-      $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/enableABTest'

--- a/tests/CTS/requests/recommend/getRecommendations.json
+++ b/tests/CTS/requests/recommend/getRecommendations.json
@@ -139,14 +139,14 @@
           "maxRecommendations": 10,
           "queryParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "query"
+            "optionalFilters": [
+              "brand:apple"
             ]
           },
           "fallbackParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "fallback"
+            "optionalFilters": [
+              "brand:samsung"
             ]
           }
         }
@@ -165,14 +165,14 @@
             "maxRecommendations": 10,
             "queryParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "query"
+              "optionalFilters": [
+                "brand:apple"
               ]
             },
             "fallbackParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "fallback"
+              "optionalFilters": [
+                "brand:samsung"
               ]
             }
           }
@@ -222,14 +222,14 @@
           "facetValue": "myFacetValue",
           "queryParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "query"
+            "optionalFilters": [
+              "brand:apple"
             ]
           },
           "fallbackParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "fallback"
+            "optionalFilters": [
+              "brand:samsung"
             ]
           }
         }
@@ -249,14 +249,14 @@
             "facetValue": "myFacetValue",
             "queryParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "query"
+              "optionalFilters": [
+                "brand:apple"
               ]
             },
             "fallbackParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "fallback"
+              "optionalFilters": [
+                "brand:samsung"
               ]
             }
           }
@@ -315,14 +315,14 @@
           "maxRecommendations": 10,
           "queryParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "query1"
+            "optionalFilters": [
+              "brand:apple"
             ]
           },
           "fallbackParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "fallback1"
+            "optionalFilters": [
+              "brand:samsung"
             ]
           }
         },
@@ -334,14 +334,14 @@
           "maxRecommendations": 10,
           "queryParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "query2"
+            "optionalFilters": [
+              "brand:google"
             ]
           },
           "fallbackParameters": {
             "query": "myQuery",
-            "facetFilters": [
-              "fallback2"
+            "optionalFilters": [
+              "brand:microsoft"
             ]
           }
         }
@@ -360,14 +360,14 @@
             "maxRecommendations": 10,
             "queryParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "query1"
+              "optionalFilters": [
+                "brand:apple"
               ]
             },
             "fallbackParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "fallback1"
+              "optionalFilters": [
+                "brand:samsung"
               ]
             }
           },
@@ -379,14 +379,14 @@
             "maxRecommendations": 10,
             "queryParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "query2"
+              "optionalFilters": [
+                "brand:google"
               ]
             },
             "fallbackParameters": {
               "query": "myQuery",
-              "facetFilters": [
-                "fallback2"
+              "optionalFilters": [
+                "brand:microsoft"
               ]
             }
           }


### PR DESCRIPTION
## 🧭 What and Why


The Recommend API ignores a few query parameters and applies its own values instead, so listing them as configurable in the spec is misleading. This removes the ones that have no effect.

### Changes included:

- Remove `ranking`, `facetFilters`, and `enableABTest` from `queryParameters` and `fallbackParameters`.
- Remove `enableRules` from `fallbackParameters`. It stays on `queryParameters`, where it's still applied.

## 🧪 Test

Validated with `redocly lint specs/recommend/spec.yml`.
