### PR TITLE
fix(clients): browseSynonyms pagination (CR-11727)

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_READ_TIMEOUT_BROWSER,
   DEFAULT_WRITE_TIMEOUT_BROWSER,
 } from '@algolia/client-common';
+import type { EndRequest, Requester } from '@algolia/client-common';
 import type { EchoResponse } from '@algolia/requester-testing';
 
 import { browserEchoRequester } from '../../requester-testing/src/browserEchoRequester';
@@ -281,5 +282,46 @@ describe('init', () => {
       'x-algolia-api-key': 'API_KEY',
       'x-algolia-application-id': 'APP_ID',
     });
+  });
+});
+
+describe('browseSynonyms', () => {
+  test('paginates until a non-full page and never re-fetches page 0 (CR-11727)', async () => {
+    const hitsPerPage = 1000;
+    const pagesRequested: number[] = [];
+
+    const paginatingRequester: Requester = {
+      send(request: EndRequest) {
+        const body = (typeof request.data === 'string' ? JSON.parse(request.data) : {}) as { page?: number };
+        const page = body.page ?? 0;
+        pagesRequested.push(page);
+
+        // Full first page, then a partial page: a correct iterator walks page 0 then page 1 and stops.
+        const count = page === 0 ? hitsPerPage : 3;
+        const hits = Array.from({ length: count }, (_, i) => ({ objectID: `page${page}-hit${i}` }));
+
+        return Promise.resolve({
+          content: JSON.stringify({ hits, nbHits: hitsPerPage + 3 }),
+          isTimedOut: false,
+          status: 200,
+        });
+      },
+    };
+
+    const paginatingClient = algoliasearch('APP_ID', 'API_KEY', { requester: paginatingRequester });
+
+    const objectIDs: string[] = [];
+    await paginatingClient.browseSynonyms({
+      indexName: 'my-index',
+      aggregator: (response) => {
+        for (const hit of response.hits) {
+          objectIDs.push(hit.objectID);
+        }
+      },
+    });
+
+    expect(pagesRequested).toEqual([0, 1]);
+    expect(objectIDs).toHaveLength(hitsPerPage + 3);
+    expect(new Set(objectIDs).size).toEqual(hitsPerPage + 3);
   });
 });

--- a/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/TestBrowseSynonyms.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/TestBrowseSynonyms.kt
@@ -1,0 +1,112 @@
+package com.algolia.client
+
+import com.algolia.client.api.SearchClient
+import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.extensions.browseSynonyms
+import com.algolia.client.model.search.SearchSynonymsParams
+import com.algolia.client.model.search.SynonymHit
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Regression guard for the `browseSynonyms` pagination contract (Jira CR-11727).
+ *
+ * The Java `browseSynonyms` helper once failed to write the incremented `page` back into the
+ * request params, so it re-fetched page 0 forever (infinite loop / OOM). Kotlin's implementation is
+ * correct; this test locks that behavior in by mocking the HTTP layer and asserting that
+ * consecutive, distinct pages are requested until a partial page ends the iteration.
+ *
+ * Placed under `jvmTest` (not `commonTest`) on purpose: the client module's test classpath has no
+ * coroutine runner in `commonTest` (`kotlinx-coroutines-test` is not a declared dependency, and
+ * `runBlocking` is not part of the JS-less multiplatform common source set), so a self-contained
+ * coroutine-driven test must live on the JVM target where `runBlocking` is available. `ktor-client-mock`
+ * is a `commonTest` dependency and is inherited here.
+ */
+class TestBrowseSynonyms {
+
+  private val hitsPerPage = 1000
+
+  /** Builds a canned `SearchSynonymsResponse` body with [count] hits prefixed by [objectIdPrefix]. */
+  private fun synonymsPageBody(objectIdPrefix: String, count: Int): String {
+    val hits =
+      (0 until count).joinToString(",") { i ->
+        """{"objectID":"$objectIdPrefix-hit$i","type":"synonym"}"""
+      }
+    return """{"hits":[$hits],"nbHits":1003}"""
+  }
+
+  @Test
+  fun browseSynonymsPaginatesUntilPartialPage() = runBlocking {
+    val requestedPages = mutableListOf<Int>()
+    val requestedPaths = mutableListOf<String>()
+
+    val engine =
+      MockEngine { request ->
+        requestedPaths += request.url.encodedPath
+
+        val bodyBytes =
+          (request.body as? OutgoingContent.ByteArrayContent)?.bytes()
+            ?: error("Unexpected request body type: ${request.body::class}")
+        val page =
+          Json.parseToJsonElement(bodyBytes.decodeToString())
+            .jsonObject["page"]!!
+            .jsonPrimitive
+            .int
+        requestedPages += page
+
+        // page 0 -> a full page (1000 hits) so iteration continues.
+        // page >= 1 -> a partial page (3 hits) so iteration stops.
+        val content =
+          if (page == 0) synonymsPageBody("page0", hitsPerPage)
+          else synonymsPageBody("page$page", 3)
+
+        respond(
+          content = content,
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+        )
+      }
+
+    val client =
+      SearchClient(appId = "appId", apiKey = "apiKey", options = ClientOptions(engine = engine))
+
+    val collected = mutableListOf<SynonymHit>()
+    client.use {
+      it.browseSynonyms(
+        indexName = "my-index",
+        searchSynonymsParams = SearchSynonymsParams(),
+        aggregator = { response -> collected += response.hits },
+      )
+    }
+
+    // The helper must request page 0 then page 1 (proving the incremented page is sent), and stop.
+    assertEquals(listOf(0, 1), requestedPages, "browseSynonyms should request consecutive pages 0, 1")
+
+    // Every request must target the synonyms search endpoint (page read from that POST body).
+    assertTrue(
+      requestedPaths.all { it.endsWith("/synonyms/search") },
+      "all requests should hit /synonyms/search, got $requestedPaths",
+    )
+
+    // All hits across both pages are aggregated, with no page re-fetched (no duplicates).
+    assertEquals(1003, collected.size, "aggregated hit count should be 1000 + 3")
+    assertEquals(
+      1003,
+      collected.map { it.objectID }.toSet().size,
+      "aggregated objectIDs should all be distinct (no page re-fetched)",
+    )
+  }
+}

--- a/clients/algoliasearch-client-php/lib/Iterators/RuleIterator.php
+++ b/clients/algoliasearch-client-php/lib/Iterators/RuleIterator.php
@@ -15,7 +15,7 @@ final class RuleIterator extends AbstractAlgoliaIterator
     {
         if (
             is_array($this->response)
-            && $this->key >= count($this->response['hits'])
+            && count($this->response['hits']) < $this->requestOptions['hitsPerPage']
         ) {
             return;
         }

--- a/clients/algoliasearch-client-php/lib/Iterators/SynonymIterator.php
+++ b/clients/algoliasearch-client-php/lib/Iterators/SynonymIterator.php
@@ -15,7 +15,7 @@ final class SynonymIterator extends AbstractAlgoliaIterator
     {
         if (
             is_array($this->response)
-            && $this->key >= count($this->response['hits'])
+            && count($this->response['hits']) < $this->requestOptions['hitsPerPage']
         ) {
             return;
         }

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -501,14 +501,13 @@ public <T> Iterable<T> browseObjects(String indexName, Class<T> innerType) {
  */
 public Iterable<SynonymHit> browseSynonyms(String indexName, SearchSynonymsParams params, RequestOptions requestOptions) {
   final Holder<Integer> currentPage = new Holder<>(0);
-
-  params.setPage(0);
-  params.setHitsPerPage(1000);
+  final int hitsPerPage = 1000;
+  params.setHitsPerPage(hitsPerPage);
 
   return AlgoliaIterableHelper.createIterable(
     () -> {
-      SearchSynonymsResponse response = this.searchSynonyms(indexName, params, requestOptions);
-      currentPage.value = response.getHits().size() < params.getHitsPerPage() ? null : currentPage.value + 1;
+      SearchSynonymsResponse response = this.searchSynonyms(indexName, params.setPage(currentPage.value), requestOptions);
+      currentPage.value = response.getHits().size() < hitsPerPage ? null : currentPage.value + 1;
       return response.getHits().iterator();
     },
     () -> currentPage.value != null
@@ -531,7 +530,7 @@ public Iterable<SynonymHit> browseSynonyms(String indexName, SearchSynonymsParam
  * @param indexName The index in which to perform the request.
  */
 public Iterable<SynonymHit> browseSynonyms(String indexName) {
-  return browseSynonyms(indexName, null, null);
+  return browseSynonyms(indexName, new SearchSynonymsParams(), null);
 }
 
 /**

--- a/tests/output/java/src/test/java/com/algolia/manual/BrowseSynonymsTest.java
+++ b/tests/output/java/src/test/java/com/algolia/manual/BrowseSynonymsTest.java
@@ -1,0 +1,93 @@
+package com.algolia.manual;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.algolia.api.SearchClient;
+import com.algolia.config.ClientOptions;
+import com.algolia.config.HttpRequest;
+import com.algolia.config.RequestOptions;
+import com.algolia.config.Requester;
+import com.algolia.model.search.SearchSynonymsParams;
+import com.algolia.model.search.SearchSynonymsResponse;
+import com.algolia.model.search.SynonymHit;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Regression test for CR-11727: `browseSynonyms` used to keep requesting `page=0` because the
+ * incremented page was never written back to the params, so a full first page made the iterator
+ * loop forever and duplicate hits. This test drives a full page followed by a partial page and
+ * asserts the iterator walks page 0 then page 1 and stops.
+ */
+class BrowseSynonymsTest {
+
+  static final int HITS_PER_PAGE = 1000;
+
+  /**
+   * Requester stub that returns a full page for `page=0` and a partial page afterwards, recording
+   * the `page` sent on each `searchSynonyms` request. No real HTTP is performed.
+   */
+  static class PaginatingRequester implements Requester {
+
+    final List<Integer> pagesRequested = new ArrayList<>();
+
+    private SearchSynonymsResponse handle(HttpRequest httpRequest) {
+      SearchSynonymsParams params = (SearchSynonymsParams) httpRequest.getBody();
+      int page = params.getPage() == null ? 0 : params.getPage();
+      pagesRequested.add(page);
+
+      int count = page == 0 ? HITS_PER_PAGE : 3;
+      List<SynonymHit> hits = new ArrayList<>();
+      for (int i = 0; i < count; i++) {
+        hits.add(new SynonymHit().setObjectID("page" + page + "-hit" + i));
+      }
+
+      return new SearchSynonymsResponse().setHits(hits).setNbHits(HITS_PER_PAGE + 3);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T execute(HttpRequest httpRequest, RequestOptions requestOptions, Class<?> returnType, Class<?> innerType) {
+      return (T) handle(httpRequest);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T execute(HttpRequest httpRequest, RequestOptions requestOptions, TypeReference<?> returnType) {
+      return (T) handle(httpRequest);
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName("browseSynonyms increments the page and terminates (CR-11727)")
+  void browseSynonymsPaginatesAndStops() throws Exception {
+    PaginatingRequester requester = new PaginatingRequester();
+
+    try (
+      SearchClient client = new SearchClient("app-id", "api-key", ClientOptions.builder().setRequester(requester).build())
+    ) {
+      List<SynonymHit> aggregated = new ArrayList<>();
+      for (SynonymHit hit : client.browseSynonyms("my-index", new SearchSynonymsParams())) {
+        aggregated.add(hit);
+        // Fail fast instead of looping forever / OOMing if the page is never advanced.
+        if (aggregated.size() > HITS_PER_PAGE + 100) {
+          fail("browseSynonyms never advanced past page 0 and kept re-fetching the same page (CR-11727)");
+        }
+      }
+
+      assertEquals(List.of(0, 1), requester.pagesRequested, "browseSynonyms must request page 0 then page 1");
+      assertEquals(HITS_PER_PAGE + 3, aggregated.size(), "browseSynonyms must aggregate every hit from both pages exactly once");
+
+      long distinctObjectIDs = aggregated.stream().map(SynonymHit::getObjectID).distinct().count();
+      assertEquals(aggregated.size(), distinctObjectIDs, "browseSynonyms must not return duplicate hits (CR-11727)");
+    }
+  }
+}

--- a/tests/output/java/src/test/java/com/algolia/manual/BrowseSynonymsTest.java
+++ b/tests/output/java/src/test/java/com/algolia/manual/BrowseSynonymsTest.java
@@ -12,6 +12,7 @@ import com.algolia.model.search.SearchSynonymsResponse;
 import com.algolia.model.search.SynonymHit;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,7 @@ class BrowseSynonymsTest {
         }
       }
 
-      assertEquals(List.of(0, 1), requester.pagesRequested, "browseSynonyms must request page 0 then page 1");
+      assertEquals(Arrays.asList(0, 1), requester.pagesRequested, "browseSynonyms must request page 0 then page 1");
       assertEquals(HITS_PER_PAGE + 3, aggregated.size(), "browseSynonyms must aggregate every hit from both pages exactly once");
 
       long distinctObjectIDs = aggregated.stream().map(SynonymHit::getObjectID).distinct().count();

--- a/tests/output/php/src/manual/BrowseSynonymsTest.php
+++ b/tests/output/php/src/manual/BrowseSynonymsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\AlgoliaSearch\Configuration\SearchConfig;
+use Algolia\AlgoliaSearch\Http\HttpClientInterface;
+use Algolia\AlgoliaSearch\Http\Psr7\Response;
+use Algolia\AlgoliaSearch\RequestOptions\RequestOptionsFactory;
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\RetryStrategy\ClusterHosts;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Regression test for the `browseSynonyms` pagination: the page-based iterator must keep paginating
+ * while a page is full and stop on the first non-full page. It previously stopped after the first
+ * full page, silently truncating the results to `hitsPerPage`.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class BrowseSynonymsTest extends TestCase
+{
+    public const HITS_PER_PAGE = 1000;
+
+    public function testBrowseSynonymsPaginatesAndStops(): void
+    {
+        $mockHttp = new class implements HttpClientInterface {
+            /** @var int[] */
+            public array $pagesRequested = [];
+
+            public function sendRequest(RequestInterface $request, $timeout, $connectTimeout)
+            {
+                $body = json_decode((string) $request->getBody(), true) ?: [];
+                $page = $body['page'] ?? 0;
+                $this->pagesRequested[] = $page;
+
+                // Full page for page 0, partial page afterwards, so a correct iterator walks page 0 then page 1.
+                $count = 0 === $page ? BrowseSynonymsTest::HITS_PER_PAGE : 3;
+                $hits = [];
+                for ($i = 0; $i < $count; ++$i) {
+                    $hits[] = ['objectID' => "page{$page}-hit{$i}"];
+                }
+
+                return new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    (string) json_encode(['hits' => $hits, 'nbHits' => BrowseSynonymsTest::HITS_PER_PAGE + 3])
+                );
+            }
+        };
+
+        $config = SearchConfig::create('test-app-id', 'test-api-key')
+            ->setFullHosts(['http://localhost:9999'])
+        ;
+
+        $client = new SearchClient(
+            new ApiWrapper($mockHttp, $config, ClusterHosts::create(['http://localhost:9999']), new RequestOptionsFactory($config)),
+            $config
+        );
+
+        $synonyms = [];
+        foreach ($client->browseSynonyms('my-index') as $synonym) {
+            $synonyms[] = $synonym;
+            // Safety net so a regression can never hang the suite.
+            if (count($synonyms) > self::HITS_PER_PAGE + 100) {
+                $this->fail('browseSynonyms did not terminate');
+            }
+        }
+
+        $this->assertEquals([0, 1], $mockHttp->pagesRequested, 'browseSynonyms must request page 0 then page 1');
+        $this->assertCount(self::HITS_PER_PAGE + 3, $synonyms, 'browseSynonyms must aggregate every hit from both pages');
+
+        $objectIDs = array_map(static fn ($hit) => $hit['objectID'], $synonyms);
+        $this->assertCount(self::HITS_PER_PAGE + 3, array_unique($objectIDs), 'browseSynonyms must not return duplicate or truncated hits');
+    }
+}

--- a/tests/output/scala/src/test/scala/algoliasearch/manual/BrowseSynonymsTest.scala
+++ b/tests/output/scala/src/test/scala/algoliasearch/manual/BrowseSynonymsTest.scala
@@ -1,0 +1,122 @@
+package algoliasearch.manual
+
+import algoliasearch.api.SearchClient
+import algoliasearch.config.ClientOptions
+import algoliasearch.extension.SearchClientExtensions
+import algoliasearch.search.{SearchSynonymsParams, SearchSynonymsResponse, SynonymHit}
+
+import okhttp3.Interceptor.Chain
+import okhttp3.{Interceptor, MediaType, Protocol, Response, ResponseBody}
+import okio.Buffer
+import org.json4s.{JInt, JLong, JObject}
+import org.json4s.native.JsonMethods.parse
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext}
+import scala.jdk.CollectionConverters._
+
+/** Fully offline HTTP stub for the `browseSynonyms` pagination regression test (Jira CR-11727).
+  *
+  * It is installed as an OkHttp application interceptor (same mechanism as the generated `EchoInterceptor`), so the
+  * whole real request path runs -- the params are serialized to a JSON body, this stub short-circuits the network, and
+  * the canned JSON is deserialized back into a `SearchSynonymsResponse` -- without ever touching the network.
+  *
+  * For every `/synonyms/search` call it reads the `page` from the request body, records it, and answers with:
+  *   - page 0    -> a FULL page of 1000 hits ("page0-hit0".."page0-hit999")
+  *   - page >= 1 -> a PARTIAL page of 3 hits ("page1-hit0".."page1-hit2")
+  *
+  * The partial page is the signal that stops pagination, so a correct implementation must request exactly pages 0 then
+  * 1. The Java bug this guards against never wrote the incremented page back into the request, so it re-fetched page 0
+  * forever.
+  */
+private class BrowseSynonymsMockInterceptor extends Interceptor {
+
+  /** Pages, in the order they were requested (FIFO). */
+  val requestedPages: ConcurrentLinkedQueue[Int] = new ConcurrentLinkedQueue[Int]()
+
+  private def hitsArray(prefix: String, count: Int): String =
+    (0 until count)
+      .map(i => s"""{"objectID":"$prefix-hit$i","type":"synonym"}""")
+      .mkString("[", ",", "]")
+
+  override def intercept(chain: Chain): Response = {
+    val request = chain.request()
+
+    val requestBody = Option(request.body) match {
+      case Some(body) =>
+        val buffer = new Buffer()
+        body.writeTo(buffer)
+        buffer.readUtf8()
+      case None => ""
+    }
+
+    val responseJson =
+      if (request.url.encodedPath.endsWith("/synonyms/search")) {
+        val page = parse(requestBody) match {
+          case JObject(fields) =>
+            fields.collectFirst {
+              case ("page", JInt(value))  => value.toInt
+              case ("page", JLong(value)) => value.toInt
+            }.getOrElse(0)
+          case _ => 0
+        }
+        requestedPages.add(page)
+
+        if (page == 0) s"""{"hits":${hitsArray("page0", 1000)},"nbHits":1003}"""
+        else s"""{"hits":${hitsArray("page1", 3)},"nbHits":1003}"""
+      } else {
+        "{}"
+      }
+
+    new Response.Builder()
+      .code(200)
+      .request(request)
+      .protocol(Protocol.HTTP_2)
+      .message("OK")
+      .body(ResponseBody.create(responseJson, MediaType.parse("application/json")))
+      .build()
+  }
+}
+
+class BrowseSynonymsTest extends AnyFunSuite {
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  test("browseSynonyms paginates until a partial page and aggregates every hit") {
+    val mock = new BrowseSynonymsMockInterceptor()
+    val client = SearchClient(
+      appId = "appId",
+      apiKey = "apiKey",
+      clientOptions = ClientOptions
+        .builder()
+        .withRequesterConfig(requester => requester.withInterceptor(mock))
+        .build()
+    )
+
+    val collectedHits = new ConcurrentLinkedQueue[SynonymHit]()
+
+    try {
+      Await.result(
+        client.browseSynonyms(
+          indexName = "my-index",
+          searchSynonymsParams = SearchSynonymsParams(),
+          aggregator = (response: SearchSynonymsResponse) => response.hits.foreach(collectedHits.add)
+        ),
+        Duration.Inf
+      )
+    } finally {
+      client.close()
+    }
+
+    val pages = mock.requestedPages.asScala.toList
+    val objectIDs = collectedHits.asScala.toList.map(_.objectID)
+
+    assert(pages == List(0, 1), s"expected pages Seq(0, 1) but requested $pages")
+    assert(objectIDs.size == 1003, s"expected 1003 aggregated hits but got ${objectIDs.size}")
+    assert(
+      objectIDs.distinct.size == 1003,
+      s"expected 1003 distinct objectIDs but got ${objectIDs.distinct.size}"
+    )
+  }
+}

--- a/tests/output/swift/Tests/manual/BrowseSynonymsTests.swift
+++ b/tests/output/swift/Tests/manual/BrowseSynonymsTests.swift
@@ -1,0 +1,139 @@
+//
+//  BrowseSynonymsTests.swift
+//  AlgoliaSearchClientTests
+//
+//  Regression guard for the `browseSynonyms` pagination contract (Jira CR-11727).
+//
+//  The Java `browseSynonyms` helper had a bug where the incremented page was never
+//  written back to the request params, so it kept re-fetching page 0 forever
+//  (infinite loop / OOM). Swift's implementation is already correct; this test
+//  mocks the HTTP transport (no network) and asserts that the helper:
+//    - requests page 0 (full page) then page 1 (partial page), then stops,
+//    - aggregates every hit from both pages (1000 + 3 == 1003),
+//    - never fetches the same page twice (1003 distinct objectIDs).
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+import XCTest
+
+import Utils
+
+@testable import AlgoliaCore
+@testable import AlgoliaSearch
+
+private struct BrowseSynonymsMockError: Error {
+    let message: String
+}
+
+/// Accumulates the hits handed to the `browseSynonyms` aggregator closure.
+///
+/// A reference type is used so the escaping aggregator mutates shared state
+/// without capturing a mutable local `var`.
+private final class HitCollector {
+    private(set) var hits: [SynonymHit] = []
+
+    func add(_ newHits: [SynonymHit]) {
+        self.hits.append(contentsOf: newHits)
+    }
+}
+
+/// A mock `RequestBuilder` standing in for the real HTTP transport.
+///
+/// For every `/1/indexes/{indexName}/synonyms/search` request it reads the `page`
+/// from the request body, records it, and returns:
+///   - page 0     -> a FULL page of 1000 hits (`page0-hit0`...`page0-hit999`),
+///   - page >= 1  -> a PARTIAL page of 3 hits (`page1-hit0`...`page1-hit2`).
+///
+/// A partial page (fewer than `hitsPerPage == 1000` hits) is exactly the
+/// condition `browseSynonyms` uses to stop paginating.
+private final class BrowseSynonymsMockRequestBuilder: RequestBuilder {
+    private(set) var requestedPages: [Int] = []
+
+    private let fullPageSize = 1000
+    private let partialPageSize = 3
+    // Convert a "stuck on page 0" pagination regression into a clean failure
+    // instead of an infinite loop that would hang the test runner.
+    private let maxRequests = 100
+
+    init() {}
+
+    func execute<T: Decodable>(urlRequest: URLRequest, timeout _: TimeInterval) async throws -> Response<T> {
+        let page = Self.readPage(from: urlRequest.httpBody)
+        self.requestedPages.append(page)
+
+        guard self.requestedPages.count <= self.maxRequests else {
+            throw BrowseSynonymsMockError(
+                message: "browseSynonyms issued \(self.requestedPages.count) requests; pagination is likely " +
+                    "stuck re-fetching the same page (pages so far: \(self.requestedPages))."
+            )
+        }
+
+        let hitsCount = page == 0 ? self.fullPageSize : self.partialPageSize
+        let responseData = Self.makeSynonymsResponseData(page: page, hitsCount: hitsCount)
+
+        guard let url = urlRequest.url,
+              let httpResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+        else {
+            throw BrowseSynonymsMockError(message: "Unable to build a mock HTTPURLResponse")
+        }
+
+        switch CodableHelper.decode(T.self, from: responseData) {
+        case let .success(body):
+            return Response(response: httpResponse, body: body, bodyData: responseData)
+        case let .failure(error):
+            throw BrowseSynonymsMockError(message: "Unable to decode mock synonyms response: \(error)")
+        }
+    }
+
+    private static func readPage(from body: Data?) -> Int {
+        guard let body,
+              let object = try? JSONSerialization.jsonObject(with: body),
+              let json = object as? [String: Any],
+              let page = json["page"] as? Int
+        else {
+            return 0
+        }
+
+        return page
+    }
+
+    private static func makeSynonymsResponseData(page: Int, hitsCount: Int) -> Data {
+        let hits = (0 ..< hitsCount)
+            .map { "{\"objectID\":\"page\(page)-hit\($0)\",\"type\":\"synonym\"}" }
+            .joined(separator: ",")
+
+        return Data("{\"hits\":[\(hits)],\"nbHits\":1003}".utf8)
+    }
+}
+
+final class BrowseSynonymsManualTests: XCTestCase {
+    func testBrowseSynonymsPaginatesUntilPartialPage() async throws {
+        let configuration = try SearchClientConfiguration(appID: "my-app-id", apiKey: "my-api-key")
+        let requestBuilder = BrowseSynonymsMockRequestBuilder()
+        let transporter = Transporter(configuration: configuration, requestBuilder: requestBuilder)
+        let client = SearchClient(configuration: configuration, transporter: transporter)
+
+        let collector = HitCollector()
+
+        try await client.browseSynonyms(
+            indexName: "my-index",
+            searchSynonymsParams: SearchSynonymsParams(),
+            aggregator: { response in
+                collector.add(response.hits)
+            }
+        )
+
+        // The helper must request page 0 (full), then page 1 (partial), then stop.
+        XCTAssertEqual(requestBuilder.requestedPages, [0, 1])
+
+        // Every hit from both pages must be aggregated: 1000 + 3 == 1003.
+        XCTAssertEqual(collector.hits.count, 1003)
+
+        // No page may be fetched twice, so every aggregated objectID is distinct.
+        let distinctObjectIDs = Set(collector.hits.map(\.objectID))
+        XCTAssertEqual(distinctObjectIDs.count, 1003)
+    }
+}


### PR DESCRIPTION
## What & why

🎟 [CR-11727](https://algolia.atlassian.net/browse/CR-11727)

`SearchClient.browseSynonyms` (Java) incremented an internal page counter but never wrote it back to the request params, so every call re-requested `page=0`. With a full first page (≥1000 synonyms) the stop condition never triggered — the iterator looped and returned duplicate hits until it ran out of memory. Fixed to write the page back before each `searchSynonyms` call (mirrors `browseRules`); the no-arg overload no longer passes `null`.

While auditing the other clients I found a **related bug in PHP**: `SynonymIterator`/`RuleIterator` stopped after the first *full* page (the guard compared the cumulative key to the current page's hit count), silently truncating results to `hitsPerPage`. They now stop only on a non-full page, like every other client. JavaScript, Kotlin, Scala and Swift were already correct.

## Tests

Added a `browseSynonyms` pagination regression test in all six implementing languages (Java, PHP, JavaScript, Kotlin, Scala, Swift): serve a full page 0 then a partial page 1, and assert the client requests pages `0 → 1`, aggregates every hit exactly once, and terminates. All pass locally.

## Notes

- Only the source fix + hand-written tests are included — CI regenerates the client code.
- The Kotlin test lives in `jvmTest` (the client's common test set has no coroutine runner).

[CR-11727]: https://algolia.atlassian.net/browse/CR-11727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ