### PR TITLE
feat(go): add Values method for enum class

### DIFF
--- a/templates/go/model_enum.mustache
+++ b/templates/go/model_enum.mustache
@@ -63,3 +63,8 @@ func (v {{{classname}}}) IsValid() bool {
 func (v {{{classname}}}) Ptr() *{{{classname}}} {
 	return &v
 }
+
+// Values returns the list of allowed values of {{{classname}}}.
+func (v {{{classname}}}) Values() []{{{classname}}} {
+	return Allowed{{{classname}}}EnumValues
+}


### PR DESCRIPTION
## 🧭 What and Why

Was looking at one of the [open PR](https://github.com/algolia/cli/pull/249/changes#diff-8dd1578447409ae9ff75c315fbbe5bfa1df33cb93075093a2ee90af5e47ee688R146) on the CLI, and noticed we couldn't use reflexion on the `enum` fields, leaving the user guessing correct values instead of using a Select.

### Changes included:

- Add a `Values` method for enum fields on the Go client

## 🧪 Test

👀 