### PR TITLE
fix(java): add warning in replaceAllObjects for empty objects

### DIFF
--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -1414,6 +1414,9 @@ public <T> List<BatchResponse> partialUpdateObjects(
  * https://api-clients-automation.netlify.app/docs/custom-helpers/#replaceallobjects for implementation
  * details.
  *
+ * <p><b>Warning:</b> calling this method with an empty {@code objects} list replaces the index with
+ * an empty one, deleting all existing records.
+ *
  * @param indexName The `indexName` to replace `objects` in.
  * @param objects The array of `objects` to store in the given Algolia `indexName`.
  * @throws AlgoliaRetryException When the retry has failed on all hosts
@@ -1429,6 +1432,9 @@ public <T> ReplaceAllObjectsResponse replaceAllObjects(String indexName, Iterabl
  * untouched. Replace all records in an index without any downtime. See
  * https://api-clients-automation.netlify.app/docs/custom-helpers/#replaceallobjects for implementation
  * details.
+ *
+ * <p><b>Warning:</b> calling this method with an empty {@code objects} list replaces the index with
+ * an empty one, deleting all existing records.
  *
  * @param indexName The `indexName` to replace `objects` in.
  * @param objects The array of `objects` to store in the given Algolia `indexName`.
@@ -1448,6 +1454,9 @@ public <T> ReplaceAllObjectsResponse replaceAllObjects(String indexName, Iterabl
  * https://api-clients-automation.netlify.app/docs/custom-helpers/#replaceallobjects for implementation
  * details.
  *
+ * <p><b>Warning:</b> calling this method with an empty {@code objects} list replaces the index with
+ * an empty one, deleting all existing records.
+ *
  * @param indexName The `indexName` to replace `objects` in.
  * @param objects The array of `objects` to store in the given Algolia `indexName`.
  * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
@@ -1466,6 +1475,9 @@ public <T> ReplaceAllObjectsResponse replaceAllObjects(String indexName, Iterabl
  * untouched. Replace all records in an index without any downtime. See
  * https://api-clients-automation.netlify.app/docs/custom-helpers/#replaceallobjects for implementation
  * details.
+ *
+ * <p><b>Warning:</b> calling this method with an empty {@code objects} list replaces the index with
+ * an empty one, deleting all existing records.
  *
  * @param indexName The `indexName` to replace `objects` in.
  * @param objects The array of `objects` to store in the given Algolia `indexName`.
@@ -1494,6 +1506,9 @@ public <T> ReplaceAllObjectsResponse replaceAllObjects(
  * https://api-clients-automation.netlify.app/docs/custom-helpers/#replaceallobjects for implementation
  * details.
  *
+ * <p><b>Warning:</b> calling this method with an empty {@code objects} list replaces the index with
+ * an empty one, deleting all existing records.
+ *
  * @param indexName The `indexName` to replace `objects` in.
  * @param objects The array of `objects` to store in the given Algolia `indexName`.
  * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
@@ -1516,6 +1531,14 @@ public <T> ReplaceAllObjectsResponse replaceAllObjects(
   RequestOptions requestOptions,
   ChunkedHelperOptions chunkedOptions
 ) {
+  if (objects instanceof java.util.Collection ? ((java.util.Collection<?>) objects).isEmpty() : !objects.iterator().hasNext()) {
+    java.util.logging.Logger
+      .getLogger(this.getClass().getName())
+      .warning(
+        "replaceAllObjects was called with an empty list of objects, which will delete all records currently in the \"" + indexName + "\" index."
+      );
+  }
+
   if (chunkedOptions == null) {
     chunkedOptions = new ChunkedHelperOptions().setMaxRetries(ChunkedHelperOptions.DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES);
   }
@@ -1699,6 +1722,16 @@ public <T> ReplaceAllObjectsWithTransformationResponse replaceAllObjectsWithTran
       " It defaults to the Ingestion API defaults." +
       " See https://www.algolia.com/doc/libraries/sdk/methods/ingestion"
     );
+  }
+
+  if (objects instanceof java.util.Collection ? ((java.util.Collection<?>) objects).isEmpty() : !objects.iterator().hasNext()) {
+    java.util.logging.Logger
+      .getLogger(this.getClass().getName())
+      .warning(
+        "replaceAllObjectsWithTransformation was called with an empty list of objects, which will delete all records currently in the \"" +
+        indexName +
+        "\" index."
+      );
   }
 
   if (chunkedOptions == null) {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-500](https://algolia.atlassian.net/browse/API-500)

Stemming from CR-11510: a customer wiped an index by calling `replaceAllObjects` with an empty list. The helper copies the source index's settings/synonyms/rules to a temp index, batches **zero** records into it, then moves the temp index over the source — leaving the original index empty. This happened silently, with no warning.

This adds a warning-level log when `replaceAllObjects` (and its `replaceAllObjectsWithTransformation` sibling) is called with an empty list of objects. **Behavior is unchanged** — the call still proceeds; it only warns.

This is the Java client; the other clients are handled in their own PRs.

### Changes included:

- Log a `WARNING` (via `java.util.logging`) when the `objects` collection is empty, added to the canonical `replaceAllObjects` and `replaceAllObjectsWithTransformation` implementations. All overloads delegate down to these, so every call path is covered: `replaceAllObjects was called with an empty list of objects, which will delete all records currently in the "<indexName>" index.`
- The empty check uses `Collection.isEmpty()` when possible and falls back to `iterator().hasNext()` for non-`Collection` `Iterable`s, so single-use iterables aren't consumed by the check.
- Add a `Warning` note to the `replaceAllObjects` Javadoc so the behavior surfaces in IDE hover/autocomplete at write-time.

### Out of scope

- The public "Replace all records" documentation page lives in the `docs-new` repo and is updated separately.

## 🧪 Test

- Regenerated the Java search client and compiled it (`:algoliasearch:compileJava --rerun-tasks` → BUILD SUCCESSFUL).
- No CTS changes: this only adds a log line and doesn't alter requests or behavior.


[API-500]: https://algolia.atlassian.net/browse/API-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ