### PR TITLE
fix(dart): dio exhaustive switch handling

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
+++ b/clients/algoliasearch-client-dart/packages/client_core/lib/src/transport/dio/dio_requester.dart
@@ -76,10 +76,7 @@ class DioRequester implements Requester {
             e.response?.statusCode ?? 0,
             e.error ?? e.response,
           );
-        case DioExceptionType.badCertificate:
-        case DioExceptionType.cancel:
-        case DioExceptionType.connectionError:
-        case DioExceptionType.unknown:
+        default:
           throw AlgoliaIOException(e);
       }
     }


### PR DESCRIPTION
dio 5.10.0 added `DioExceptionType.transformTimeout`, which made the `switch (e.type)` in hand-written `client_core/.../dio_requester.dart` non-exhaustive → a fatal `dart analyze` error. The dart client gitignores `pubspec.lock`, so CI resolves `dio ^5.x` fresh and picks it up.

Replaced the final explicit case group with a `default` so unclassified (and future) `DioExceptionType` values map to `AlgoliaIOException`, keeping the published client resilient to `dio` bumps. Existing behavior unchanged.

Fixes algolia/algoliasearch-client-dart#23