### PR TITLE
feat(javascript): Request-ID and Correlation-ID support

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -27,7 +27,7 @@
     "files": [
       {
         "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-        "maxSize": "21KB"
+        "maxSize": "21.25KB"
       },
       {
         "path": "packages/algoliasearch/dist/lite/builds/browser.umd.js",

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -39,7 +39,7 @@
       },
       {
         "path": "packages/client-abtesting/dist/builds/browser.umd.js",
-        "maxSize": "6KB"
+        "maxSize": "6.25KB"
       },
       {
         "path": "packages/client-analytics/dist/builds/browser.umd.js",

--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -35,7 +35,7 @@
       },
       {
         "path": "packages/abtesting/dist/builds/browser.umd.js",
-        "maxSize": "6KB"
+        "maxSize": "6.25KB"
       },
       {
         "path": "packages/client-abtesting/dist/builds/browser.umd.js",
@@ -75,7 +75,7 @@
       },
       {
         "path": "packages/recommend/dist/builds/browser.umd.js",
-        "maxSize": "6KB"
+        "maxSize": "6.25KB"
       },
       {
         "path": "packages/agent-studio/dist/builds/browser.umd.js",

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.common.test.ts
@@ -69,6 +69,7 @@ describe('api', () => {
   test('exposes the search client transporter for the algoliasearch client', () => {
     expect(client.transporter).not.toBeUndefined();
     expect(client.transporter).toEqual({
+      requestIdChannel: 'queryParameters',
       algoliaAgent: {
         add: expect.any(Function),
         value: expect.stringContaining(
@@ -214,6 +215,7 @@ describe('search with legacy signature', () => {
     expect(req.searchParams).toStrictEqual({
       'x-algolia-api-key': 'API_KEY',
       'x-algolia-application-id': 'APP_ID',
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
     });
   });
 
@@ -234,6 +236,7 @@ describe('search with legacy signature', () => {
     expect(req.searchParams).toStrictEqual({
       'x-algolia-api-key': 'API_KEY',
       'x-algolia-application-id': 'APP_ID',
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
     });
   });
 
@@ -255,6 +258,7 @@ describe('search with legacy signature', () => {
     expect(req.searchParams).toStrictEqual({
       'x-algolia-api-key': 'API_KEY',
       'x-algolia-application-id': 'APP_ID',
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
     });
   });
 });
@@ -276,6 +280,7 @@ describe('init', () => {
     expect(qpResult.searchParams).toEqual({
       'x-algolia-api-key': 'bar',
       'x-algolia-application-id': 'foo',
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
     });
 
     const headerResult = (await headerClient.customGet({
@@ -296,6 +301,7 @@ describe('init', () => {
     expect(res.searchParams).toEqual({
       'x-algolia-api-key': 'API_KEY',
       'x-algolia-application-id': 'APP_ID',
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
     });
   });
 });

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
@@ -33,9 +33,21 @@ function createRecordingRequester(): { requester: Requester; requests: EndReques
     requester: {
       send(request: EndRequest) {
         requests.push(request);
-        const content = request.url.includes('/task/')
-          ? JSON.stringify({ status: 'published', updatedAt: '2026-01-01T00:00:00Z' })
-          : JSON.stringify({ taskID: 42, objectIDs: [], updatedAt: '2026-01-01T00:00:00Z' });
+        let content = JSON.stringify({ taskID: 42, objectIDs: [], updatedAt: '2026-01-01T00:00:00Z' });
+        if (request.url.includes('/task/')) {
+          content = JSON.stringify({ status: 'published', updatedAt: '2026-01-01T00:00:00Z' });
+        } else if (request.url.includes('/push/')) {
+          content = JSON.stringify({ runID: 'run-1', eventID: 'event-1', message: 'pushed' });
+        } else if (request.url.includes('/events/')) {
+          content = JSON.stringify({
+            eventID: 'event-1',
+            runID: 'run-1',
+            status: 'succeeded',
+            type: 'record',
+            batchSize: 1,
+            publishedAt: '2026-01-01T00:00:00Z',
+          });
+        }
 
         return Promise.resolve({ content, isTimedOut: false, status: 200 });
       },
@@ -66,6 +78,32 @@ test('replaceAllObjects shares one request-id across copy, batch, wait and move'
   const ids = requests.map((request) => request.headers['request-id']);
   expect(ids[0]).toMatch(/^[0-9A-Za-z]{11}$/);
   expect(new Set(ids).size).toBe(1);
+});
+
+test('replaceAllObjectsWithTransformation shares one request-id across its search calls and sends none to ingestion', async () => {
+  const { requester, requests } = createRecordingRequester();
+  const client = algoliasearch('APP_ID', 'API_KEY', {
+    requester,
+    transformationOptions: { region: 'eu', requester },
+  });
+
+  await client.replaceAllObjectsWithTransformation({ indexName: 'foo', objects: [{ objectID: '1' }] });
+
+  const searchRequests = requests.filter((request) => request.url.includes('algolia.net'));
+  const ingestionRequests = requests.filter((request) => request.url.includes('data.eu.algolia.com'));
+
+  expect(requests).toHaveLength(8);
+  expect(searchRequests).toHaveLength(6);
+  expect(ingestionRequests).toHaveLength(2);
+
+  const searchIds = searchRequests.map((request) => request.headers['request-id']);
+  expect(searchIds[0]).toMatch(/^[0-9A-Za-z]{11}$/);
+  expect(new Set(searchIds).size).toBe(1);
+
+  for (const request of ingestionRequests) {
+    expect(request.headers['request-id']).toBeUndefined();
+    expect(new URL(request.url).searchParams.get('x-algolia-request-id')).toBeNull();
+  }
 });
 
 test('each helper invocation mints a fresh request-id', async () => {

--- a/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/algoliasearch/__tests__/algoliasearch.node.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
+import type { EndRequest, Requester } from '../../client-common/src/types';
 import { LogLevelEnum } from '../../client-common/src/types';
 import { createConsoleLogger } from '../../logger-console/src/logger';
 import { algoliasearch, apiClientVersion } from '../builds/node';
@@ -22,6 +23,73 @@ test('forwards node search helpers', () => {
     const resp = client.generateSecuredApiKey({ parentApiKey: 'foo', restrictions: { validUntil: 200 } });
     client.getSecuredApiKeyRemainingValidity({ securedApiKey: resp });
   }).not.toThrow();
+});
+
+function createRecordingRequester(): { requester: Requester; requests: EndRequest[] } {
+  const requests: EndRequest[] = [];
+
+  return {
+    requests,
+    requester: {
+      send(request: EndRequest) {
+        requests.push(request);
+        const content = request.url.includes('/task/')
+          ? JSON.stringify({ status: 'published', updatedAt: '2026-01-01T00:00:00Z' })
+          : JSON.stringify({ taskID: 42, objectIDs: [], updatedAt: '2026-01-01T00:00:00Z' });
+
+        return Promise.resolve({ content, isTimedOut: false, status: 200 });
+      },
+    },
+  };
+}
+
+test('chunkedBatch shares one request-id across its batch calls and task polls', async () => {
+  const { requester, requests } = createRecordingRequester();
+  const client = algoliasearch('APP_ID', 'API_KEY', { requester });
+  const objects = Array.from({ length: 1500 }, (_, i) => ({ objectID: `${i}` }));
+
+  await client.chunkedBatch({ indexName: 'foo', objects, waitForTasks: true });
+
+  expect(requests).toHaveLength(4);
+  const ids = requests.map((request) => request.headers['request-id']);
+  expect(ids[0]).toMatch(/^[0-9A-Za-z]{11}$/);
+  expect(new Set(ids).size).toBe(1);
+});
+
+test('replaceAllObjects shares one request-id across copy, batch, wait and move', async () => {
+  const { requester, requests } = createRecordingRequester();
+  const client = algoliasearch('APP_ID', 'API_KEY', { requester });
+
+  await client.replaceAllObjects({ indexName: 'foo', objects: [{ objectID: '1' }] });
+
+  expect(requests).toHaveLength(8);
+  const ids = requests.map((request) => request.headers['request-id']);
+  expect(ids[0]).toMatch(/^[0-9A-Za-z]{11}$/);
+  expect(new Set(ids).size).toBe(1);
+});
+
+test('each helper invocation mints a fresh request-id', async () => {
+  const { requester, requests } = createRecordingRequester();
+  const client = algoliasearch('APP_ID', 'API_KEY', { requester });
+
+  await client.chunkedBatch({ indexName: 'foo', objects: [{ objectID: '1' }] });
+  await client.chunkedBatch({ indexName: 'foo', objects: [{ objectID: '1' }] });
+
+  expect(requests).toHaveLength(2);
+  expect(requests[0].headers['request-id']).not.toBe(requests[1].headers['request-id']);
+});
+
+test('a caller-supplied request-id flows through helpers untouched', async () => {
+  const { requester, requests } = createRecordingRequester();
+  const client = algoliasearch('APP_ID', 'API_KEY', { requester });
+
+  await client.chunkedBatch(
+    { indexName: 'foo', objects: [{ objectID: '1' }], waitForTasks: true },
+    { headers: { 'request-id': 'CallerChose' } },
+  );
+
+  expect(requests).toHaveLength(2);
+  expect(requests.map((request) => request.headers['request-id'])).toEqual(['CallerChose', 'CallerChose']);
 });
 
 test('with logger', async () => {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { createMemoryCache, createNullCache } from '../../cache';
 import { createNullLogger } from '../../logger';
-import { ApiError, DetailedApiError, RetryError, createTransporter } from '../../transporter';
+import { ApiError, DeserializationError, DetailedApiError, RetryError, createTransporter } from '../../transporter';
 import type { AlgoliaAgent, Requester, Transporter } from '../../types';
 
 describe('correlation ID on errors', () => {
@@ -182,6 +182,46 @@ describe('correlation ID on errors', () => {
     );
 
     expect(error).toBeInstanceOf(RetryError);
+    expect(error.correlationId).toBeUndefined();
+    expect(error.message).not.toContain('Correlation-ID');
+  });
+
+  test('surfaces the correlation ID when a successful response body fails to parse', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 200,
+        content: 'not json',
+        headers: { 'correlation-id': 'abc123def45' },
+        isTimedOut: false,
+      }),
+    });
+
+    const error: DeserializationError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(DeserializationError);
+    expect(error.correlationId).toBe('abc123def45');
+    expect(error.message).toContain('(Correlation-ID: abc123def45)');
+  });
+
+  test('omits the correlation ID from a parse failure when the header is absent', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 200,
+        content: 'not json',
+        headers: {},
+        isTimedOut: false,
+      }),
+    });
+
+    const error: DeserializationError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(DeserializationError);
     expect(error.correlationId).toBeUndefined();
     expect(error.message).not.toContain('Correlation-ID');
   });

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from 'vitest';
+import { createMemoryCache, createNullCache } from '../../cache';
+import { createNullLogger } from '../../logger';
+import { ApiError, DetailedApiError, RetryError, createTransporter } from '../../transporter';
+import type { AlgoliaAgent, Requester, Transporter } from '../../types';
+
+describe('correlation ID on errors', () => {
+  const algoliaAgent: AlgoliaAgent = {
+    value: 'test',
+    add: () => algoliaAgent,
+  };
+
+  function createTestTransporter(requester: Requester, hostCount = 1): Transporter {
+    return createTransporter({
+      hosts: Array.from({ length: hostCount }, (_, i) => ({
+        url: `localhost-${i}`,
+        accept: 'readWrite',
+        protocol: 'https',
+      })),
+      hostsCache: createNullCache(),
+      baseHeaders: {},
+      baseQueryParameters: {},
+      algoliaAgent,
+      logger: createNullLogger(),
+      timeouts: {
+        connect: 1000,
+        read: 2000,
+        write: 3000,
+      },
+      requester,
+      requestsCache: createMemoryCache(),
+      responsesCache: createMemoryCache(),
+    });
+  }
+
+  const request = {
+    method: 'GET',
+    path: '/test',
+    queryParameters: {},
+    headers: {},
+  } as const;
+
+  test('exposes the correlation ID on 4xx errors and appends it to the message', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 403,
+        content: JSON.stringify({ message: 'Invalid API key', status: 403 }),
+        headers: { 'correlation-id': 'abc123def45' },
+        isTimedOut: false,
+      }),
+    });
+
+    const error: ApiError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.correlationId).toBe('abc123def45');
+    expect(error.message).toBe('Invalid API key (Correlation-ID: abc123def45)');
+    expect(error.status).toBe(403);
+  });
+
+  test('leaves errors byte-identical to today when the header is absent', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 403,
+        content: JSON.stringify({ message: 'Invalid API key', status: 403 }),
+        headers: {},
+        isTimedOut: false,
+      }),
+    });
+
+    const error: ApiError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.correlationId).toBeUndefined();
+    expect(error.message).toBe('Invalid API key');
+  });
+
+  test('reads the header case-insensitively from custom requesters', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 400,
+        content: JSON.stringify({ message: 'Bad request', status: 400 }),
+        headers: { 'Correlation-ID': 'abc123def45' },
+        isTimedOut: false,
+      }),
+    });
+
+    await expect(transporter.request(request)).rejects.toMatchObject({
+      correlationId: 'abc123def45',
+    });
+  });
+
+  test('threads the correlation ID through detailed errors', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 400,
+        content: JSON.stringify({ message: 'Invalid request', status: 400, error: { code: 'invalid_request' } }),
+        headers: { 'correlation-id': 'abc123def45' },
+        isTimedOut: false,
+      }),
+    });
+
+    const error: DetailedApiError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(DetailedApiError);
+    expect(error.correlationId).toBe('abc123def45');
+    expect(error.error).toEqual({ code: 'invalid_request' });
+  });
+
+  test('never reads the unrelated edge X-Algolia-RequestID header', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 403,
+        content: JSON.stringify({ message: 'Invalid API key', status: 403 }),
+        headers: { 'x-algolia-requestid': 'edge-pop-id' },
+        isTimedOut: false,
+      }),
+    });
+
+    const error: ApiError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error.correlationId).toBeUndefined();
+    expect(error.message).toBe('Invalid API key');
+  });
+
+  test('surfaces the last-seen correlation ID when all hosts are exhausted', async () => {
+    let attempt = 0;
+    const transporter = createTestTransporter(
+      {
+        send: async () => {
+          attempt++;
+          return {
+            status: 500,
+            content: JSON.stringify({ message: 'Internal error', status: 500 }),
+            headers: { 'correlation-id': `cid-attempt-${attempt}` },
+            isTimedOut: false,
+          };
+        },
+      },
+      2,
+    );
+
+    const error: RetryError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(RetryError);
+    expect(attempt).toBe(2);
+    expect(error.correlationId).toBe('cid-attempt-2');
+    expect(error.message).toContain('Unreachable hosts');
+    expect(error.message).toContain('(Correlation-ID: cid-attempt-2)');
+  });
+
+  test('carries no correlation ID when every attempt times out', async () => {
+    const transporter = createTestTransporter(
+      {
+        send: async () => ({
+          status: 0,
+          content: '',
+          isTimedOut: true,
+        }),
+      },
+      2,
+    );
+
+    const error: RetryError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(RetryError);
+    expect(error.correlationId).toBeUndefined();
+    expect(error.message).not.toContain('Correlation-ID');
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestId.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestId.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { generateRequestId } from '../../transporter';
+
+describe('generateRequestId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('matches the 11-char base62 format', () => {
+    for (let i = 0; i < 1000; i++) {
+      expect(generateRequestId()).toMatch(/^[0-9A-Za-z]{11}$/);
+    }
+  });
+
+  test('generates distinct values across calls', () => {
+    const ids = new Set(Array.from({ length: 10000 }, () => generateRequestId()));
+
+    expect(ids.size).toBe(10000);
+  });
+
+  test('uses crypto.getRandomValues when available', () => {
+    const getRandomValues = vi.fn((bytes: Uint8Array) => bytes.fill(0));
+    vi.stubGlobal('crypto', { getRandomValues });
+
+    expect(generateRequestId()).toBe('AAAAAAAAAAA');
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to Math.random when the crypto global is absent', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    for (let i = 0; i < 1000; i++) {
+      expect(generateRequestId()).toMatch(/^[0-9A-Za-z]{11}$/);
+    }
+  });
+
+  test('generates distinct values without the crypto global', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    const ids = new Set(Array.from({ length: 10000 }, () => generateRequestId()));
+
+    expect(ids.size).toBe(10000);
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestId.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestId.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { generateRequestId } from '../../transporter';
+import { generateRequestId, withRequestId } from '../../transporter';
 
 describe('generateRequestId', () => {
   afterEach(() => {
@@ -40,5 +40,106 @@ describe('generateRequestId', () => {
     const ids = new Set(Array.from({ length: 10000 }, () => generateRequestId()));
 
     expect(ids.size).toBe(10000);
+  });
+});
+
+describe('withRequestId', () => {
+  const transporter = (requestIdChannel?: 'headers' | 'queryParameters') => ({
+    requestIdChannel,
+    baseHeaders: {},
+    baseQueryParameters: {},
+  });
+
+  test('returns the options unchanged when the channel is off', () => {
+    const requestOptions = { headers: { 'x-custom': 'value' } };
+
+    expect(withRequestId(transporter(undefined), requestOptions)).toBe(requestOptions);
+    expect(withRequestId(transporter(undefined), undefined)).toBeUndefined();
+  });
+
+  test('adds a request-id header on the headers channel', () => {
+    const requestOptions = withRequestId(transporter('headers'), { headers: { 'x-custom': 'value' } });
+
+    expect(requestOptions?.headers).toMatchObject({
+      'x-custom': 'value',
+      'request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
+    });
+    expect(requestOptions?.queryParameters).toBeUndefined();
+  });
+
+  test('adds an x-algolia-request-id query parameter on the queryParameters channel', () => {
+    const requestOptions = withRequestId(transporter('queryParameters'), undefined);
+
+    expect(requestOptions?.queryParameters).toMatchObject({
+      'x-algolia-request-id': expect.stringMatching(/^[0-9A-Za-z]{11}$/),
+    });
+    expect(requestOptions?.headers).toBeUndefined();
+  });
+
+  test('creates the options when none are given', () => {
+    expect(withRequestId(transporter('headers'), undefined)?.headers?.['request-id']).toMatch(/^[0-9A-Za-z]{11}$/);
+  });
+
+  test('preserves the other request options', () => {
+    const requestOptions = withRequestId(transporter('headers'), {
+      timeouts: { read: 10 },
+      queryParameters: { forwardToReplicas: 'true' },
+      cacheable: false,
+    });
+
+    expect(requestOptions).toMatchObject({
+      timeouts: { read: 10 },
+      queryParameters: { forwardToReplicas: 'true' },
+      cacheable: false,
+    });
+  });
+
+  test('generates a distinct ID per call', () => {
+    const first = withRequestId(transporter('headers'), undefined)?.headers?.['request-id'];
+    const second = withRequestId(transporter('headers'), undefined)?.headers?.['request-id'];
+
+    expect(first).not.toBe(second);
+  });
+
+  test('keeps a caller-supplied request-id header, case-insensitively', () => {
+    const requestOptions = { headers: { 'Request-ID': 'CallerChose' } };
+
+    expect(withRequestId(transporter('headers'), requestOptions)).toBe(requestOptions);
+    expect(withRequestId(transporter('queryParameters'), requestOptions)).toBe(requestOptions);
+  });
+
+  test('keeps a caller-supplied x-algolia-request-id query parameter', () => {
+    const requestOptions = { queryParameters: { 'x-algolia-request-id': 'CallerChose' } };
+
+    expect(withRequestId(transporter('headers'), requestOptions)).toBe(requestOptions);
+    expect(withRequestId(transporter('queryParameters'), requestOptions)).toBe(requestOptions);
+  });
+
+  test('is a no-op on its own output, so nested helpers share one ID', () => {
+    const requestOptions = withRequestId(transporter('headers'), undefined);
+
+    expect(withRequestId(transporter('headers'), requestOptions)).toBe(requestOptions);
+  });
+
+  test('respects a request-id set in the transporter base headers', () => {
+    const requestOptions = withRequestId(
+      { requestIdChannel: 'headers', baseHeaders: { 'Request-ID': 'BaseChose' }, baseQueryParameters: {} },
+      undefined,
+    );
+
+    expect(requestOptions).toBeUndefined();
+  });
+
+  test('respects an x-algolia-request-id set in the transporter base query parameters', () => {
+    const requestOptions = withRequestId(
+      {
+        requestIdChannel: 'queryParameters',
+        baseHeaders: {},
+        baseQueryParameters: { 'x-algolia-request-id': 'BaseChose' },
+      },
+      undefined,
+    );
+
+    expect(requestOptions).toBeUndefined();
   });
 });

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'vitest';
+import { createMemoryCache, createNullCache } from '../../cache';
+import { createNullLogger } from '../../logger';
+import { createTransporter } from '../../transporter';
+import type { AlgoliaAgent, EndRequest, Requester, TransporterOptions, TransporterWithHttpInfo } from '../../types';
+
+const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
+
+describe('request ID channel', () => {
+  const algoliaAgent: AlgoliaAgent = {
+    value: 'test',
+    add: () => algoliaAgent,
+  };
+
+  function createTestTransporter(
+    requester: Requester,
+    options: Partial<TransporterOptions> = {},
+  ): TransporterWithHttpInfo {
+    return createTransporter({
+      hosts: [{ url: 'localhost', accept: 'readWrite', protocol: 'https' }],
+      hostsCache: createNullCache(),
+      baseHeaders: {},
+      baseQueryParameters: {},
+      algoliaAgent,
+      logger: createNullLogger(),
+      timeouts: {
+        connect: 1000,
+        read: 2000,
+        write: 3000,
+      },
+      requester,
+      requestsCache: createMemoryCache({ serializable: false }),
+      responsesCache: createMemoryCache(),
+      ...options,
+    });
+  }
+
+  function createEchoRequester(): { requester: Requester; requests: EndRequest[] } {
+    const requests: EndRequest[] = [];
+
+    return {
+      requests,
+      requester: {
+        send: async (endRequest) => {
+          requests.push(endRequest);
+          return { status: 200, content: '{}', isTimedOut: false };
+        },
+      },
+    };
+  }
+
+  function sentQueryParameterId(endRequest: EndRequest): string | null {
+    return new URL(endRequest.url).searchParams.get('x-algolia-request-id');
+  }
+
+  const request = {
+    method: 'GET',
+    path: '/test',
+    queryParameters: {},
+    headers: {},
+  } as const;
+
+  test('sends no request ID when no channel is configured', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester);
+
+    await transporter.request(request);
+
+    expect(requests[0].headers['request-id']).toBeUndefined();
+    expect(sentQueryParameterId(requests[0])).toBeNull();
+  });
+
+  test('sends the request ID as a header on the headers channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request);
+
+    expect(requests[0].headers['request-id']).toMatch(REQUEST_ID_FORMAT);
+    expect(sentQueryParameterId(requests[0])).toBeNull();
+  });
+
+  test('sends the request ID as a query parameter on the queryParameters channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });
+
+    await transporter.request(request);
+
+    expect(sentQueryParameterId(requests[0])).toMatch(REQUEST_ID_FORMAT);
+    expect(requests[0].headers['request-id']).toBeUndefined();
+  });
+
+  test('reuses the ID across retry attempts and mints a fresh one per call', async () => {
+    const requests: EndRequest[] = [];
+    let sendCount = 0;
+    const requester: Requester = {
+      send: async (endRequest) => {
+        requests.push(endRequest);
+        sendCount++;
+        if (sendCount === 1) {
+          return { status: 500, content: JSON.stringify({ message: 'error', status: 500 }), isTimedOut: false };
+        }
+        return { status: 200, content: '{}', isTimedOut: false };
+      },
+    };
+    const transporter = createTestTransporter(requester, {
+      hosts: [
+        { url: 'localhost-1', accept: 'readWrite', protocol: 'https' },
+        { url: 'localhost-2', accept: 'readWrite', protocol: 'https' },
+      ],
+      requestIdChannel: 'headers',
+    });
+
+    await transporter.request(request);
+
+    expect(requests).toHaveLength(2);
+    const firstCallId = requests[0].headers['request-id'];
+    expect(firstCallId).toMatch(REQUEST_ID_FORMAT);
+    expect(requests[1].headers['request-id']).toBe(firstCallId);
+
+    await transporter.request(request);
+
+    expect(requests).toHaveLength(3);
+    expect(requests[2].headers['request-id']).toMatch(REQUEST_ID_FORMAT);
+    expect(requests[2].headers['request-id']).not.toBe(firstCallId);
+  });
+
+  test('preserves a caller-supplied Request-ID header', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request, { headers: { 'Request-ID': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBe('callerSuppl1');
+  });
+
+  test('never mints when the caller supplied a header, even on the queryParameters channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });
+
+    await transporter.request(request, { headers: { 'Request-ID': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBe('callerSuppl1');
+    expect(sentQueryParameterId(requests[0])).toBeNull();
+  });
+
+  test('preserves a caller-supplied x-algolia-request-id query parameter', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });
+
+    await transporter.request(request, { queryParameters: { 'x-algolia-request-id': 'callerSuppl1' } });
+
+    expect(sentQueryParameterId(requests[0])).toBe('callerSuppl1');
+    expect(requests[0].headers['request-id']).toBeUndefined();
+  });
+
+  test('leaves the cache key unchanged so cacheable calls still hit the cache', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });
+    const cacheableRequest = { ...request, cacheable: true };
+
+    await transporter.request(cacheableRequest);
+    await transporter.request(cacheableRequest);
+
+    expect(requests).toHaveLength(1);
+  });
+
+  test('shares one wire request and one ID between deduplicated concurrent calls', async () => {
+    const requests: EndRequest[] = [];
+    const requester: Requester = {
+      send: async (endRequest) => {
+        requests.push(endRequest);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { status: 200, content: '{}', isTimedOut: false };
+      },
+    };
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+    const cacheableRequest = { ...request, cacheable: true };
+
+    await Promise.all([transporter.request(cacheableRequest), transporter.request(cacheableRequest)]);
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers['request-id']).toMatch(REQUEST_ID_FORMAT);
+  });
+
+  test('sends the request ID on requestWithHttpInfo', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.requestWithHttpInfo(request);
+
+    expect(requests[0].headers['request-id']).toMatch(REQUEST_ID_FORMAT);
+  });
+
+  test('sends the request ID on streamed requests', async () => {
+    const requests: EndRequest[] = [];
+    const requester: Requester = {
+      send: async () => ({ status: 200, content: '{}', isTimedOut: false }),
+      sendStream: async (endRequest) => {
+        requests.push(endRequest);
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        });
+      },
+    };
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.requestStream(request).next();
+
+    expect(requests[0].headers['request-id']).toMatch(REQUEST_ID_FORMAT);
+  });
+});

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
@@ -154,6 +154,25 @@ describe('request ID channel', () => {
     expect(requests[0].headers['request-id']).toBeUndefined();
   });
 
+  test('never mints when the caller supplied a query parameter, even on the headers channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request, { queryParameters: { 'x-algolia-request-id': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBeUndefined();
+    expect(sentQueryParameterId(requests[0])).toBe('callerSuppl1');
+  });
+
+  test('detects a caller-supplied query parameter case-insensitively on the headers channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request, { queryParameters: { 'X-Algolia-Request-Id': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBeUndefined();
+  });
+
   test('leaves the cache key unchanged so cacheable calls still hit the cache', async () => {
     const { requester, requests } = createEchoRequester();
     const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/withHttpInfo.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/withHttpInfo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { createMemoryCache, createNullCache } from '../../cache';
 import { createNullLogger } from '../../logger';
-import { ApiError, DetailedApiError, createTransporter } from '../../transporter';
+import { DetailedApiError, createTransporter } from '../../transporter';
 import type { AlgoliaAgent, Requester, TransporterWithHttpInfo } from '../../types';
 
 describe('transporter requestWithHttpInfo', () => {
@@ -120,8 +120,16 @@ describe('transporter requestWithHttpInfo', () => {
       headers: {},
     } as const;
 
-    await expect(transporter.requestWithHttpInfo(request)).rejects.toThrow(new ApiError('Invalid API key', 403, []));
-    await expect(transporter.request(request)).rejects.toThrow(new ApiError('Invalid API key', 403, []));
+    await expect(transporter.requestWithHttpInfo(request)).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'Invalid API key',
+      status: 403,
+    });
+    await expect(transporter.request(request)).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'Invalid API key',
+      status: 403,
+    });
   });
 
   test('throws detailed errors when the response contains one', async () => {

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -19,6 +19,7 @@ import {
   deserializeFailure,
   deserializeSuccess,
   deserializeSuccessWithHttpInfo,
+  getLastCorrelationId,
   serializeData,
   serializeHeaders,
   serializeUrl,
@@ -157,7 +158,7 @@ export function createTransporter({
        */
       const host = retryableHosts.pop();
       if (host === undefined) {
-        throw new RetryError(stackTraceWithoutCredentials(stackTrace));
+        throw new RetryError(stackTraceWithoutCredentials(stackTrace), getLastCorrelationId(stackTrace));
       }
 
       const timeout = { ...timeouts, ...requestOptions.timeouts };

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -53,7 +53,7 @@ export function createTransporter({
     if (
       requestIdChannel === undefined ||
       headers['request-id'] !== undefined ||
-      queryParameters['x-algolia-request-id'] !== undefined
+      Object.keys(queryParameters).some((parameter) => parameter.toLowerCase() === 'x-algolia-request-id')
     ) {
       return;
     }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -3,6 +3,7 @@ import { iterSSEEvents } from '../sse';
 import type {
   AlgoliaHttpResponse,
   EndRequest,
+  Headers,
   Host,
   QueryParameters,
   Request,
@@ -24,6 +25,7 @@ import {
   serializeHeaders,
   serializeUrl,
 } from './helpers';
+import { generateRequestId } from './requestId';
 import { isRetryable, isSuccess } from './responses';
 import { stackFrameWithoutCredentials, stackTraceWithoutCredentials } from './stackTrace';
 
@@ -45,7 +47,24 @@ export function createTransporter({
   responsesCache,
   compress,
   compression,
+  requestIdChannel,
 }: TransporterOptions): TransporterWithHttpInfo {
+  function injectRequestId(headers: Headers, queryParameters: QueryParameters): void {
+    if (
+      requestIdChannel === undefined ||
+      headers['request-id'] !== undefined ||
+      queryParameters['x-algolia-request-id'] !== undefined
+    ) {
+      return;
+    }
+
+    if (requestIdChannel === 'headers') {
+      headers['request-id'] = generateRequestId();
+    } else {
+      queryParameters['x-algolia-request-id'] = generateRequestId();
+    }
+  }
+
   async function createRetryableOptions(compatibleHosts: Host[]): Promise<RetryableOptions> {
     const statefulHosts = await Promise.all(
       compatibleHosts.map((compatibleHost) => {
@@ -146,6 +165,8 @@ export function createTransporter({
         }
       }
     }
+
+    injectRequestId(headers, queryParameters);
 
     let timeoutsCount = 0;
 
@@ -387,6 +408,8 @@ export function createTransporter({
         }
       }
     }
+
+    injectRequestId(headers, queryParameters);
 
     const isRead = request.useReadTransporter || request.method === 'GET';
     const compatibleHosts = hosts.filter(

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts
@@ -443,6 +443,7 @@ export function createTransporter({
     algoliaAgent,
     baseHeaders,
     baseQueryParameters,
+    requestIdChannel,
     hosts,
     request: createRequest,
     requestWithHttpInfo: createRequestWithHttpInfo,

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -33,19 +33,23 @@ export class IndexAlreadyExistsError extends AlgoliaError {
 export class ErrorWithStackTrace extends AlgoliaError {
   stackTrace: StackFrame[];
 
-  constructor(message: string, stackTrace: StackFrame[], name: string) {
-    super(message, name);
+  correlationId?: string | undefined;
+
+  constructor(message: string, stackTrace: StackFrame[], name: string, correlationId?: string | undefined) {
+    super(correlationId ? `${message} (Correlation-ID: ${correlationId})` : message, name);
     // the array and object should be frozen to reflect the stackTrace at the time of the error
     this.stackTrace = stackTrace;
+    this.correlationId = correlationId;
   }
 }
 
 export class RetryError extends ErrorWithStackTrace {
-  constructor(stackTrace: StackFrame[]) {
+  constructor(stackTrace: StackFrame[], correlationId?: string | undefined) {
     super(
       'Unreachable hosts - your application id may be incorrect. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support',
       stackTrace,
       'RetryError',
+      correlationId,
     );
   }
 }
@@ -53,8 +57,14 @@ export class RetryError extends ErrorWithStackTrace {
 export class ApiError extends ErrorWithStackTrace {
   status: number;
 
-  constructor(message: string, status: number, stackTrace: StackFrame[], name = 'ApiError') {
-    super(message, stackTrace, name);
+  constructor(
+    message: string,
+    status: number,
+    stackTrace: StackFrame[],
+    name = 'ApiError',
+    correlationId?: string | undefined,
+  ) {
+    super(message, stackTrace, name, correlationId);
     this.status = status;
   }
 }
@@ -88,8 +98,14 @@ export type DetailedError = {
 export class DetailedApiError extends ApiError {
   error: DetailedError;
 
-  constructor(message: string, status: number, error: DetailedError, stackTrace: StackFrame[]) {
-    super(message, status, stackTrace, 'DetailedApiError');
+  constructor(
+    message: string,
+    status: number,
+    error: DetailedError,
+    stackTrace: StackFrame[],
+    correlationId?: string | undefined,
+  ) {
+    super(message, status, stackTrace, 'DetailedApiError', correlationId);
     this.error = error;
   }
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/errors.ts
@@ -72,9 +72,12 @@ export class ApiError extends ErrorWithStackTrace {
 export class DeserializationError extends AlgoliaError {
   response: Response;
 
-  constructor(message: string, response: Response) {
-    super(message, 'DeserializationError');
+  correlationId?: string | undefined;
+
+  constructor(message: string, response: Response, correlationId?: string | undefined) {
+    super(correlationId ? `${message} (Correlation-ID: ${correlationId})` : message, 'DeserializationError');
     this.response = response;
+    this.correlationId = correlationId;
   }
 }
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
@@ -92,7 +92,7 @@ export function deserializeSuccess<TObject>(response: Response): TObject {
   try {
     return JSON.parse(response.content);
   } catch (e) {
-    throw new DeserializationError((e as Error).message, response);
+    throw new DeserializationError((e as Error).message, response, getCorrelationId(response.headers));
   }
 }
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/helpers.ts
@@ -105,15 +105,42 @@ export function deserializeSuccessWithHttpInfo<TData>(response: Response): Algol
   };
 }
 
-export function deserializeFailure({ content, status }: Response, stackFrame: StackFrame[]): Error {
+export function getCorrelationId(headers: Headers | undefined): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (headers['correlation-id'] !== undefined) {
+    return headers['correlation-id'];
+  }
+
+  const header = Object.keys(headers).find((key) => key.toLowerCase() === 'correlation-id');
+
+  return header === undefined ? undefined : headers[header];
+}
+
+export function getLastCorrelationId(stackTrace: StackFrame[]): string | undefined {
+  for (let i = stackTrace.length - 1; i >= 0; i--) {
+    const correlationId = getCorrelationId(stackTrace[i].response.headers);
+    if (correlationId !== undefined) {
+      return correlationId;
+    }
+  }
+
+  return undefined;
+}
+
+export function deserializeFailure(response: Response, stackFrame: StackFrame[]): Error {
+  const { content, status } = response;
+  const correlationId = getCorrelationId(response.headers);
   try {
     const parsed = JSON.parse(content);
     if ('error' in parsed) {
-      return new DetailedApiError(parsed.message, status, parsed.error, stackFrame);
+      return new DetailedApiError(parsed.message, status, parsed.error, stackFrame, correlationId);
     }
-    return new ApiError(parsed.message, status, stackFrame);
+    return new ApiError(parsed.message, status, stackFrame, 'ApiError', correlationId);
   } catch {
     // ..
   }
-  return new ApiError(content, status, stackFrame);
+  return new ApiError(content, status, stackFrame, 'ApiError', correlationId);
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/index.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/index.ts
@@ -3,5 +3,6 @@ export * from './createStatefulHost';
 export * from './createTransporter';
 export * from './errors';
 export * from './helpers';
+export * from './requestId';
 export * from './responses';
 export * from './stackTrace';

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
@@ -26,7 +26,8 @@ export function generateRequestId(): string {
 function hasRequestId(headers: Headers | undefined, queryParameters: QueryParameters | undefined): boolean {
   return (
     (headers !== undefined && Object.keys(headers).some((header) => header.toLowerCase() === 'request-id')) ||
-    queryParameters?.['x-algolia-request-id'] !== undefined
+    (queryParameters !== undefined &&
+      Object.keys(queryParameters).some((parameter) => parameter.toLowerCase() === 'x-algolia-request-id'))
   );
 }
 

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
@@ -1,0 +1,22 @@
+const BASE62_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const REQUEST_ID_LENGTH = 11;
+
+export function generateRequestId(): string {
+  let requestId = '';
+
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(REQUEST_ID_LENGTH);
+    globalThis.crypto.getRandomValues(bytes);
+    for (const byte of bytes) {
+      requestId += BASE62_CHARS[byte % BASE62_CHARS.length];
+    }
+
+    return requestId;
+  }
+
+  for (let i = 0; i < REQUEST_ID_LENGTH; i++) {
+    requestId += BASE62_CHARS[Math.floor(Math.random() * BASE62_CHARS.length)];
+  }
+
+  return requestId;
+}

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
@@ -34,7 +34,8 @@ function hasRequestId(headers: Headers | undefined, queryParameters: QueryParame
 /**
  * Returns request options carrying a Request-ID on the transporter's channel, so that every
  * request a multi-request helper performs shares the same ID. Returns the options unchanged
- * when the channel is off or when a Request-ID is already supplied.
+ * when the channel is off or when a Request-ID is already supplied. Never apply ahead of a
+ * cacheable operation: the ID enters the cache key and defeats caching and deduplication.
  */
 export function withRequestId(
   transporter: Pick<Transporter, 'requestIdChannel' | 'baseHeaders' | 'baseQueryParameters'>,

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/requestId.ts
@@ -1,3 +1,5 @@
+import type { Headers, QueryParameters, RequestOptions, Transporter } from '../types';
+
 const BASE62_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 const REQUEST_ID_LENGTH = 11;
 
@@ -19,4 +21,38 @@ export function generateRequestId(): string {
   }
 
   return requestId;
+}
+
+function hasRequestId(headers: Headers | undefined, queryParameters: QueryParameters | undefined): boolean {
+  return (
+    (headers !== undefined && Object.keys(headers).some((header) => header.toLowerCase() === 'request-id')) ||
+    queryParameters?.['x-algolia-request-id'] !== undefined
+  );
+}
+
+/**
+ * Returns request options carrying a Request-ID on the transporter's channel, so that every
+ * request a multi-request helper performs shares the same ID. Returns the options unchanged
+ * when the channel is off or when a Request-ID is already supplied.
+ */
+export function withRequestId(
+  transporter: Pick<Transporter, 'requestIdChannel' | 'baseHeaders' | 'baseQueryParameters'>,
+  requestOptions?: RequestOptions | undefined,
+): RequestOptions | undefined {
+  if (
+    transporter.requestIdChannel === undefined ||
+    hasRequestId(transporter.baseHeaders, transporter.baseQueryParameters) ||
+    hasRequestId(requestOptions?.headers, requestOptions?.queryParameters)
+  ) {
+    return requestOptions;
+  }
+
+  if (transporter.requestIdChannel === 'headers') {
+    return { ...requestOptions, headers: { ...requestOptions?.headers, 'request-id': generateRequestId() } };
+  }
+
+  return {
+    ...requestOptions,
+    queryParameters: { ...requestOptions?.queryParameters, 'x-algolia-request-id': generateRequestId() },
+  };
 }

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/types/transporter.ts
@@ -162,6 +162,13 @@ export type TransporterOptions = {
   compress?: (data: string) => Promise<Uint8Array>;
 
   compression?: 'gzip';
+
+  /**
+   * Where the generated Request-ID is sent: as the `Request-ID` header, or as the
+   * `x-algolia-request-id` query parameter. When undefined, no Request-ID is sent.
+   * A caller-supplied Request-ID is never overwritten.
+   */
+  requestIdChannel?: 'headers' | 'queryParameters' | undefined;
 };
 
 export type Transporter = TransporterOptions & {

--- a/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
             'src/__tests__/sse.test.ts',
             'src/__tests__/transporter/cache.test.ts',
             'src/__tests__/transporter/compression.test.ts',
+            'src/__tests__/transporter/correlationId.test.ts',
+            'src/__tests__/transporter/withHttpInfo.test.ts',
           ],
           name: 'node',
           environment: 'node',

--- a/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
             'src/__tests__/transporter/cache.test.ts',
             'src/__tests__/transporter/compression.test.ts',
             'src/__tests__/transporter/correlationId.test.ts',
+            'src/__tests__/transporter/requestId.test.ts',
             'src/__tests__/transporter/withHttpInfo.test.ts',
           ],
           name: 'node',

--- a/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
             'src/__tests__/transporter/compression.test.ts',
             'src/__tests__/transporter/correlationId.test.ts',
             'src/__tests__/transporter/requestId.test.ts',
+            'src/__tests__/transporter/requestIdChannel.test.ts',
             'src/__tests__/transporter/withHttpInfo.test.ts',
           ],
           name: 'node',

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaJavascriptGenerator.java
@@ -157,6 +157,10 @@ public class AlgoliaJavascriptGenerator extends TypeScriptNodeClientCodegen {
     additionalProperties.put("is" + Helpers.capitalize(Helpers.camelize((String) additionalProperties.get("client"))) + "Client", true);
     additionalProperties.put("isSearchClient", CLIENT.equals("search") || isAlgoliasearchClient);
     additionalProperties.put("isAlgoliasearchClient", isAlgoliasearchClient);
+    additionalProperties.put(
+      "requestIdSupport",
+      CLIENT.equals("search") || CLIENT.equals("recommend") || CLIENT.equals("composition") || isAlgoliasearchClient
+    );
     additionalProperties.put("packageVersion", Helpers.getPackageJsonVersion(packageName));
     additionalProperties.put("packageName", packageName);
     additionalProperties.put("npmPackageName", isAlgoliasearchClient ? packageName : "@algolia/" + packageName);

--- a/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/AlgoliaCTSGenerator.java
@@ -147,6 +147,10 @@ public class AlgoliaCTSGenerator extends DefaultCodegen {
       bundle.put("mode", mode);
       bundle.put("is" + Helpers.capitalize(Helpers.camelize(client)) + "Client", true);
       bundle.put("isSearchClient", client.contains("search")); // just so algoliasearch is treated as a search client too
+      bundle.put(
+        "requestIdSupport",
+        client.equals("search") || client.equals("recommend") || client.equals("composition") || client.equals("algoliasearch")
+      );
       bundle.put("client", Helpers.createClientName(importClientName, language) + "Client");
       bundle.put("clientPrefix", Helpers.createClientName(importClientName, language));
       bundle.put("hasRegionalHost", hasRegionalHost);

--- a/templates/javascript/clients/algoliasearch/builds/definition.mustache
+++ b/templates/javascript/clients/algoliasearch/builds/definition.mustache
@@ -1,6 +1,6 @@
 // {{{generationBanner}}}
 
-import { createIterablePromise, DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES, logWarning } from '@algolia/client-common';
+import { createIterablePromise, DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES, logWarning, withRequestId } from '@algolia/client-common';
 import type { ApiError, ClientOptions, RequestOptions } from '@algolia/client-common';
 
 {{#dependencies}}
@@ -158,6 +158,8 @@ export function algoliasearch(
         throw new Error('`transformationOptions` must be set in the client config before calling this method. It defaults to the Ingestion API defaults. See https://www.algolia.com/doc/libraries/sdk/methods/ingestion/');
       }
 
+      const searchRequestOptions = withRequestId(client.transporter, requestOptions);
+
       if (objects.length === 0) {
         logWarning(client.transporter.logger, `replaceAllObjectsWithTransformation was called with an empty list of objects, which will delete all records currently in the "${indexName}" index.`);
       }
@@ -179,7 +181,7 @@ export function algoliasearch(
               scope: scopes,
             },
           },
-          requestOptions,
+          searchRequestOptions,
         );
 
         const watchResponses = await ingestionTransporter.chunkedPush(
@@ -191,7 +193,7 @@ export function algoliasearch(
           indexName: tmpIndexName,
           taskID: copyOperationResponse.taskID,
           maxRetries,
-        });
+        }, searchRequestOptions);
 
         copyOperationResponse = await this.operationIndex(
           {
@@ -202,30 +204,30 @@ export function algoliasearch(
               scope: scopes,
             },
           },
-          requestOptions,
+          searchRequestOptions,
         );
         await this.waitForTask({
           indexName: tmpIndexName,
           taskID: copyOperationResponse.taskID,
           maxRetries,
-        });
+        }, searchRequestOptions);
 
         const moveOperationResponse = await this.operationIndex(
           {
             indexName: tmpIndexName,
             operationIndexParams: { operation: 'move', destination: indexName },
           },
-          requestOptions,
+          searchRequestOptions,
         );
         await this.waitForTask({
           indexName: tmpIndexName,
           taskID: moveOperationResponse.taskID,
           maxRetries,
-        });
+        }, searchRequestOptions);
 
         return { copyOperationResponse, watchResponses, moveOperationResponse };
       } catch (error) {
-        await this.deleteIndex({ indexName: tmpIndexName });
+        await this.deleteIndex({ indexName: tmpIndexName }, searchRequestOptions);
 
         throw error;
       }

--- a/templates/javascript/clients/client/api/compositionHelpers.mustache
+++ b/templates/javascript/clients/client/api/compositionHelpers.mustache
@@ -19,6 +19,7 @@ waitForCompositionTask(
   }: WaitForCompositionTaskOptions,
   requestOptions?: RequestOptions
 ): Promise<GetTaskResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
   let retryCount = 0;
 
   return createIterablePromise({

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -20,6 +20,7 @@ waitForTask(
   }: WaitForTaskOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<GetTaskResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
   let retryCount = 0;
 
   return createIterablePromise({
@@ -54,6 +55,7 @@ waitForAppTask(
   }: WaitForAppTaskOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<GetTaskResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
   let retryCount = 0;
 
   return createIterablePromise({
@@ -92,6 +94,7 @@ waitForApiKey(
   }: WaitForApiKeyOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<GetApiKeyResponse | undefined> {
+  requestOptions = withRequestId(transporter, requestOptions);
   let retryCount = 0;
   const baseIteratorOptions: IterableOptions<
     GetApiKeyResponse | undefined
@@ -169,6 +172,8 @@ browseObjects<T>(
   }: BrowseOptions<BrowseResponse<T>> & BrowseProps,
   requestOptions?: RequestOptions | undefined
 ): Promise<BrowseResponse<T>> {
+  requestOptions = withRequestId(transporter, requestOptions);
+
   return createIterablePromise<BrowseResponse<T>>({
     func: (previousResponse) => {
       return this.browse(
@@ -207,6 +212,7 @@ browseRules(
   }: BrowseOptions<SearchRulesResponse> & SearchRulesProps,
   requestOptions?: RequestOptions | undefined
 ): Promise<SearchRulesResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
   const params = {
     ...searchRulesParams,
     hitsPerPage: searchRulesParams?.hitsPerPage || 1000,
@@ -251,6 +257,7 @@ browseSynonyms(
   }: BrowseOptions<SearchSynonymsResponse> & SearchSynonymsProps,
   requestOptions?: RequestOptions | undefined
 ): Promise<SearchSynonymsResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
   const params = {
     ...searchSynonymsParams,
     page: searchSynonymsParams?.page || 0,
@@ -291,6 +298,7 @@ browseSynonyms(
  * @param requestOptions - The requestOptions to send along with the query, they will be forwarded to the `getTask` method and merged with the transporter requestOptions.
  */
 async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, batchSize = 1000, maxRetries = 100 }: ChunkedBatchOptions, requestOptions?: RequestOptions): Promise<Array<BatchResponse>> {
+  requestOptions = withRequestId(transporter, requestOptions);
   let requests: Array<BatchRequest> = [];
   const responses: Array<BatchResponse> = [];
 
@@ -305,7 +313,7 @@ async chunkedBatch({ indexName, objects, action = 'addObject', waitForTasks, bat
 
   if (waitForTasks) {
     for (const resp of responses) {
-      await this.waitForTask({indexName, taskID: resp.taskID, maxRetries});
+      await this.waitForTask({indexName, taskID: resp.taskID, maxRetries}, requestOptions);
     }
   }
 
@@ -414,6 +422,8 @@ async replaceAllObjects(
   { indexName, objects, batchSize, scopes, maxRetries = DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES }: ReplaceAllObjectsOptions,
   requestOptions?: RequestOptions | undefined
 ): Promise<ReplaceAllObjectsResponse> {
+  requestOptions = withRequestId(transporter, requestOptions);
+
   if (objects.length === 0) {
     logWarning(transporter.logger, `replaceAllObjects was called with an empty list of objects, which will delete all records currently in the "${indexName}" index.`);
   }
@@ -447,7 +457,7 @@ async replaceAllObjects(
       indexName: tmpIndexName,
       taskID: copyOperationResponse.taskID,
       maxRetries,
-    });
+    }, requestOptions);
 
     copyOperationResponse = await this.operationIndex(
       {
@@ -464,7 +474,7 @@ async replaceAllObjects(
       indexName: tmpIndexName,
       taskID: copyOperationResponse.taskID,
       maxRetries,
-    });
+    }, requestOptions);
 
     const moveOperationResponse = await this.operationIndex(
       {
@@ -477,11 +487,11 @@ async replaceAllObjects(
       indexName: tmpIndexName,
       taskID: moveOperationResponse.taskID,
       maxRetries,
-    });
+    }, requestOptions);
 
     return { copyOperationResponse, batchResponses, moveOperationResponse };
   } catch (error) {
-    await this.deleteIndex({ indexName: tmpIndexName });
+    await this.deleteIndex({ indexName: tmpIndexName }, requestOptions);
 
     throw error;
   }

--- a/templates/javascript/clients/client/api/helpers.mustache
+++ b/templates/javascript/clients/client/api/helpers.mustache
@@ -497,9 +497,9 @@ async replaceAllObjects(
   }
 },
 
-async indexExists({ indexName }: GetSettingsProps): Promise<boolean> {
+async indexExists({ indexName }: GetSettingsProps, requestOptions?: RequestOptions | undefined): Promise<boolean> {
   try {
-    await this.getSettings({ indexName });
+    await this.getSettings({ indexName }, requestOptions);
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       return false;

--- a/templates/javascript/clients/client/api/imports.mustache
+++ b/templates/javascript/clients/client/api/imports.mustache
@@ -11,9 +11,11 @@ import {
   serializeQueryParameters,
   createIterablePromise,
   logWarning,
+  withRequestId,
   {{/isSearchClient}}
   {{#isCompositionClient}}
   createIterablePromise,
+  withRequestId,
   {{/isCompositionClient}}
   {{#isIngestionClient}}
   createIterablePromise,

--- a/templates/javascript/clients/client/api/nodeHelpers.mustache
+++ b/templates/javascript/clients/client/api/nodeHelpers.mustache
@@ -53,13 +53,14 @@ async accountCopyIndex(
   { sourceIndexName, destinationAppID, destinationApiKey, destinationIndexName, batchSize, maxRetries = 100 }: AccountCopyIndexOptions,
   requestOptions?: RequestOptions | undefined,
 ): Promise<void> {
+  requestOptions = withRequestId(this.transporter, requestOptions);
   const responses: Array<{ taskID: UpdatedAtResponse['taskID'] }> = [];
 
   if (this.appId === destinationAppID) {
     throw new IndicesInSameAppError();
   }
 
-  if (!(await this.indexExists({ indexName: sourceIndexName }))) {
+  if (!(await this.indexExists({ indexName: sourceIndexName }, requestOptions))) {
     throw new IndexNotFoundError(sourceIndexName);
   }
 
@@ -80,7 +81,7 @@ async accountCopyIndex(
     ...options,
   });
 
-  if (await destinationClient.indexExists({ indexName: destinationIndexName })) {
+  if (await destinationClient.indexExists({ indexName: destinationIndexName }, requestOptions)) {
     throw new IndexAlreadyExistsError(destinationIndexName);
   }
 
@@ -88,7 +89,7 @@ async accountCopyIndex(
     await destinationClient.setSettings(
       {
         indexName: destinationIndexName,
-        indexSettings: await this.getSettings({ indexName: sourceIndexName }),
+        indexSettings: await this.getSettings({ indexName: sourceIndexName }, requestOptions),
       },
       requestOptions,
     ),
@@ -104,7 +105,7 @@ async accountCopyIndex(
         ),
       );
     },
-  });
+  }, requestOptions);
 
   await this.browseSynonyms({
     indexName: sourceIndexName,
@@ -116,7 +117,7 @@ async accountCopyIndex(
         ),
       );
     },
-  });
+  }, requestOptions);
 
   await this.browseObjects({
     indexName: sourceIndexName,
@@ -129,9 +130,9 @@ async accountCopyIndex(
         )),
       );
     },
-  });
+  }, requestOptions);
 
   for (const response of responses) {
-    await destinationClient.waitForTask({ indexName: destinationIndexName, taskID: response.taskID, maxRetries });
+    await destinationClient.waitForTask({ indexName: destinationIndexName, taskID: response.taskID, maxRetries }, requestOptions);
   }
 },

--- a/templates/javascript/clients/client/builds/browser.mustache
+++ b/templates/javascript/clients/client/builds/browser.mustache
@@ -15,6 +15,9 @@
     requester: createXhrRequester(),
     algoliaAgents: [{ segment: 'Browser' }],
     authMode: 'Within{{#isCompositionClient}}Headers{{/isCompositionClient}}{{#isAdvancedPersonalizationClient}}Headers{{/isAdvancedPersonalizationClient}}{{^isAdvancedPersonalizationClient}}{{^isCompositionClient}}QueryParameters{{/isCompositionClient}}{{/isAdvancedPersonalizationClient}}',
+    {{#requestIdSupport}}
+    requestIdChannel: 'queryParameters',
+    {{/requestIdSupport}}
     responsesCache: createMemoryCache(),
     requestsCache: createMemoryCache({ serializable: false }),
     hostsCache: createFallbackableCache({

--- a/templates/javascript/clients/client/builds/definition.mustache
+++ b/templates/javascript/clients/client/builds/definition.mustache
@@ -10,7 +10,8 @@ import {
   createFallbackableCache,
   createBrowserLocalStorageCache,
   createNullCache,
-  serializeQueryParameters
+  serializeQueryParameters,
+  withRequestId
 } from '@algolia/client-common';
 
 import type { RequestOptions, ClientOptions } from '@algolia/client-common';

--- a/templates/javascript/clients/client/builds/fetch.mustache
+++ b/templates/javascript/clients/client/builds/fetch.mustache
@@ -24,6 +24,9 @@ import { createHmac } from 'node:crypto';
       logger: createNullLogger(),
       requester: createFetchRequester(),
       algoliaAgents: [{ segment: 'Fetch' }],
+      {{#requestIdSupport}}
+      requestIdChannel: 'queryParameters',
+      {{/requestIdSupport}}
       responsesCache: createNullCache(),
       requestsCache: createNullCache(),
       hostsCache: createMemoryCache(),

--- a/templates/javascript/clients/client/builds/liteNode.mustache
+++ b/templates/javascript/clients/client/builds/liteNode.mustache
@@ -16,6 +16,9 @@ export type {{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}} = ReturnTyp
     logger: createNullLogger(),
     requester: createHttpRequester(),
     algoliaAgents: [{ segment: 'Node.js', version: process.versions.node }],
+    {{#requestIdSupport}}
+    requestIdChannel: 'headers',
+    {{/requestIdSupport}}
     responsesCache: createNullCache(),
     requestsCache: createNullCache(),
       hostsCache: createMemoryCache(),

--- a/templates/javascript/clients/client/builds/node.mustache
+++ b/templates/javascript/clients/client/builds/node.mustache
@@ -24,6 +24,9 @@ import { createHmac } from 'node:crypto';
       logger: createNullLogger(),
       requester: createHttpRequester(),
       algoliaAgents: [{ segment: 'Node.js', version: process.versions.node }],
+      {{#requestIdSupport}}
+      requestIdChannel: 'headers',
+      {{/requestIdSupport}}
       responsesCache: createNullCache(),
       requestsCache: createNullCache(),
       hostsCache: createMemoryCache(),

--- a/templates/javascript/clients/client/builds/worker.mustache
+++ b/templates/javascript/clients/client/builds/worker.mustache
@@ -24,6 +24,9 @@ export type {{#lambda.titlecase}}{{clientName}}{{/lambda.titlecase}} = ReturnTyp
       logger: createNullLogger(),
       requester: createFetchRequester(),
       algoliaAgents: [{ segment: 'Worker' }],
+      {{#requestIdSupport}}
+      requestIdChannel: 'queryParameters',
+      {{/requestIdSupport}}
       responsesCache: createNullCache(),
       requestsCache: createNullCache(),
       hostsCache: createMemoryCache(),

--- a/templates/javascript/tests/client/client.mustache
+++ b/templates/javascript/tests/client/client.mustache
@@ -34,7 +34,8 @@ describe('init', () => {
     const headerResult = (await headerClient.customGet({
       path: '1/bar',
     })) as unknown as EchoResponse;
-    expect(headerResult.headers).toEqual({
+    const { 'request-id': requestId, ...headers } = headerResult.headers;
+    expect(headers).toEqual({
       accept: 'application/json',
       'content-type': 'text/plain',
       'x-algolia-api-key': 'bar',

--- a/templates/javascript/tests/client/client.mustache
+++ b/templates/javascript/tests/client/client.mustache
@@ -34,8 +34,14 @@ describe('init', () => {
     const headerResult = (await headerClient.customGet({
       path: '1/bar',
     })) as unknown as EchoResponse;
+    {{#requestIdSupport}}
     const { 'request-id': requestId, ...headers } = headerResult.headers;
+    expect(requestId).toMatch(/^[0-9A-Za-z]{11}$/);
     expect(headers).toEqual({
+    {{/requestIdSupport}}
+    {{^requestIdSupport}}
+    expect(headerResult.headers).toEqual({
+    {{/requestIdSupport}}
       accept: 'application/json',
       'content-type': 'text/plain',
       'x-algolia-api-key': 'bar',


### PR DESCRIPTION
## 🧭 What and Why

🎟 [API-516](https://algolia.atlassian.net/browse/API-516) (epic [API-515](https://algolia.atlassian.net/browse/API-515) · [spec](https://algolia.atlassian.net/wiki/spaces/APIC/pages/7352287252))

JavaScript reference implementation of the search clusters' tracing contract, reviewed by Engines before the 10 language ports.

- **Correlation-ID on errors** — every failed call exposes the server's `Correlation-ID` as `error.correlationId` and appended to the message: `Invalid API key (Correlation-ID: …)`. Customers can quote it to support without inspecting raw HTTP. Header absent → errors byte-identical to today.
- **Request-ID on requests** — the transporter mints an 11-char base62 ID once per call and resends the *same* value on every retry/host-fallback attempt, so one log search finds all attempts of one operation. Node builds send the `Request-ID` header; browser/fetch/worker builds (incl. lite) send the `x-algolia-request-id` query parameter, which never triggers a CORS preflight. A caller-supplied ID always wins, and minting happens after the cache/dedup boundary — cache keys and request deduplication are provably unchanged. Covers `request`, `requestWithHttpInfo` and `requestStream`.

Scoped via a `requestIdSupport` generator flag to **search, recommend, composition, algoliasearch (+lite)**; all other clients' generated code is untouched (their bundles grow ~0.25KB because `client-common` carries the plumbing — abtesting/recommend budgets bumped accordingly). Non-breaking: trailing optional params on the error classes, new optional `requestIdChannel` transporter option (`undefined` = off).

## 📋 Behavioral notes

- **Helpers now forward caller `requestOptions` to their internal calls.** The helper docstrings have always documented that `requestOptions` are forwarded to the `waitForTask`/`getTask` polls, and the batch writes inside `chunkedBatch`/`replaceAllObjects` already forwarded them — but the polls (and `replaceAllObjects`' failure-path `deleteIndex`, plus `indexExists` in `accountCopyIndex`) were called bare. They now receive the caller's `requestOptions`, which is also what lets one helper invocation share a single Request-ID. Side effect to be aware of: caller-supplied headers, query parameters and timeouts now apply to those internal requests too.
- **Error messages gain a suffix when the server returns a Correlation-ID.** Per the Engines contract, the CID is both a structured field *and* appended to `error.message`. Signatures and absent-header behavior are unchanged, but consumers matching exact message strings will see the suffix appear based on **server-side** header rollout, not client version — `error.correlationId` is the stable way to read it.

## 🧪 Test

- Unit tests across `client-common` and all `algoliasearch` builds: cache key unchanged, dedup shares one ID, same ID across retries, fresh per call, caller precedence, per-build channel, CID on 4xx/retry-exhaustion/timeout paths, edge `X-Algolia-RequestID` never read.
- Live check against a cloud-native app: the returned Correlation-ID ends with the exact 11-char `request-id` the client sent (suffix echo), and real API errors surface their CID.
- Drive-by: `withHttpInfo.test.ts` was never registered in `vitest.config.ts` — registered and its assertions fixed.


[API-516]: https://algolia.atlassian.net/browse/API-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[API-515]: https://algolia.atlassian.net/browse/API-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
