### PR TITLE
docs(specs): document the Correlation-ID and Request-ID headers

### DIFF
--- a/specs/search/spec.yml
+++ b/specs/search/spec.yml
@@ -71,6 +71,18 @@ info:
     Successful responses return `2xx` statuses. Client errors return `4xx` statuses. Server errors return `5xx` statuses.
     Error responses have a `message` property with more information.
 
+    ## Request identifiers
+
+    Every response includes a `Correlation-ID` header that identifies the request in Algolia's logs.
+    When contacting the Algolia support team about a specific request, include this identifier in your ticket.
+
+    To tag requests with your own identifier, send a `Request-ID` header with exactly 11 alphanumeric characters.
+    Clusters that support it embed the identifier at the end of the `Correlation-ID`,
+    so all attempts of a retried operation can be found by searching for those characters.
+    Headers that don't match the expected format are ignored.
+
+    Don't use the `Correlation-ID` as a unique key: retried requests may receive the same identifier.
+
     ## Version
 
     The current version of the Search API is version 1, indicated by the `/1/` in each endpoint's URL.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: SRCH-9256

Every Search API response carries a `Correlation-ID` header, and callers can tag requests with a `Request-ID` header, but neither is documented. Customers cannot know they should quote the `Correlation-ID` in support tickets, which is the main way the support team traces a specific request through Algolia's logs.

### Changes included:

- A "Request identifiers" section in the Search API overview (`specs/search/spec.yml` `info.description`): the `Correlation-ID` response header and its role in support tickets, the optional `Request-ID` request header and how retries of the same operation can be found through it, and a warning against using the `Correlation-ID` as a unique key.

Open wording question for docs review: `Request-ID` embedding is live on Algolia's cloud-native clusters and inert elsewhere, hence the "clusters that support it" phrasing. Happy to adjust if there is a house style for capability differences between infrastructures.

## 🧪 Test

Documentation-only change to the spec description; no generated code is affected.
