### PR TITLE
fix(specs): add facetFilters back to recommend fallbackParameters

### DIFF
--- a/specs/recommend/common/schemas/QueryParameters.yml
+++ b/specs/recommend/common/schemas/QueryParameters.yml
@@ -17,6 +17,10 @@ fallbackParams:
     - $ref: '#/baseRecommendSearchParams'
     - $ref: '../../../common/schemas/SearchParams.yml#/searchParamsQuery'
     - $ref: './IndexSettings.yml#/recommendIndexSettings'
+    - type: object
+      properties:
+        facetFilters:
+          $ref: '../../../common/schemas/SearchParams.yml#/baseSearchParamsWithoutQuery/properties/facetFilters'
 
 baseRecommendSearchParams:
   type: object

--- a/tests/CTS/requests/recommend/getRecommendations.json
+++ b/tests/CTS/requests/recommend/getRecommendations.json
@@ -147,6 +147,9 @@
             "query": "myQuery",
             "optionalFilters": [
               "brand:samsung"
+            ],
+            "facetFilters": [
+              "brand:apple"
             ]
           }
         }
@@ -173,6 +176,9 @@
               "query": "myQuery",
               "optionalFilters": [
                 "brand:samsung"
+              ],
+              "facetFilters": [
+                "brand:apple"
               ]
             }
           }


### PR DESCRIPTION
## 🧭 What and Why

Fixes #6725

#6604 dropped `facetFilters` from both `queryParameters` and `fallbackParameters` on Recommend. Dropping it from `queryParameters` was right, since the API overrides it there. But `facetFilters` is a supported `fallbackParameters` value, and the [fallback docs](https://www.algolia.com/doc/guides/algolia-recommend/how-to/set-up#show-fallback-recommendations) tell you to use it. It shouldn't have left the fallback schema.

This adds it back to `fallbackParams` only. I put it on an inline object the same way #6604 kept `enableRules`, so it lands on the fallback schema without leaking back into `queryParameters` (both share `baseRecommendSearchParams`).

The three other params #6604 removed stay removed: `ranking`, `enableABTest`, and `enableRules` (from fallback). The API ignores those and applies its own values, so listing them was misleading. `numericFilters`, the other documented fallback param, was never touched.

### Changes included:

- Add `facetFilters` to `fallbackParams` (inline, not on the shared base).
- Add `facetFilters` to the `getRecommendations` "all parameters" CTS test, under `fallbackParameters`.

## 🧪 Test

`yarn cli build specs recommend` passes lint and validation. Checked the bundled output: `facetFilters` shows up under `fallbackParams` and stays absent from `recommendSearchParams`.