### PR TITLE
snippets: annotate helper response types in doc code samples

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/Snippet.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/Snippet.java
@@ -43,6 +43,7 @@ public class Snippet {
     // for dynamic snippets, we need to reset the context because the order of generation is random
     context.put("method", method);
     context.put("returnType", null);
+    context.put("listReturnType", null);
     context.put("requestOptions", null);
     context.put("parameters", null);
     context.put("parametersWithDataType", null);
@@ -52,13 +53,30 @@ public class Snippet {
       context.put("returnType", camelize(ope.returnType));
     }
 
+    boolean isHelper = (boolean) ope.vendorExtensions.getOrDefault("x-helper", false);
+
+    // Expose the item type of list-returning helpers so snippet templates can annotate the
+    // response variable, making the return shape explicit in documentation code samples.
+    // WatchResponse is excluded: the hand-written `*WithTransformation` helpers return the
+    // ingestion client's WatchResponse model (usually imported under an alias), which the
+    // snippet's own client models would shadow with a nominally different type.
+    if (
+      isHelper &&
+      ope.returnBaseType != null &&
+      ope.returnContainer != null &&
+      (ope.returnContainer.equalsIgnoreCase("array") || ope.returnContainer.equalsIgnoreCase("list")) &&
+      !camelize(ope.returnBaseType).equals("WatchResponse")
+    ) {
+      context.put("listReturnType", camelize(ope.returnBaseType));
+    }
+
     try {
       context.put("isGeneric", (boolean) ope.vendorExtensions.getOrDefault("x-is-generic", false));
       context.put("isReturnGeneric", (boolean) ope.vendorExtensions.getOrDefault("x-return-is-generic", false));
       context.put("isCustomRequest", Helpers.CUSTOM_METHODS.contains(ope.operationIdOriginal));
       context.put("isAsyncMethod", (boolean) ope.vendorExtensions.getOrDefault("x-asynchronous-helper", true));
       context.put("hasParams", ope.getHasParams());
-      context.put("isHelper", (boolean) ope.vendorExtensions.getOrDefault("x-helper", false));
+      context.put("isHelper", isHelper);
       context.put("isStreaming", (boolean) ope.vendorExtensions.getOrDefault("x-streaming", false));
       context.put("hasRequestOptions", requestOptions != null);
 

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/SnippetsGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/SnippetsGenerator.java
@@ -100,6 +100,8 @@ public class SnippetsGenerator extends TestsGenerator {
     }
 
     List<Object> blocks = new ArrayList<>();
+    // model names of list-returning helpers, so import templates can bring the types in scope
+    Set<String> listReturnTypes = new TreeSet<>();
     ParametersWithDataType paramsType = new ParametersWithDataType(models, language, client, true);
 
     for (Map.Entry<String, CodegenOperation> entry : operations.entrySet()) {
@@ -126,6 +128,9 @@ public class SnippetsGenerator extends TestsGenerator {
         test.put("testIndex", i == 0 ? "" : i);
         snippet.addMethodCall(test, paramsType, ope);
         addRequestOptions(paramsType, snippet.requestOptions, test);
+        if (test.get("listReturnType") != null) {
+          listReturnTypes.add((String) test.get("listReturnType"));
+        }
         tests.add(test);
       }
       Map<String, Object> testObj = new HashMap<>();
@@ -133,5 +138,6 @@ public class SnippetsGenerator extends TestsGenerator {
       blocks.add(testObj);
     }
     bundle.put("blocksRequests", blocks);
+    bundle.put("listReturnTypes", new ArrayList<>(listReturnTypes));
   }
 }

--- a/templates/csharp/snippets/method.mustache
+++ b/templates/csharp/snippets/method.mustache
@@ -30,7 +30,7 @@ public class Snippet{{client}}
     {{> snippets/init}}
 
     // Call the API
-     {{#hasResponse}}var response =  {{/hasResponse}}{{> tests/method}};
+     {{#hasResponse}}{{#listReturnType}}List<{{.}}>{{/listReturnType}}{{^listReturnType}}var{{/listReturnType}} response =  {{/hasResponse}}{{> tests/method}};
     // >LOG
     {{#hasResponse}}
     // print the response

--- a/templates/dart/snippets/method.mustache
+++ b/templates/dart/snippets/method.mustache
@@ -15,7 +15,7 @@ void snippetFor{{method}}{{testIndex}}() async {
   {{> snippets/init}}
   
   // Call the API
-  {{#hasResponse}}final response = {{/hasResponse}}{{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}(
+  {{#hasResponse}}final {{#listReturnType}}List<{{.}}> {{/listReturnType}}response = {{/hasResponse}}{{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}(
     {{#parametersWithDataType}}
     {{> tests/request_param}}
     {{/parametersWithDataType}}

--- a/templates/go/snippets/method.mustache
+++ b/templates/go/snippets/method.mustache
@@ -24,6 +24,10 @@ func SnippetFor{{#lambda.titlecase}}{{method}}{{/lambda.titlecase}}Of{{#lambda.p
       // handle the eventual error
       panic(err)
     }
+    {{#listReturnType}}
+
+    // response is a slice of {{clientImport}}.{{.}}
+    {{/listReturnType}}
     
     // >LOG
     {{#hasResponse}}

--- a/templates/java/snippets/method.mustache
+++ b/templates/java/snippets/method.mustache
@@ -18,7 +18,7 @@ class Snippet{{client}} {
     {{> snippets/init}}
 
     // Call the API
-    {{#hasResponse}}{{{returnType}}} response ={{/hasResponse}}{{> tests/method}};
+    {{#hasResponse}}{{#listReturnType}}List<{{.}}>{{/listReturnType}}{{^listReturnType}}{{{returnType}}}{{/listReturnType}} response ={{/hasResponse}}{{> tests/method}};
     // >LOG
     {{#hasResponse}}
     // print the response

--- a/templates/javascript/snippets/import.mustache
+++ b/templates/javascript/snippets/import.mustache
@@ -1,1 +1,1 @@
-import { {{clientName}} } from '{{{importPackage}}}';
+import { {{clientName}}{{#listReturnTypes}}, type {{.}}{{/listReturnTypes}} } from '{{{importPackage}}}';

--- a/templates/javascript/snippets/method.mustache
+++ b/templates/javascript/snippets/method.mustache
@@ -20,7 +20,7 @@ export {{#isAsyncMethod}}async{{/isAsyncMethod}} function snippetFor{{#lambda.pa
 
   // Call the API
   {{^isStreaming}}
-  {{#hasResponse}}const response = {{/hasResponse}}{{> tests/method}};
+  {{#hasResponse}}const response{{#listReturnType}}: {{.}}[]{{/listReturnType}} = {{/hasResponse}}{{> tests/method}};
 
   // >LOG
   {{#hasResponse}}

--- a/templates/kotlin/snippets/method.mustache
+++ b/templates/kotlin/snippets/method.mustache
@@ -17,7 +17,7 @@ class Snippet{{client}} {
       {{> snippets/init}}
 
       // Call the API
-      {{#hasResponse}}var response = {{/hasResponse}}client.{{> tests/method}}
+      {{#hasResponse}}var response{{#listReturnType}}: List<{{.}}>{{/listReturnType}} = {{/hasResponse}}client.{{> tests/method}}
       
       // >LOG
       {{#hasResponse}}

--- a/templates/php/snippets/import.mustache
+++ b/templates/php/snippets/import.mustache
@@ -1,1 +1,4 @@
 use Algolia\AlgoliaSearch\Api\{{client}};
+{{#listReturnTypes}}
+use Algolia\AlgoliaSearch\Model\{{clientPrefix}}\{{.}};
+{{/listReturnTypes}}

--- a/templates/php/snippets/method.mustache
+++ b/templates/php/snippets/method.mustache
@@ -24,6 +24,9 @@ class Snippet{{client}}
         {{> snippets/init}}
 
         // Call the API
+        {{#listReturnType}}
+        /** @var array<{{.}}> $response */
+        {{/listReturnType}}
         {{#hasResponse}}$response = {{/hasResponse}}{{> tests/method}};
 
         // >LOG

--- a/templates/python/snippets/import.mustache
+++ b/templates/python/snippets/import.mustache
@@ -1,3 +1,6 @@
 from algoliasearch.{{{import}}}.client import {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}
 from algoliasearch.{{{import}}}.client import {{#lambda.pascalcase}}{{{client}}}Sync{{/lambda.pascalcase}}
+{{#listReturnTypes}}
+from algoliasearch.{{{import}}}.models import {{.}}
+{{/listReturnTypes}}
 from json import loads

--- a/templates/python/snippets/method.mustache
+++ b/templates/python/snippets/method.mustache
@@ -18,7 +18,7 @@ def snippet_for_{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{testIndex}
 
     # Call the API 
     {{^isStreaming}}
-    {{#hasResponse}}response = {{/hasResponse}}client.{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> tests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
+    {{#hasResponse}}response{{#listReturnType}}: list[{{.}}]{{/listReturnType}} = {{/hasResponse}}client.{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> tests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})
 
     # >LOG
     {{#hasResponse}}

--- a/templates/ruby/snippets/method.mustache
+++ b/templates/ruby/snippets/method.mustache
@@ -15,6 +15,9 @@ def snippet_for_{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}{{testIndex}
 
   # Call the API
   {{#hasResponse}}response = {{/hasResponse}}{{> tests/method}}
+  {{#listReturnType}}
+  # response is an array of {{.}} objects
+  {{/listReturnType}}
 
   # >LOG
   {{#hasResponse}}

--- a/templates/scala/snippets/method.mustache
+++ b/templates/scala/snippets/method.mustache
@@ -28,7 +28,7 @@ class Snippet{{client}} {
     {{> snippets/init}}
 
     // Call the API
-    {{#hasResponse}}val response = {{/hasResponse}}{{#isAsyncMethod}}Await.result(
+    {{#hasResponse}}val response{{#listReturnType}}: Seq[{{.}}]{{/listReturnType}} = {{/hasResponse}}{{#isAsyncMethod}}Await.result(
       {{/isAsyncMethod}}{{> tests/method}}{{#isAsyncMethod}},
       Duration(100, "sec")
     )

--- a/templates/swift/snippets/method.mustache
+++ b/templates/swift/snippets/method.mustache
@@ -17,7 +17,7 @@ final class {{client}}Snippet {
     {{> snippets/init}}
 
     // Call the API
-    {{#hasResponse}}let response{{#isGeneric}}: {{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{/isGeneric}}{{#isReturnGeneric}}: [String: AnyCodable]{{/isReturnGeneric}} = {{/hasResponse}}try {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}({{#hasParams}}{{#parametersWithDataType}}{{> tests/generateParams }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}{{/hasParams}}{{#hasRequestOptions}}, requestOptions: RequestOptions({{#requestOptions.headers}}
+    {{#hasResponse}}let response{{#isGeneric}}: {{#lambda.prefix}}{{{returnType}}}{{/lambda.prefix}}<{{#lambda.prefix}}Hit{{/lambda.prefix}}>{{/isGeneric}}{{#isReturnGeneric}}: [String: AnyCodable]{{/isReturnGeneric}}{{#listReturnType}}: [{{#lambda.prefix}}{{.}}{{/lambda.prefix}}]{{/listReturnType}} = {{/hasResponse}}try {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{method}}({{#hasParams}}{{#parametersWithDataType}}{{> tests/generateParams }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}{{/hasParams}}{{#hasRequestOptions}}, requestOptions: RequestOptions({{#requestOptions.headers}}
       headers: [{{#parametersWithDataType}}"{{key}}": {{> tests/paramValue }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}]{{/requestOptions.headers}}
       {{#requestOptions.headers}}{{#requestOptions.queryParameters}},{{/requestOptions.queryParameters}}{{/requestOptions.headers}}{{#requestOptions.queryParameters}}
       queryParameters: [{{#parametersWithDataType}}"{{key}}": {{> tests/paramValue }}{{^-last}}, {{/-last}}{{/parametersWithDataType}}]{{/requestOptions.queryParameters}}


### PR DESCRIPTION
## 🧭 What

Documentation code snippets for list-returning helpers (`saveObjects`, `deleteObjects`, `partialUpdateObjects`, `chunkedBatch`) now carry an explicit response type:

- **Typed annotation** where the language supports it:
  - JavaScript `const response: BatchResponse[] = ...` (+ `import type`)
  - Python `response: list[BatchResponse] = ...` (+ model import, pyright-checked)
  - Java `List<BatchResponse> response = ...` (also fixes the raw `List` previously rendered — the item type was lost)
  - C# `List<BatchResponse> response = ...` (instead of `var`)
  - Kotlin `: List<BatchResponse>`, Scala `: Seq[BatchResponse]`, Swift `: [BatchResponse]`, Dart `List<BatchResponse>`
  - PHP `/** @var array<BatchResponse> $response */` (+ model `use`)
- **Short comment** for languages without inline annotations:
  - Go `// response is a slice of search.BatchResponse`
  - Ruby `# response is an array of BatchResponse objects`

The annotation sits between the method call and the `>LOG` marker, so it flows into `*-snippets.json` and the docs "Usage" blocks (as well as the MCP snippets) with no changes needed in docs-new.

## 🧪 Why

See [this Slack thread](https://algolia-grid.enterprise.slack.com/archives/C0D3A9E82/p1783441525416929): the current SDK docs never show the return shape of helpers, while the legacy v1 docs documented the old single-object `{ taskID, objectIDs }` response. LLMs (and humans) reading the docs therefore assume `response.taskID` exists — but the v2 helpers return an **array** of batch responses. Making the type explicit in every code sample counters that.

## 📝 Notes

- Mechanism: `Snippet.java` exposes `listReturnType` (item type of list-returning `x-helper` operations) + `SnippetsGenerator` collects the types for import templates. Any future list-returning helper picks this up automatically.
- The `*WithTransformation` helpers are deliberately **not** annotated: the hand-written client helpers return the ingestion client's `WatchResponse` under an alias, which is nominally different from the per-client generated `WatchResponse` model (pyright flags the mismatch). Annotating those needs per-language aliasing and can be a follow-up.
- Generated `docs/snippets/**` outputs are not part of this PR; CI regenerates them.