### PR TITLE
fix(dart): add missing READMEs for ingestion and agent studio packages

### DIFF
--- a/clients/algoliasearch-client-dart/packages/client_agent_studio/README.md
+++ b/clients/algoliasearch-client-dart/packages/client_agent_studio/README.md
@@ -1,0 +1,40 @@
+<!-- centered logo -->
+<p align="center">
+  <a href="https://www.algolia.com">
+    <img alt="Algolia for Dart" src="https://raw.githubusercontent.com/algolia/algoliasearch-client-common/master/banners/dart.png" >
+  </a>
+</p>
+
+<!-- centered badges -->
+<p align="center">
+  <a href="https://pub.dartlang.org/packages/algolia_client_agent_studio"><img src="https://img.shields.io/pub/v/algolia_client_agent_studio.svg" alt="Latest version"></a>
+  <a href="https://pub.dev/packages/algolia_client_agent_studio/publisher"><img src="https://img.shields.io/pub/publisher/algolia_client_agent_studio.svg" alt="Publisher"></a>
+</p>
+
+<h3 align="center">
+  <strong>Algolia Agent Studio API Client</strong>
+</h3>
+
+<p align="center">
+  The Algolia Agent Studio API lets you build and operate generative AI agents that use Algolia data, tools, and your chosen LLM provider. Use it to create, configure, publish, and update agents, then generate chat completions grounded in live data from your Algolia indices.
+</p>
+
+## 💡 Installation
+
+Add Algolia Agent Studio API Client as a dependency in your project directly from pub.dev:
+
+#### For Dart projects:
+
+```shell
+dart pub add algolia_client_agent_studio
+```
+
+#### For Flutter projects:
+
+```shell
+flutter pub add algolia_client_agent_studio
+```
+
+## License
+
+Algolia API Client is an open-sourced software licensed under the [MIT license](LICENSE).

--- a/clients/algoliasearch-client-dart/packages/client_ingestion/README.md
+++ b/clients/algoliasearch-client-dart/packages/client_ingestion/README.md
@@ -1,0 +1,40 @@
+<!-- centered logo -->
+<p align="center">
+  <a href="https://www.algolia.com">
+    <img alt="Algolia for Dart" src="https://raw.githubusercontent.com/algolia/algoliasearch-client-common/master/banners/dart.png" >
+  </a>
+</p>
+
+<!-- centered badges -->
+<p align="center">
+  <a href="https://pub.dartlang.org/packages/algolia_client_ingestion"><img src="https://img.shields.io/pub/v/algolia_client_ingestion.svg" alt="Latest version"></a>
+  <a href="https://pub.dev/packages/algolia_client_ingestion/publisher"><img src="https://img.shields.io/pub/publisher/algolia_client_ingestion.svg" alt="Publisher"></a>
+</p>
+
+<h3 align="center">
+  <strong>Algolia Ingestion API Client</strong>
+</h3>
+
+<p align="center">
+  The Algolia Ingestion API lets you connect third-party services and platforms with Algolia and schedule tasks to ingest your data. It powers the no-code data connectors and lets you manage sources, destinations, tasks, and transformations for keeping your indices up to date.
+</p>
+
+## 💡 Installation
+
+Add Algolia Ingestion API Client as a dependency in your project directly from pub.dev:
+
+#### For Dart projects:
+
+```shell
+dart pub add algolia_client_ingestion
+```
+
+#### For Flutter projects:
+
+```shell
+flutter pub add algolia_client_ingestion
+```
+
+## License
+
+Algolia API Client is an open-sourced software licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
## Summary

- Every Dart release since 1.50.0 has failed to publish: `dart pub publish --dry-run` exits with code 65 on `packages/client_ingestion` and `packages/client_agent_studio` because they have no `README.md` (see [1.51.3 run](https://github.com/algolia/algoliasearch-client-dart/actions/runs/28928408175)). The failed dry runs also leave `client_search` and `algoliasearch` unpublished since they depend on the first publish wave.
- Dart package READMEs are hand-written (no README template exists for Dart, and `generation.config.mjs` treats the Dart client as hand-written by default), so this adds the two missing files here in the monorepo, mirroring the structure of the existing package READMEs (banner, pub.dev badges, description from the API spec, install instructions, license).

Note: `client_abtesting_v3` and `client_realtime_personalization` also lack READMEs but are not in the publish matrix of `release.yml`, so they don't block releases.

## Test plan

- [ ] CI is green
- [ ] Next Dart release: `Publish - dry run` passes for `client_ingestion` and `client_agent_studio`, and the `client_search` / `algoliasearch` waves run