### PR TITLE
feat(java): add async batch indexing helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,7 @@ pubspec.lock
 
 swiftformat
 
+# agent working files
+.agents/plans/
+
 foo

--- a/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/ApiClient.java
+++ b/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/ApiClient.java
@@ -99,6 +99,16 @@ public abstract class ApiClient implements Closeable {
   }
 
   /**
+   * Returns the client's executor for asynchronous work.
+   *
+   * <p>Intended for generated helper code that schedules CompletableFuture continuations on the
+   * same executor used by {@link #executeAsync}.
+   */
+  protected ExecutorService getExecutor() {
+    return executor;
+  }
+
+  /**
    * Executes an HTTP request asynchronously and returns a {@link CompletableFuture} of the response
    * deserialized into a specified type.
    */

--- a/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/utils/ChunkedHelperOptions.java
+++ b/clients/algoliasearch-client-java/algoliasearch/src/main/java/com/algolia/utils/ChunkedHelperOptions.java
@@ -7,6 +7,7 @@ public class ChunkedHelperOptions {
   public static final int DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES = 800;
 
   private int maxRetries = TaskUtils.DEFAULT_MAX_RETRIES;
+  private int maxConcurrency = 1;
 
   /**
    * Returns the maximum number of retries for polling task completion.
@@ -28,6 +29,40 @@ public class ChunkedHelperOptions {
       throw new IllegalArgumentException("`maxRetries` must be greater than 0");
     }
     this.maxRetries = maxRetries;
+    return this;
+  }
+
+  /**
+   * Returns the maximum number of batch chunks in flight concurrently.
+   *
+   * @return the maximum concurrency.
+   */
+  public int getMaxConcurrency() {
+    return maxConcurrency;
+  }
+
+  /**
+   * Sets the maximum number of batch chunks in flight concurrently for the chunked batch helpers.
+   * Defaults to 1 (sequential, exact v4 semantics).
+   *
+   * <p>Honored by {@code chunkedBatch} / {@code saveObjects} / {@code partialUpdateObjects} /
+   * {@code deleteObjects} (both synchronous and {@code *Async} variants), and by {@code
+   * replaceAllObjects}' batch phase (it passes the caller's chunked options through to {@code
+   * chunkedBatch}). Ignored by {@code chunkedPush} and the {@code *WithTransformation} helpers.
+   *
+   * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
+   * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails
+   * the operation while sibling in-flight chunks still execute.
+   *
+   * @param maxConcurrency must be greater than 0; values less than 1 throw {@link
+   *     IllegalArgumentException}.
+   * @return this instance for chaining.
+   */
+  public ChunkedHelperOptions setMaxConcurrency(int maxConcurrency) {
+    if (maxConcurrency < 1) {
+      throw new IllegalArgumentException("`maxConcurrency` must be greater than 0");
+    }
+    this.maxConcurrency = maxConcurrency;
     return this;
   }
 }

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -773,9 +773,8 @@ public <T> List<BatchResponse> chunkedBatch(
  * Helper: Chunks the given `objects` list in subset of 1000 elements max in order to make it fit
  * in `batch` requests.
  *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
+ * <p>{@code chunkedOptions.maxConcurrency} is honored; see
+ * {@link ChunkedHelperOptions#setMaxConcurrency(int)}.
  *
  * @summary Helper: Chunks the given `objects` list in subset of 1000 elements max in order to
  *     make it fit in `batch` requests.
@@ -804,7 +803,7 @@ public <T> List<BatchResponse> chunkedBatch(
 ) {
   int maxRetries = chunkedOptions != null ? chunkedOptions.getMaxRetries() : TaskUtils.DEFAULT_MAX_RETRIES;
   List<BatchResponse> responses = LaunderThrowable.await(
-    chunkedBatchAsyncInternal(indexName, objects, action, batchSize, requestOptions, chunkedOptions)
+    chunkedBatchAsync(indexName, objects, action, batchSize, requestOptions, chunkedOptions)
   );
   if (waitForTasks) {
     responses.forEach(response ->
@@ -829,93 +828,6 @@ public <T> List<BatchResponse> chunkedBatch(
   RequestOptions requestOptions
 ) {
   return chunkedBatch(indexName, objects, action, waitForTasks, 1000, requestOptions);
-}
-
-/**
- * Helper: Asynchronously chunks the given {@code objects} list into batches of at most {@code
- * batchSize} elements for {@code batch} requests.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
- * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
- * returned future while sibling in-flight chunks still execute.
- *
- * @param indexName The `indexName` to replace `objects` in.
- * @param objects The array of `objects` to store in the given Algolia `indexName`.
- * @param action The `batch` `action` to perform on the given array of `objects`.
- * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
- *     to `length(objects) / batchSize`. Defaults to 1000.
- * @param requestOptions The requestOptions to send along with the query, they will be merged with
- *     the transporter requestOptions. (optional)
- * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
- * @see ChunkedHelperOptions
- */
-public <T> CompletableFuture<List<BatchResponse>> chunkedBatchAsync(
-  String indexName,
-  Iterable<T> objects,
-  Action action,
-  int batchSize,
-  RequestOptions requestOptions,
-  ChunkedHelperOptions chunkedOptions
-) {
-  return chunkedBatchAsyncInternal(indexName, objects, action, batchSize, requestOptions, chunkedOptions);
-}
-
-private <T> CompletableFuture<List<BatchResponse>> chunkedBatchAsyncInternal(
-  String indexName,
-  Iterable<T> objects,
-  Action action,
-  int batchSize,
-  RequestOptions requestOptions,
-  ChunkedHelperOptions chunkedOptions
-) {
-  if (batchSize < 1) {
-    throw new AlgoliaRuntimeException("`batchSize` must be greater than 0");
-  }
-  int maxConcurrency = chunkedOptions != null ? chunkedOptions.getMaxConcurrency() : 1;
-  Iterator<T> it = objects.iterator();
-  List<BatchResponse> responses = Collections.synchronizedList(new ArrayList<>());
-  return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
-}
-
-private <T> CompletableFuture<List<BatchResponse>> chunkedBatchNextWave(
-  String indexName,
-  Iterator<T> it,
-  Action action,
-  int batchSize,
-  int maxConcurrency,
-  RequestOptions requestOptions,
-  List<BatchResponse> responses
-) {
-  List<CompletableFuture<BatchResponse>> wave = new ArrayList<>();
-  while (wave.size() < maxConcurrency && it.hasNext()) {
-    List<BatchRequest> requests = new ArrayList<>();
-    while (requests.size() < batchSize && it.hasNext()) {
-      requests.add(new BatchRequest().setAction(action).setBody(it.next()));
-    }
-    wave.add(batchAsync(indexName, new BatchWriteParams().setRequests(requests), requestOptions));
-  }
-  if (wave.isEmpty()) {
-    return CompletableFuture.completedFuture(new ArrayList<>(responses));
-  }
-  return CompletableFuture
-    .allOf(wave.toArray(new CompletableFuture[0]))
-    .thenComposeAsync(ignored -> {
-      for (CompletableFuture<BatchResponse> f : wave) {
-        responses.add(f.join());
-      }
-      return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
-    });
 }
 
 /**
@@ -1131,68 +1043,6 @@ public <T> List<BatchResponse> saveObjects(String indexName, Iterable<T> objects
 }
 
 /**
- * Helper: Asynchronously saves the given array of objects in the given index. The
- * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
- * with at most 1000 objects in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * @param indexName The `indexName` to replace `objects` in.
- * @param objects The array of `objects` to store in the given Algolia `indexName`.
- */
-public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(String indexName, Iterable<T> objects) {
-  return saveObjectsAsync(indexName, objects, 1000, null, null);
-}
-
-/**
- * Helper: Asynchronously saves the given array of objects in the given index. The
- * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
- * with at most {@code batchSize} objects in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
- * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
- * returned future while sibling in-flight chunks still execute.
- *
- * @param indexName The `indexName` to replace `objects` in.
- * @param objects The array of `objects` to store in the given Algolia `indexName`.
- * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
- *     to `length(objects) / batchSize`.
- * @param requestOptions The requestOptions to send along with the query, they will be merged with
- *     the transporter requestOptions. (optional)
- * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
- * @see ChunkedHelperOptions
- */
-public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(
-  String indexName,
-  Iterable<T> objects,
-  int batchSize,
-  RequestOptions requestOptions,
-  ChunkedHelperOptions chunkedOptions
-) {
-  return chunkedBatchAsync(indexName, objects, Action.ADD_OBJECT, batchSize, requestOptions, chunkedOptions);
-}
-
-/**
  * Helper: Deletes every records for the given objectIDs. The `chunkedBatch` helper is used under
  * the hood, which creates a `batch` requests with at most 1000 objectIDs in it.
  *
@@ -1266,85 +1116,25 @@ public List<BatchResponse> deleteObjects(String indexName, List<String> objectID
  * @see ChunkedHelperOptions
  */
 public List<BatchResponse> deleteObjects(String indexName, List<String> objectIDs, boolean waitForTasks, int batchSize, RequestOptions requestOptions, ChunkedHelperOptions chunkedOptions) {
-  List<Map<String, String>> objects = new ArrayList<>();
+  return chunkedBatch(
+    indexName,
+    objectIDsToDeleteRequests(objectIDs),
+    Action.DELETE_OBJECT,
+    waitForTasks,
+    batchSize,
+    requestOptions,
+    chunkedOptions
+  );
+}
 
+private static List<Map<String, String>> objectIDsToDeleteRequests(List<String> objectIDs) {
+  List<Map<String, String>> objects = new ArrayList<>();
   for (String id : objectIDs) {
     Map<String, String> obj = new HashMap<>();
     obj.put("objectID", id);
     objects.add(obj);
   }
-
-  return chunkedBatch(indexName, objects, Action.DELETE_OBJECT, waitForTasks, batchSize, requestOptions, chunkedOptions);
-}
-
-/**
- * Helper: Asynchronously deletes every record for the given objectIDs. The
- * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
- * with at most 1000 objectIDs in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * @param indexName The `indexName` to delete `objectIDs` from.
- * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
- */
-public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(String indexName, List<String> objectIDs) {
-  return deleteObjectsAsync(indexName, objectIDs, 1000, null, null);
-}
-
-/**
- * Helper: Asynchronously deletes every record for the given objectIDs. The
- * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
- * with at most {@code batchSize} objectIDs in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
- * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
- * returned future while sibling in-flight chunks still execute.
- *
- * @param indexName The `indexName` to delete `objectIDs` from.
- * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
- * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
- *     to `length(objects) / batchSize`.
- * @param requestOptions The requestOptions to send along with the query, they will be merged with
- *     the transporter requestOptions. (optional)
- * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
- * @see ChunkedHelperOptions
- */
-public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(
-  String indexName,
-  List<String> objectIDs,
-  int batchSize,
-  RequestOptions requestOptions,
-  ChunkedHelperOptions chunkedOptions
-) {
-  List<Map<String, String>> objects = new ArrayList<>();
-
-  for (String id : objectIDs) {
-    Map<String, String> obj = new HashMap<>();
-    obj.put("objectID", id);
-    objects.add(obj);
-  }
-
-  return chunkedBatchAsync(indexName, objects, Action.DELETE_OBJECT, batchSize, requestOptions, chunkedOptions);
+  return objects;
 }
 
 /**
@@ -1609,84 +1399,6 @@ public <T> List<BatchResponse> partialUpdateObjects(
     objects,
     createIfNotExists ? Action.PARTIAL_UPDATE_OBJECT : Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
     waitForTasks,
-    batchSize,
-    requestOptions,
-    chunkedOptions
-  );
-}
-
-/**
- * Helper: Asynchronously replaces object content of all the given objects according to their
- * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
- * which creates {@code batch} requests with at most 1000 objects in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * @param indexName The `indexName` to update `objects` in.
- * @param objects The array of `objects` to update in the given Algolia `indexName`.
- * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
- *     will fail.
- */
-public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
-  String indexName,
-  Iterable<T> objects,
-  boolean createIfNotExists
-) {
-  return partialUpdateObjectsAsync(indexName, objects, createIfNotExists, 1000, null, null);
-}
-
-/**
- * Helper: Asynchronously replaces object content of all the given objects according to their
- * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
- * which creates {@code batch} requests with at most {@code batchSize} objects in each.
- *
- * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
- * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
- *
- * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
- * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
- * are already indexed.
- *
- * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
- * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
- * resources will surprise.
- *
- * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
- * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
- * returned future while sibling in-flight chunks still execute.
- *
- * @param indexName The `indexName` to update `objects` in.
- * @param objects The array of `objects` to update in the given Algolia `indexName`.
- * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
- *     will fail.
- * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
- *     to `length(objects) / batchSize`.
- * @param requestOptions The requestOptions to send along with the query, they will be merged with
- *     the transporter requestOptions. (optional)
- * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
- * @see ChunkedHelperOptions
- */
-public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
-  String indexName,
-  Iterable<T> objects,
-  boolean createIfNotExists,
-  int batchSize,
-  RequestOptions requestOptions,
-  ChunkedHelperOptions chunkedOptions
-) {
-  return chunkedBatchAsync(
-    indexName,
-    objects,
-    createIfNotExists ? Action.PARTIAL_UPDATE_OBJECT : Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
     batchSize,
     requestOptions,
     chunkedOptions
@@ -2196,6 +1908,7 @@ public boolean indexExists(String indexName) {
   }
   return true;
 }
+{{> async_batch_helpers}}
 {{/isSearchClient}}
 {{#isAgentStudioClient}}
 {{> agent_studio_helpers}}

--- a/templates/java/api_helpers.mustache
+++ b/templates/java/api_helpers.mustache
@@ -773,6 +773,10 @@ public <T> List<BatchResponse> chunkedBatch(
  * Helper: Chunks the given `objects` list in subset of 1000 elements max in order to make it fit
  * in `batch` requests.
  *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
  * @summary Helper: Chunks the given `objects` list in subset of 1000 elements max in order to
  *     make it fit in `batch` requests.
  * @param indexName - The `indexName` to replace `objects` in.
@@ -799,28 +803,13 @@ public <T> List<BatchResponse> chunkedBatch(
   ChunkedHelperOptions chunkedOptions
 ) {
   int maxRetries = chunkedOptions != null ? chunkedOptions.getMaxRetries() : TaskUtils.DEFAULT_MAX_RETRIES;
-  List<BatchResponse> responses = new ArrayList<>();
-  List<BatchRequest> requests = new ArrayList<>();
-
-  for (T item : objects) {
-    if (requests.size() == batchSize) {
-      BatchResponse batch = batch(indexName, new BatchWriteParams().setRequests(requests), requestOptions);
-      responses.add(batch);
-      requests.clear();
-    }
-
-    requests.add(new BatchRequest().setAction(action).setBody(item));
-  }
-
-  if (requests.size() > 0) {
-    BatchResponse batch = batch(indexName, new BatchWriteParams().setRequests(requests), requestOptions);
-    responses.add(batch);
-  }
-
+  List<BatchResponse> responses = LaunderThrowable.await(
+    chunkedBatchAsyncInternal(indexName, objects, action, batchSize, requestOptions, chunkedOptions)
+  );
   if (waitForTasks) {
-    responses.forEach(response -> waitForTask(indexName, response.getTaskID(), maxRetries, TaskUtils.DEFAULT_TIMEOUT, requestOptions));
+    responses.forEach(response ->
+      waitForTask(indexName, response.getTaskID(), maxRetries, TaskUtils.DEFAULT_TIMEOUT, requestOptions));
   }
-
   return responses;
 }
 
@@ -840,6 +829,93 @@ public <T> List<BatchResponse> chunkedBatch(
   RequestOptions requestOptions
 ) {
   return chunkedBatch(indexName, objects, action, waitForTasks, 1000, requestOptions);
+}
+
+/**
+ * Helper: Asynchronously chunks the given {@code objects} list into batches of at most {@code
+ * batchSize} elements for {@code batch} requests.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
+ * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
+ * returned future while sibling in-flight chunks still execute.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ * @param action The `batch` `action` to perform on the given array of `objects`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`. Defaults to 1000.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> chunkedBatchAsync(
+  String indexName,
+  Iterable<T> objects,
+  Action action,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsyncInternal(indexName, objects, action, batchSize, requestOptions, chunkedOptions);
+}
+
+private <T> CompletableFuture<List<BatchResponse>> chunkedBatchAsyncInternal(
+  String indexName,
+  Iterable<T> objects,
+  Action action,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  if (batchSize < 1) {
+    throw new AlgoliaRuntimeException("`batchSize` must be greater than 0");
+  }
+  int maxConcurrency = chunkedOptions != null ? chunkedOptions.getMaxConcurrency() : 1;
+  Iterator<T> it = objects.iterator();
+  List<BatchResponse> responses = Collections.synchronizedList(new ArrayList<>());
+  return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
+}
+
+private <T> CompletableFuture<List<BatchResponse>> chunkedBatchNextWave(
+  String indexName,
+  Iterator<T> it,
+  Action action,
+  int batchSize,
+  int maxConcurrency,
+  RequestOptions requestOptions,
+  List<BatchResponse> responses
+) {
+  List<CompletableFuture<BatchResponse>> wave = new ArrayList<>();
+  while (wave.size() < maxConcurrency && it.hasNext()) {
+    List<BatchRequest> requests = new ArrayList<>();
+    while (requests.size() < batchSize && it.hasNext()) {
+      requests.add(new BatchRequest().setAction(action).setBody(it.next()));
+    }
+    wave.add(batchAsync(indexName, new BatchWriteParams().setRequests(requests), requestOptions));
+  }
+  if (wave.isEmpty()) {
+    return CompletableFuture.completedFuture(new ArrayList<>(responses));
+  }
+  return CompletableFuture
+    .allOf(wave.toArray(new CompletableFuture[0]))
+    .thenComposeAsync(ignored -> {
+      for (CompletableFuture<BatchResponse> f : wave) {
+        responses.add(f.join());
+      }
+      return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
+    });
 }
 
 /**
@@ -1055,6 +1131,68 @@ public <T> List<BatchResponse> saveObjects(String indexName, Iterable<T> objects
 }
 
 /**
+ * Helper: Asynchronously saves the given array of objects in the given index. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most 1000 objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ */
+public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(String indexName, Iterable<T> objects) {
+  return saveObjectsAsync(indexName, objects, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously saves the given array of objects in the given index. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most {@code batchSize} objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
+ * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
+ * returned future while sibling in-flight chunks still execute.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsync(indexName, objects, Action.ADD_OBJECT, batchSize, requestOptions, chunkedOptions);
+}
+
+/**
  * Helper: Deletes every records for the given objectIDs. The `chunkedBatch` helper is used under
  * the hood, which creates a `batch` requests with at most 1000 objectIDs in it.
  *
@@ -1075,7 +1213,7 @@ public List<BatchResponse> deleteObjects(String indexName, List<String> objectID
  *     the transporter requestOptions. (optional)
  */
 public List<BatchResponse> deleteObjects(String indexName, List<String> objectIDs, RequestOptions requestOptions) {
-  return deleteObjects(indexName, objectIDs, false, null);
+  return deleteObjects(indexName, objectIDs, false, requestOptions);
 }
 
 /**
@@ -1137,6 +1275,76 @@ public List<BatchResponse> deleteObjects(String indexName, List<String> objectID
   }
 
   return chunkedBatch(indexName, objects, Action.DELETE_OBJECT, waitForTasks, batchSize, requestOptions, chunkedOptions);
+}
+
+/**
+ * Helper: Asynchronously deletes every record for the given objectIDs. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most 1000 objectIDs in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * @param indexName The `indexName` to delete `objectIDs` from.
+ * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
+ */
+public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(String indexName, List<String> objectIDs) {
+  return deleteObjectsAsync(indexName, objectIDs, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously deletes every record for the given objectIDs. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most {@code batchSize} objectIDs in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
+ * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
+ * returned future while sibling in-flight chunks still execute.
+ *
+ * @param indexName The `indexName` to delete `objectIDs` from.
+ * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(
+  String indexName,
+  List<String> objectIDs,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  List<Map<String, String>> objects = new ArrayList<>();
+
+  for (String id : objectIDs) {
+    Map<String, String> obj = new HashMap<>();
+    obj.put("objectID", id);
+    objects.add(obj);
+  }
+
+  return chunkedBatchAsync(indexName, objects, Action.DELETE_OBJECT, batchSize, requestOptions, chunkedOptions);
 }
 
 /**
@@ -1401,6 +1609,84 @@ public <T> List<BatchResponse> partialUpdateObjects(
     objects,
     createIfNotExists ? Action.PARTIAL_UPDATE_OBJECT : Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
     waitForTasks,
+    batchSize,
+    requestOptions,
+    chunkedOptions
+  );
+}
+
+/**
+ * Helper: Asynchronously replaces object content of all the given objects according to their
+ * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
+ * which creates {@code batch} requests with at most 1000 objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * @param indexName The `indexName` to update `objects` in.
+ * @param objects The array of `objects` to update in the given Algolia `indexName`.
+ * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
+ *     will fail.
+ */
+public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  boolean createIfNotExists
+) {
+  return partialUpdateObjectsAsync(indexName, objects, createIfNotExists, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously replaces object content of all the given objects according to their
+ * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
+ * which creates {@code batch} requests with at most {@code batchSize} objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining chunks fail with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed.
+ *
+ * <p>The {@code objects} Iterable is consumed lazily, one wave at a time: the first wave on the
+ * calling thread, subsequent waves on executor threads — lazy iterators touching thread-confined
+ * resources will surprise.
+ *
+ * <p>With {@code maxConcurrency > 1}, cross-chunk ordering (including duplicate-objectID
+ * last-write-wins across chunks in the same wave) is not guaranteed, and one failed chunk fails the
+ * returned future while sibling in-flight chunks still execute.
+ *
+ * @param indexName The `indexName` to update `objects` in.
+ * @param objects The array of `objects` to update in the given Algolia `indexName`.
+ * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
+ *     will fail.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  boolean createIfNotExists,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsync(
+    indexName,
+    objects,
+    createIfNotExists ? Action.PARTIAL_UPDATE_OBJECT : Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
     batchSize,
     requestOptions,
     chunkedOptions

--- a/templates/java/async_batch_helpers.mustache
+++ b/templates/java/async_batch_helpers.mustache
@@ -1,0 +1,250 @@
+{{#isSearchClient}}
+/**
+ * Helper: Asynchronously chunks the given {@code objects} list into batches of at most {@code
+ * batchSize} elements for {@code batch} requests.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>Do not call {@code close()} on the client while the returned future is pending — the executor
+ * shuts down and remaining work fails with {@code RejectedExecutionException} while earlier chunks
+ * are already indexed. All continuations run on the client's executor.
+ *
+ * <p>The {@code objects} Iterable is consumed one wave at a time — the first wave on the calling
+ * thread, subsequent waves on the client's executor. Lazy iterators that touch thread-confined
+ * resources may therefore surprise.
+ *
+ * <p>For concurrency semantics (ordering, last-write-wins, failure blast radius), see
+ * {@link ChunkedHelperOptions#setMaxConcurrency(int)}.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ * @param action The `batch` `action` to perform on the given array of `objects`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`. Defaults to 1000.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> chunkedBatchAsync(
+  String indexName,
+  Iterable<T> objects,
+  Action action,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  if (batchSize < 1) {
+    throw new AlgoliaRuntimeException("`batchSize` must be greater than 0");
+  }
+  int maxConcurrency = chunkedOptions != null ? chunkedOptions.getMaxConcurrency() : 1;
+  Iterator<T> it = objects.iterator();
+  // Waves are strictly sequential: responses.add runs only in the post-allOf continuation;
+  // future completion provides happens-before between waves (plain list is safe).
+  List<BatchResponse> responses = new ArrayList<>();
+  return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
+}
+
+private <T> CompletableFuture<List<BatchResponse>> chunkedBatchNextWave(
+  String indexName,
+  Iterator<T> it,
+  Action action,
+  int batchSize,
+  int maxConcurrency,
+  RequestOptions requestOptions,
+  List<BatchResponse> responses
+) {
+  List<CompletableFuture<BatchResponse>> wave = new ArrayList<>();
+  while (wave.size() < maxConcurrency && it.hasNext()) {
+    List<BatchRequest> requests = new ArrayList<>();
+    while (requests.size() < batchSize && it.hasNext()) {
+      requests.add(new BatchRequest().setAction(action).setBody(it.next()));
+    }
+    wave.add(batchAsync(indexName, new BatchWriteParams().setRequests(requests), requestOptions));
+  }
+  if (wave.isEmpty()) {
+    return CompletableFuture.completedFuture(new ArrayList<>(responses));
+  }
+  return CompletableFuture
+    .allOf(wave.toArray(new CompletableFuture[0]))
+    .thenComposeAsync(ignored -> {
+      for (CompletableFuture<BatchResponse> f : wave) {
+        responses.add(f.join());
+      }
+      return chunkedBatchNextWave(indexName, it, action, batchSize, maxConcurrency, requestOptions, responses);
+    }, getExecutor());
+}
+
+/**
+ * Helper: Asynchronously saves the given array of objects in the given index. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most 1000 objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ */
+public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(String indexName, Iterable<T> objects) {
+  return saveObjectsAsync(indexName, objects, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously saves the given array of objects in the given index. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most {@code batchSize} objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats. For concurrency semantics, see
+ * {@link ChunkedHelperOptions#setMaxConcurrency(int)}.
+ *
+ * @param indexName The `indexName` to replace `objects` in.
+ * @param objects The array of `objects` to store in the given Algolia `indexName`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> saveObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsync(indexName, objects, Action.ADD_OBJECT, batchSize, requestOptions, chunkedOptions);
+}
+
+/**
+ * Helper: Asynchronously deletes every record for the given objectIDs. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most 1000 objectIDs in each. ObjectIDs are materialized into request maps before batching
+ * begins.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats.
+ *
+ * @param indexName The `indexName` to delete `objectIDs` from.
+ * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
+ */
+public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(String indexName, List<String> objectIDs) {
+  return deleteObjectsAsync(indexName, objectIDs, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously deletes every record for the given objectIDs. The
+ * {@code chunkedBatchAsync} helper is used under the hood, which creates {@code batch} requests
+ * with at most {@code batchSize} objectIDs in each. ObjectIDs are materialized into request maps
+ * before batching begins.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats. For concurrency semantics, see
+ * {@link ChunkedHelperOptions#setMaxConcurrency(int)}.
+ *
+ * @param indexName The `indexName` to delete `objectIDs` from.
+ * @param objectIDs The array of `objectIDs` to delete from the `indexName`.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public CompletableFuture<List<BatchResponse>> deleteObjectsAsync(
+  String indexName,
+  List<String> objectIDs,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsync(
+    indexName,
+    objectIDsToDeleteRequests(objectIDs),
+    Action.DELETE_OBJECT,
+    batchSize,
+    requestOptions,
+    chunkedOptions
+  );
+}
+
+/**
+ * Helper: Asynchronously replaces object content of all the given objects according to their
+ * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
+ * which creates {@code batch} requests with at most 1000 objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats.
+ *
+ * @param indexName The `indexName` to update `objects` in.
+ * @param objects The array of `objects` to update in the given Algolia `indexName`.
+ * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
+ *     will fail.
+ */
+public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  boolean createIfNotExists
+) {
+  return partialUpdateObjectsAsync(indexName, objects, createIfNotExists, 1000, null, null);
+}
+
+/**
+ * Helper: Asynchronously replaces object content of all the given objects according to their
+ * respective {@code objectID} field. The {@code chunkedBatchAsync} helper is used under the hood,
+ * which creates {@code batch} requests with at most {@code batchSize} objects in each.
+ *
+ * <p>Does not wait for tasks; call {@code waitForTask(indexName, taskID)} on each returned {@code
+ * taskID}, or use the synchronous variant with {@code waitForTasks=true}.
+ *
+ * <p>See {@link #chunkedBatchAsync(String, Iterable, Action, int, RequestOptions, ChunkedHelperOptions)}
+ * for threading and lifecycle caveats. For concurrency semantics, see
+ * {@link ChunkedHelperOptions#setMaxConcurrency(int)}.
+ *
+ * @param indexName The `indexName` to update `objects` in.
+ * @param objects The array of `objects` to update in the given Algolia `indexName`.
+ * @param createIfNotExists To be provided if non-existing objects are passed, otherwise, the call
+ *     will fail.
+ * @param batchSize The size of the chunk of `objects`. The number of `batch` calls will be equal
+ *     to `length(objects) / batchSize`.
+ * @param requestOptions The requestOptions to send along with the query, they will be merged with
+ *     the transporter requestOptions. (optional)
+ * @param chunkedOptions Optional configuration for the helper (e.g. maxConcurrency). (optional)
+ * @see ChunkedHelperOptions
+ */
+public <T> CompletableFuture<List<BatchResponse>> partialUpdateObjectsAsync(
+  String indexName,
+  Iterable<T> objects,
+  boolean createIfNotExists,
+  int batchSize,
+  RequestOptions requestOptions,
+  ChunkedHelperOptions chunkedOptions
+) {
+  return chunkedBatchAsync(
+    indexName,
+    objects,
+    createIfNotExists ? Action.PARTIAL_UPDATE_OBJECT : Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
+    batchSize,
+    requestOptions,
+    chunkedOptions
+  );
+}
+{{/isSearchClient}}

--- a/tests/output/java/src/test/java/com/algolia/manual/AsyncBatchHelpersTest.java
+++ b/tests/output/java/src/test/java/com/algolia/manual/AsyncBatchHelpersTest.java
@@ -1,0 +1,459 @@
+package com.algolia.manual;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.algolia.api.SearchClient;
+import com.algolia.config.ClientOptions;
+import com.algolia.config.HttpRequest;
+import com.algolia.config.RequestOptions;
+import com.algolia.config.Requester;
+import com.algolia.exceptions.AlgoliaApiException;
+import com.algolia.exceptions.AlgoliaRuntimeException;
+import com.algolia.model.search.Action;
+import com.algolia.model.search.BatchRequest;
+import com.algolia.model.search.BatchResponse;
+import com.algolia.model.search.BatchWriteParams;
+import com.algolia.model.search.GetTaskResponse;
+import com.algolia.model.search.TaskStatus;
+import com.algolia.utils.ChunkedHelperOptions;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Regression tests for CR-11794: Java v4 async batch helpers ({@code chunkedBatchAsync}, {@code
+ * saveObjectsAsync}, {@code partialUpdateObjectsAsync}, {@code deleteObjectsAsync}) and the sync
+ * reimplementation on the async core (including {@code waitForTasks} polling after all batches and
+ * the {@code deleteObjects(..., RequestOptions)} forward fix).
+ */
+class AsyncBatchHelpersTest {
+
+  static final String INDEX = "my-index";
+
+  /** Snapshot of one call through the stubbed {@link Requester}. */
+  static final class CapturedRequest {
+
+    final HttpRequest httpRequest;
+    final RequestOptions requestOptions;
+    final String path;
+    final String method;
+
+    /** Non-null only for {@code /batch} requests. */
+    final BatchWriteParams batchBody;
+
+    CapturedRequest(HttpRequest httpRequest, RequestOptions requestOptions) {
+      this.httpRequest = httpRequest;
+      this.requestOptions = requestOptions;
+      this.path = httpRequest.getPath();
+      this.method = httpRequest.getMethod();
+      if (path != null && path.contains("/batch")) {
+        this.batchBody = (BatchWriteParams) httpRequest.getBody();
+      } else {
+        this.batchBody = null;
+      }
+    }
+  }
+
+  /**
+   * Requester stub that records batch/task traffic, tracks in-flight concurrency, optionally gates
+   * completion, and can fail on the Nth {@code /batch} call. No real HTTP is performed.
+   */
+  static class CapturingRequester implements Requester {
+
+    final List<CapturedRequest> captured = Collections.synchronizedList(new ArrayList<CapturedRequest>());
+    final AtomicInteger currentInFlight = new AtomicInteger();
+    final AtomicInteger maxInFlight = new AtomicInteger();
+    final AtomicInteger nextTaskId = new AtomicInteger(1);
+    final AtomicInteger batchCallCount = new AtomicInteger();
+
+    volatile CyclicBarrier gate;
+    volatile CountDownLatch latch;
+
+    /** 1-based; {@code 0} means never fail. */
+    volatile int failOnBatchCall;
+
+    void setGate(CyclicBarrier gate) {
+      this.gate = gate;
+    }
+
+    void setLatch(CountDownLatch latch) {
+      this.latch = latch;
+    }
+
+    void setFailOnBatchCall(int failOnBatchCall) {
+      this.failOnBatchCall = failOnBatchCall;
+    }
+
+    List<CapturedRequest> batchRequests() {
+      List<CapturedRequest> batches = new ArrayList<CapturedRequest>();
+      synchronized (captured) {
+        for (CapturedRequest c : captured) {
+          if (c.batchBody != null) {
+            batches.add(c);
+          }
+        }
+      }
+      return batches;
+    }
+
+    private Object handle(HttpRequest httpRequest, RequestOptions requestOptions) throws Exception {
+      CapturedRequest capturedRequest = new CapturedRequest(httpRequest, requestOptions);
+      captured.add(capturedRequest);
+
+      String path = httpRequest.getPath();
+      boolean isBatch = path != null && path.contains("/batch");
+      boolean isTask = path != null && path.contains("/task/");
+
+      if (isBatch) {
+        currentInFlight.incrementAndGet();
+        maxInFlight.updateAndGet(prev -> Math.max(prev, currentInFlight.get()));
+        try {
+          awaitGates();
+          int n = batchCallCount.incrementAndGet();
+          if (failOnBatchCall > 0 && n == failOnBatchCall) {
+            throw new AlgoliaApiException("simulated batch failure on call " + n, 500);
+          }
+          return new BatchResponse().setTaskID((long) nextTaskId.getAndIncrement());
+        } finally {
+          currentInFlight.decrementAndGet();
+        }
+      }
+
+      if (isTask) {
+        awaitGates();
+        return new GetTaskResponse().setStatus(TaskStatus.PUBLISHED);
+      }
+
+      awaitGates();
+      throw new AlgoliaRuntimeException("unexpected path in CapturingRequester: " + path);
+    }
+
+    private void awaitGates() throws Exception {
+      CyclicBarrier barrier = this.gate;
+      if (barrier != null) {
+        barrier.await(5, TimeUnit.SECONDS);
+      }
+      CountDownLatch countDownLatch = this.latch;
+      if (countDownLatch != null) {
+        if (!countDownLatch.await(5, TimeUnit.SECONDS)) {
+          throw new AlgoliaRuntimeException("CapturingRequester latch timed out");
+        }
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T execute(HttpRequest httpRequest, RequestOptions requestOptions, Class<?> returnType, Class<?> innerType) {
+      try {
+        return (T) handle(httpRequest, requestOptions);
+      } catch (AlgoliaRuntimeException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new AlgoliaRuntimeException(e);
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T execute(HttpRequest httpRequest, RequestOptions requestOptions, TypeReference<?> returnType) {
+      try {
+        return (T) handle(httpRequest, requestOptions);
+      } catch (AlgoliaRuntimeException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new AlgoliaRuntimeException(e);
+      }
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  static Map<String, String> record(String objectID) {
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("objectID", objectID);
+    return map;
+  }
+
+  static List<Map<String, String>> records(int count) {
+    List<Map<String, String>> list = new ArrayList<Map<String, String>>();
+    for (int i = 0; i < count; i++) {
+      list.add(record("id-" + i));
+    }
+    return list;
+  }
+
+  static SearchClient client(CapturingRequester requester) {
+    return new SearchClient("app-id", "api-key", ClientOptions.builder().setRequester(requester).build());
+  }
+
+  static void assertRequestSequenceEqual(List<CapturedRequest> expected, List<CapturedRequest> actual) {
+    assertEquals(expected.size(), actual.size(), "request count");
+    for (int i = 0; i < expected.size(); i++) {
+      CapturedRequest e = expected.get(i);
+      CapturedRequest a = actual.get(i);
+      assertEquals(e.path, a.path, "path at index " + i);
+      assertEquals(e.method, a.method, "method at index " + i);
+      assertEquals(e.batchBody, a.batchBody, "BatchWriteParams at index " + i);
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  @DisplayName("chunkedBatchAsync splits into full chunks plus trailing partial (CR-11794)")
+  void chunkedBatchAsyncSplitsChunksIncludingTrailingPartial() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    List<Map<String, String>> objects = records(7);
+
+    try (SearchClient client = client(requester)) {
+      List<BatchResponse> responses = client.chunkedBatchAsync(INDEX, objects, Action.ADD_OBJECT, 3, null, null).get(10, TimeUnit.SECONDS);
+
+      assertEquals(3, responses.size());
+      List<CapturedRequest> batches = requester.batchRequests();
+      assertEquals(3, batches.size());
+      assertEquals(3, batches.get(0).batchBody.getRequests().size());
+      assertEquals(3, batches.get(1).batchBody.getRequests().size());
+      assertEquals(1, batches.get(2).batchBody.getRequests().size());
+
+      assertEquals(record("id-0"), batches.get(0).batchBody.getRequests().get(0).getBody());
+      assertEquals(record("id-2"), batches.get(0).batchBody.getRequests().get(2).getBody());
+      assertEquals(record("id-3"), batches.get(1).batchBody.getRequests().get(0).getBody());
+      assertEquals(record("id-6"), batches.get(2).batchBody.getRequests().get(0).getBody());
+
+      for (CapturedRequest batch : batches) {
+        assertTrue(batch.path.contains("/1/indexes/" + INDEX + "/batch"));
+        assertEquals("POST", batch.method);
+        for (BatchRequest req : batch.batchBody.getRequests()) {
+          assertEquals(Action.ADD_OBJECT, req.getAction());
+        }
+      }
+    }
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName("chunkedBatchAsync empty Iterable completes with empty list and no HTTP (CR-11794)")
+  void chunkedBatchAsyncEmptyIterableMakesNoRequests() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+
+    try (SearchClient client = client(requester)) {
+      List<BatchResponse> responses = client
+        .chunkedBatchAsync(INDEX, Collections.<Map<String, String>>emptyList(), Action.ADD_OBJECT, 3, null, null)
+        .get(5, TimeUnit.SECONDS);
+
+      assertTrue(responses.isEmpty());
+      assertTrue(requester.captured.isEmpty());
+    }
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName("batchSize < 1 throws AlgoliaRuntimeException synchronously on sync and async (CR-11794)")
+  void chunkedBatchRejectsNonPositiveBatchSize() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    List<Map<String, String>> objects = records(1);
+
+    try (SearchClient client = client(requester)) {
+      assertThrows(AlgoliaRuntimeException.class, () -> client.chunkedBatchAsync(INDEX, objects, Action.ADD_OBJECT, 0, null, null));
+      assertThrows(AlgoliaRuntimeException.class, () -> client.chunkedBatch(INDEX, objects, Action.ADD_OBJECT, false, 0, null, null));
+      assertTrue(requester.captured.isEmpty(), "validation must happen before any HTTP");
+    }
+  }
+
+  @Test
+  @Timeout(20)
+  @DisplayName("async core is sequential by default (maxConcurrency=1) (CR-11794)")
+  void asyncCoreIsSequentialByDefault() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    // 10 objects / batchSize 2 → 5 chunks (≥4)
+    List<Map<String, String>> objects = records(10);
+
+    try (SearchClient client = client(requester)) {
+      client.chunkedBatchAsync(INDEX, objects, Action.ADD_OBJECT, 2, null, null).get(15, TimeUnit.SECONDS);
+
+      List<CapturedRequest> batches = requester.batchRequests();
+      assertTrue(batches.size() >= 4, "expected ≥4 chunks, got " + batches.size());
+      assertEquals(1, requester.maxInFlight.get(), "default maxConcurrency must keep in-flight at 1");
+
+      for (int i = 0; i < batches.size(); i++) {
+        assertEquals(record("id-" + i * 2), batches.get(i).batchBody.getRequests().get(0).getBody());
+      }
+    }
+  }
+
+  @Test
+  @Timeout(30)
+  @DisplayName("maxConcurrency bounds in-flight /batch requests per wave (CR-11794)")
+  void maxConcurrencyBoundsInFlightRequests() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    CyclicBarrier barrier = new CyclicBarrier(3);
+    requester.setGate(barrier);
+    // 9 objects / batchSize 3 / maxConcurrency 3 → one wave of exactly 3 concurrent batches
+    List<Map<String, String>> objects = records(9);
+    ChunkedHelperOptions chunkedOptions = new ChunkedHelperOptions().setMaxConcurrency(3);
+
+    try (SearchClient client = client(requester)) {
+      client.chunkedBatchAsync(INDEX, objects, Action.ADD_OBJECT, 3, null, chunkedOptions).get(20, TimeUnit.SECONDS);
+
+      assertEquals(3, requester.maxInFlight.get(), "must observe exactly 3 concurrent in-flight batches");
+      assertEquals(3, requester.batchRequests().size());
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  @DisplayName("failed chunk fails the returned future with AlgoliaApiException cause (CR-11794)")
+  void failedChunkFailsFutureWithAlgoliaApiExceptionCause() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    requester.setFailOnBatchCall(2);
+    List<Map<String, String>> objects = records(5); // batchSize 2 → chunks of 2/2/1
+
+    try (SearchClient client = client(requester)) {
+      ExecutionException thrown = assertThrows(ExecutionException.class, () ->
+        client.chunkedBatchAsync(INDEX, objects, Action.ADD_OBJECT, 2, null, null).get(10, TimeUnit.SECONDS)
+      );
+      assertTrue(thrown.getCause() instanceof AlgoliaApiException, "cause must be AlgoliaApiException, got " + thrown.getCause());
+    }
+  }
+
+  @Test
+  @Timeout(20)
+  @DisplayName("sync saveObjects emits identical request sequence to saveObjectsAsync (CR-11794)")
+  void syncHelperEmitsIdenticalRequestsToAsync() throws Exception {
+    List<Map<String, String>> objects = records(7);
+
+    CapturingRequester asyncRequester = new CapturingRequester();
+    CapturingRequester syncRequester = new CapturingRequester();
+
+    try (SearchClient asyncClient = client(asyncRequester); SearchClient syncClient = client(syncRequester)) {
+      asyncClient.saveObjectsAsync(INDEX, objects, 3, null, null).get(10, TimeUnit.SECONDS);
+      syncClient.saveObjects(INDEX, objects, false, 3, null, null);
+
+      assertRequestSequenceEqual(asyncRequester.batchRequests(), syncRequester.batchRequests());
+    }
+
+    CapturingRequester failingRequester = new CapturingRequester();
+    failingRequester.setFailOnBatchCall(1);
+    try (SearchClient client = client(failingRequester)) {
+      AlgoliaApiException thrown = assertThrows(AlgoliaApiException.class, () -> client.saveObjects(INDEX, objects, false, 3, null, null));
+      assertEquals(500, thrown.getStatusCode());
+    }
+  }
+
+  @Test
+  @Timeout(20)
+  @DisplayName("sync waitForTasks polls getTask only after all /batch calls (CR-11794)")
+  void syncWaitForTasksPollsAfterAllBatches() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    List<Map<String, String>> objects = records(7); // batchSize 3 → 3 batches → 3 getTask
+
+    try (SearchClient client = client(requester)) {
+      client.saveObjects(INDEX, objects, true, 3, null, null);
+
+      List<CapturedRequest> all = new ArrayList<CapturedRequest>(requester.captured);
+      assertTrue(all.size() >= 6, "expected 3 batch + 3 getTask, got " + all.size());
+
+      int lastBatchIndex = -1;
+      int firstTaskIndex = -1;
+      for (int i = 0; i < all.size(); i++) {
+        CapturedRequest c = all.get(i);
+        if (c.batchBody != null) {
+          lastBatchIndex = i;
+        } else if (c.path != null && c.path.contains("/task/")) {
+          if (firstTaskIndex < 0) {
+            firstTaskIndex = i;
+          }
+          assertEquals("GET", c.method);
+        }
+      }
+
+      assertEquals(3, requester.batchRequests().size());
+      assertTrue(firstTaskIndex > lastBatchIndex, "all getTask polls must come after all /batch calls");
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  @DisplayName("public async helpers map to the correct Action values (CR-11794)")
+  void publicAsyncHelpersMapActionsCorrectly() throws Exception {
+    List<Map<String, String>> objects = Arrays.asList(record("a"), record("b"));
+
+    CapturingRequester saveRequester = new CapturingRequester();
+    try (SearchClient client = client(saveRequester)) {
+      client.saveObjectsAsync(INDEX, objects, 10, null, null).get(5, TimeUnit.SECONDS);
+      assertEquals(Action.ADD_OBJECT, saveRequester.batchRequests().get(0).batchBody.getRequests().get(0).getAction());
+    }
+
+    CapturingRequester createRequester = new CapturingRequester();
+    try (SearchClient client = client(createRequester)) {
+      client.partialUpdateObjectsAsync(INDEX, objects, true, 10, null, null).get(5, TimeUnit.SECONDS);
+      assertEquals(Action.PARTIAL_UPDATE_OBJECT, createRequester.batchRequests().get(0).batchBody.getRequests().get(0).getAction());
+    }
+
+    CapturingRequester noCreateRequester = new CapturingRequester();
+    try (SearchClient client = client(noCreateRequester)) {
+      client.partialUpdateObjectsAsync(INDEX, objects, false, 10, null, null).get(5, TimeUnit.SECONDS);
+      assertEquals(
+        Action.PARTIAL_UPDATE_OBJECT_NO_CREATE,
+        noCreateRequester.batchRequests().get(0).batchBody.getRequests().get(0).getAction()
+      );
+    }
+  }
+
+  @Test
+  @Timeout(15)
+  @DisplayName("deleteObjectsAsync wraps IDs as {objectID} with DELETE_OBJECT (CR-11794)")
+  void deleteObjectsAsyncBuildsDeleteRequests() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    List<String> ids = Arrays.asList("x", "y", "z");
+
+    try (SearchClient client = client(requester)) {
+      client.deleteObjectsAsync(INDEX, ids, 2, null, null).get(5, TimeUnit.SECONDS);
+
+      List<CapturedRequest> batches = requester.batchRequests();
+      assertEquals(2, batches.size());
+      assertEquals(2, batches.get(0).batchBody.getRequests().size());
+      assertEquals(1, batches.get(1).batchBody.getRequests().size());
+
+      BatchRequest first = batches.get(0).batchBody.getRequests().get(0);
+      assertEquals(Action.DELETE_OBJECT, first.getAction());
+      assertEquals(record("x"), first.getBody());
+      assertEquals(record("y"), batches.get(0).batchBody.getRequests().get(1).getBody());
+      assertEquals(record("z"), batches.get(1).batchBody.getRequests().get(0).getBody());
+    }
+  }
+
+  @Test
+  @Timeout(10)
+  @DisplayName("deleteObjects(index, ids, requestOptions) forwards RequestOptions (CR-11794)")
+  void deleteObjectsForwardsRequestOptions() throws Exception {
+    CapturingRequester requester = new CapturingRequester();
+    RequestOptions requestOptions = new RequestOptions()
+      .addExtraHeader("X-Test-Forward", "cr-11794")
+      .addExtraQueryParameters("forwarded", "yes");
+
+    try (SearchClient client = client(requester)) {
+      client.deleteObjects(INDEX, Arrays.asList("obj-1"), requestOptions);
+
+      List<CapturedRequest> batches = requester.batchRequests();
+      assertEquals(1, batches.size());
+      // RequestOptions are applied by HttpRequester at send time; at the Requester boundary they
+      // arrive as the execute(..., requestOptions, ...) argument (not merged onto HttpRequest).
+      assertNotNull(batches.get(0).requestOptions, "requestOptions must be forwarded to the requester");
+      assertEquals("cr-11794", batches.get(0).requestOptions.getHeaders().get("x-test-forward"));
+      assertEquals("yes", batches.get(0).requestOptions.getQueryParameters().get("forwarded"));
+    }
+  }
+}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [CR-11794](https://algolia.atlassian.net/browse/CR-11794)

Customers migrating from Java v3 lost the async batch-indexing helpers (`partialUpdateObjectsAsync` and friends) and now have to block application threads on bulk updates. This restores a `CompletableFuture` surface for the batch helpers, backed by the same core the sync helpers use, plus an opt-in `maxConcurrency` knob (default 1 = today's exact sequential semantics). Java-only on purpose: the other ten clients are either already async-idiomatic or idiomatically blocking.

### Changes included:

- `chunkedBatchAsync`, `saveObjectsAsync`, `partialUpdateObjectsAsync`, `deleteObjectsAsync` on `SearchClient`. Async variants don't wait for tasks — call `waitForTask` per taskID, or use the sync variant.
- `ChunkedHelperOptions.maxConcurrency` to parallelize chunk uploads, off by default.
- Bug fix riding along: `deleteObjects(indexName, objectIDs, requestOptions)` silently dropped its `requestOptions`; `batchSize < 1` is now rejected.

## 🧪 Test

Hand-written JUnit suite (`com.algolia.manual`, runs in CTS) covering chunking math, concurrency bounds, failure propagation, and sync/async request equivalence.

**Reviewer note:** the wave recursion uses `thenComposeAsync` on the client executor deliberately — plain `thenCompose` can nest on the stack when futures complete before callback registration.


[CR-11794]: https://algolia.atlassian.net/browse/CR-11794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ