### PR TITLE
chore(scripts): authenticate to ghcr.io during docker setup

### DIFF
--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -1,5 +1,20 @@
 #! /bin/bash
 
+# Authenticate to the GitHub Container Registry so private images can be pulled.
+# Skips when already logged in, and degrades gracefully when gh is missing or unauthenticated.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Skipping ghcr.io login: gh (GitHub CLI) is not installed."
+else
+  docker_config="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+  if [ -f "$docker_config" ] && jq -e '(.auths // {}) | has("ghcr.io")' "$docker_config" >/dev/null 2>&1; then
+    echo "Already logged in to ghcr.io, skipping docker login."
+  elif ! gh auth status >/dev/null 2>&1; then
+    echo "Skipping ghcr.io login: not authenticated with gh (run 'gh auth login')."
+  else
+    gh auth token | docker login ghcr.io -u "$(gh api user --jq .login)" --password-stdin
+  fi
+fi
+
 export NODE_VERSION=$(cat .nvmrc)
 
 while read line; do


### PR DESCRIPTION
## Summary

- Log in to the GitHub Container Registry (`ghcr.io`) at the start of `yarn docker:setup` (`scripts/docker/setup.sh`), using the `gh` CLI token and the authenticated user's login (`gh api user --jq .login`), so private base images can be pulled.
- Skips the login when Docker is already authenticated to `ghcr.io` (checks `.auths` in Docker's `config.json`, honoring `DOCKER_CONFIG`).
- Degrades gracefully with an informative message when `gh` is not installed or the user is not authenticated on `gh`, instead of aborting setup.

## Test plan

- [ ] `gh` not installed -> prints skip message, setup continues.
- [ ] `gh` installed but not authenticated -> prints skip message, setup continues.
- [ ] Already logged in to `ghcr.io` -> prints "already logged in", no re-login.
- [ ] Authenticated and not logged in -> performs `docker login ghcr.io`.