### PR TITLE
feat(cts): Request-ID/Correlation-ID CTS foundation

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/ResponseProp.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/ResponseProp.java
@@ -9,12 +9,15 @@ public class ResponseProp {
   @JsonDeserialize(using = RawDeserializer.class)
   public String body;
 
+  public String correlationIdSuffix;
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ResponseProp {\n");
     sb.append("    statusCode: ").append(statusCode).append("\n");
     sb.append("    body: ").append(body).append("\n");
+    sb.append("    correlationIdSuffix: ").append(correlationIdSuffix).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/SnippetsGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/SnippetsGenerator.java
@@ -75,6 +75,7 @@ public class SnippetsGenerator extends TestsGenerator {
             }
 
             Snippet newSnippet = new Snippet(step.method, test.testName, step.parameters, step.requestOptions);
+            newSnippet.skipLanguages = test.skipLanguages;
             Snippet[] existing = snippets.get(step.method);
             if (existing == null) {
               snippets.put(step.method, new Snippet[] { newSnippet });

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -6,6 +6,9 @@ import com.algolia.codegen.cts.manager.CTSManager;
 import com.algolia.codegen.exceptions.CTSException;
 import com.algolia.codegen.utils.*;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
@@ -64,6 +67,18 @@ public class TestsRequest extends TestsGenerator {
         return body.replace("$", "\\$");
       default:
         return body;
+    }
+  }
+
+  private boolean e2eTemplateRenders(String tag) {
+    Path e2eTemplate = Path.of("templates", language, "tests", "e2e", "e2e.mustache");
+    if (!Files.exists(e2eTemplate)) {
+      return true;
+    }
+    try {
+      return Files.readString(e2eTemplate).contains(tag);
+    } catch (IOException e) {
+      return false;
     }
   }
 
@@ -165,6 +180,18 @@ public class TestsRequest extends TestsGenerator {
 
           if (req.response != null) {
             req.response.body = escapeBody(req.response.body);
+            if (req.response.correlationIdSuffix != null && !e2eTemplateRenders("correlationIdSuffix")) {
+              throw new CTSException(
+                "the test asserts 'correlationIdSuffix' but templates/" +
+                  language +
+                  "/tests/e2e/e2e.mustache never references it, so the generated e2e test" +
+                  " would pass without asserting anything. Implement the" +
+                  " {{#correlationIdSuffix}} section (see" +
+                  " templates/javascript/tests/e2e/e2e.mustache) before removing '" +
+                  language +
+                  "' from skipLanguages."
+              );
+            }
             test.put("response", req.response);
           }
 

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -180,17 +180,33 @@ public class TestsRequest extends TestsGenerator {
 
           if (req.response != null) {
             req.response.body = escapeBody(req.response.body);
-            if (req.response.correlationIdSuffix != null && !e2eTemplateRenders("correlationIdSuffix")) {
-              throw new CTSException(
-                "the test asserts 'correlationIdSuffix' but templates/" +
-                  language +
-                  "/tests/e2e/e2e.mustache never references it, so the generated e2e test" +
-                  " would pass without asserting anything. Implement the" +
-                  " {{#correlationIdSuffix}} section (see" +
-                  " templates/javascript/tests/e2e/e2e.mustache) before removing '" +
-                  language +
-                  "' from skipLanguages."
-              );
+            if (req.response.correlationIdSuffix != null) {
+              if (req.request == null || !"GET".equals(req.request.method)) {
+                throw new CTSException(
+                  "'correlationIdSuffix' re-issues the request through the transporter to read" +
+                    " the response headers, so it only supports GET operations: anything else" +
+                    " would execute the operation twice."
+                );
+              }
+              if (req.request.queryParameters != null || (req.requestOptions != null && req.requestOptions.queryParameters != null)) {
+                throw new CTSException(
+                  "'correlationIdSuffix' re-issues the request with only the path and the" +
+                    " requestOptions headers: query parameters would be silently dropped from" +
+                    " the second call."
+                );
+              }
+              if (!e2eTemplateRenders("correlationIdSuffix")) {
+                throw new CTSException(
+                  "the test asserts 'correlationIdSuffix' but templates/" +
+                    language +
+                    "/tests/e2e/e2e.mustache never references it, so the generated e2e test" +
+                    " would pass without asserting anything. Implement the" +
+                    " {{#correlationIdSuffix}} section (see" +
+                    " templates/javascript/tests/e2e/e2e.mustache) before removing '" +
+                    language +
+                    "' from skipLanguages."
+                );
+              }
             }
             test.put("response", req.response);
           }

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -70,7 +70,7 @@ public class TestsRequest extends TestsGenerator {
     }
   }
 
-  private boolean e2eTemplateRenders(String tag) {
+  private boolean e2eTemplateRenders(String tag) throws CTSException {
     Path e2eTemplate = Path.of("templates", language, "tests", "e2e", "e2e.mustache");
     if (!Files.exists(e2eTemplate)) {
       return true;
@@ -78,7 +78,7 @@ public class TestsRequest extends TestsGenerator {
     try {
       return Files.readString(e2eTemplate).contains(tag);
     } catch (IOException e) {
-      return false;
+      throw new CTSException("failed to read " + e2eTemplate + " while validating '" + tag + "'", e);
     }
   }
 
@@ -193,6 +193,13 @@ public class TestsRequest extends TestsGenerator {
                   "'correlationIdSuffix' re-issues the request with only the path and the" +
                     " requestOptions headers: query parameters would be silently dropped from" +
                     " the second call."
+                );
+              }
+              if (!ope.headerParams.isEmpty()) {
+                throw new CTSException(
+                  "'correlationIdSuffix' re-issues the request with only the path and the" +
+                    " requestOptions headers: operation-level header parameters would be" +
+                    " silently dropped from the second call."
                 );
               }
               if (!e2eTemplateRenders("correlationIdSuffix")) {

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -5,6 +5,7 @@ import static org.openapitools.codegen.utils.StringUtils.camelize;
 import com.algolia.codegen.cts.manager.CTSManager;
 import com.algolia.codegen.exceptions.CTSException;
 import com.algolia.codegen.utils.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -193,18 +194,32 @@ public class TestsRequest extends TestsGenerator {
                     " would execute the operation twice."
                 );
               }
-              if (req.request.queryParameters != null || (req.requestOptions != null && req.requestOptions.queryParameters != null)) {
-                throw new CTSException(
-                  "'correlationIdSuffix' re-issues the request with only the path and the" +
-                    " requestOptions headers: query parameters would be silently dropped from" +
-                    " the second call."
-                );
+              Set<String> reissuedQueryParams =
+                req.requestOptions == null || req.requestOptions.queryParameters == null
+                  ? Set.of()
+                  : req.requestOptions.queryParameters.keySet();
+              if (req.request.queryParameters != null) {
+                Iterator<String> expectedQueryParams = new ObjectMapper().readTree(req.request.queryParameters).fieldNames();
+                while (expectedQueryParams.hasNext()) {
+                  String param = expectedQueryParams.next();
+                  if (!reissuedQueryParams.contains(param)) {
+                    throw new CTSException(
+                      "'correlationIdSuffix' re-issues the request with only the path, the" +
+                        " requestOptions headers and the requestOptions query parameters: the" +
+                        " '" +
+                        param +
+                        "' query parameter comes from the operation parameters and would be" +
+                        " silently dropped from the second call."
+                    );
+                  }
+                }
               }
               if (!ope.headerParams.isEmpty()) {
                 throw new CTSException(
-                  "'correlationIdSuffix' re-issues the request with only the path and the" +
-                    " requestOptions headers: operation-level header parameters would be" +
-                    " silently dropped from the second call."
+                  "'correlationIdSuffix' re-issues the request with only the path, the" +
+                    " requestOptions headers and the requestOptions query parameters:" +
+                    " operation-level header parameters would be silently dropped from the" +
+                    " second call."
                 );
               }
               if (!e2eTemplateRenders("correlationIdSuffix")) {

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -181,6 +181,11 @@ public class TestsRequest extends TestsGenerator {
           if (req.response != null) {
             req.response.body = escapeBody(req.response.body);
             if (req.response.correlationIdSuffix != null) {
+              if (req.response.correlationIdSuffix.isEmpty()) {
+                throw new CTSException(
+                  "'correlationIdSuffix' must not be empty: the generated 'endsWith' assertion" + " would always pass."
+                );
+              }
               if (req.request == null || !"GET".equals(req.request.method)) {
                 throw new CTSException(
                   "'correlationIdSuffix' re-issues the request through the transporter to read" +

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -18,6 +18,8 @@ import org.openapitools.codegen.SupportingFile;
 
 public class TestsRequest extends TestsGenerator {
 
+  private static final ObjectMapper JSON = new ObjectMapper();
+
   private final boolean withSyncTests;
   private List<SupportingFile> supportingFiles;
 
@@ -199,7 +201,7 @@ public class TestsRequest extends TestsGenerator {
                   ? Set.of()
                   : req.requestOptions.queryParameters.keySet();
               if (req.request.queryParameters != null) {
-                Iterator<String> expectedQueryParams = new ObjectMapper().readTree(req.request.queryParameters).fieldNames();
+                Iterator<String> expectedQueryParams = JSON.readTree(req.request.queryParameters).fieldNames();
                 while (expectedQueryParams.hasNext()) {
                   String param = expectedQueryParams.next();
                   if (!reissuedQueryParams.contains(param)) {

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -16,6 +16,7 @@ import { assertValidReplaceAllObjects } from './testServer/replaceAllObjects.ts'
 import { assertValidReplaceAllObjectsFailed } from './testServer/replaceAllObjectsFailed.ts';
 import { assertValidReplaceAllObjectsScopes } from './testServer/replaceAllObjectsScopes.ts';
 import { assertValidReplaceAllObjectsWithTransformation } from './testServer/replaceAllObjectsWithTransformation.ts';
+import { assertValidRequestIds } from './testServer/requestId.ts';
 import { assertSuccessServerCalled } from './testServer/success.ts';
 import { assertValidTimeouts } from './testServer/timeout.ts';
 import { assertValidWaitForApiKey } from './testServer/waitFor.ts';
@@ -191,6 +192,7 @@ export async function runCts(
     assertValidReplaceAllObjects(languages.length - skip('dart'));
     assertValidReplaceAllObjectsWithTransformation(languages.length);
     assertValidAccountCopyIndex(only('javascript'));
+    assertValidRequestIds(only('javascript'));
     assertValidReplaceAllObjectsFailed(languages.length - skip('dart'));
     assertValidReplaceAllObjectsScopes(languages.length - skip('dart'));
     assertValidWaitForApiKey(languages.length - skip('dart'));

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -16,7 +16,7 @@ import { assertValidReplaceAllObjects } from './testServer/replaceAllObjects.ts'
 import { assertValidReplaceAllObjectsFailed } from './testServer/replaceAllObjectsFailed.ts';
 import { assertValidReplaceAllObjectsScopes } from './testServer/replaceAllObjectsScopes.ts';
 import { assertValidReplaceAllObjectsWithTransformation } from './testServer/replaceAllObjectsWithTransformation.ts';
-import { assertValidRequestIds } from './testServer/requestId.ts';
+import { assertNoRequestIdLeaks, assertValidRequestIds, REQUEST_ID_LANGUAGES } from './testServer/requestId.ts';
 import { assertSuccessServerCalled } from './testServer/success.ts';
 import { assertValidTimeouts } from './testServer/timeout.ts';
 import { assertValidWaitForApiKey } from './testServer/waitFor.ts';
@@ -192,7 +192,8 @@ export async function runCts(
     assertValidReplaceAllObjects(languages.length - skip('dart'));
     assertValidReplaceAllObjectsWithTransformation(languages.length);
     assertValidAccountCopyIndex(only('javascript'));
-    assertValidRequestIds(only('javascript'));
+    assertValidRequestIds(languages.filter((lang) => REQUEST_ID_LANGUAGES.includes(lang)).length);
+    assertNoRequestIdLeaks(languages.length);
     assertValidReplaceAllObjectsFailed(languages.length - skip('dart'));
     assertValidReplaceAllObjectsScopes(languages.length - skip('dart'));
     assertValidWaitForApiKey(languages.length - skip('dart'));

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -24,18 +24,25 @@ const aciState: Record<
 
 const aciRequestIds: Record<string, string[]> = {};
 
+// languages that have ported Request-ID support (API-516)
+const hasRequestIdSupport = (lang: string) => {
+  return lang === 'javascript';
+};
+
 export function assertValidAccountCopyIndex(expectedCount: number): void {
   expect(Object.keys(aciState)).to.have.length(expectedCount);
   for (const lang in aciState) {
     expect(aciState[lang].waitTaskCount).to.equal(5);
 
-    const requestIds = aciRequestIds[lang] ?? [];
-    expect(requestIds).to.not.be.empty;
-    expect(requestIds[0]).to.match(/^[0-9A-Za-z]{11}$/);
-    expect(new Set(requestIds).size).to.equal(
-      1,
-      `every accountCopyIndex request on both applications must share one Request-ID for ${lang}`,
-    );
+    if (hasRequestIdSupport(lang)) {
+      const requestIds = aciRequestIds[lang] ?? [];
+      expect(requestIds).to.not.be.empty;
+      expect(requestIds[0]).to.match(/^[0-9A-Za-z]{11}$/);
+      expect(new Set(requestIds).size).to.equal(
+        1,
+        `every accountCopyIndex request on both applications must share one Request-ID for ${lang}`,
+      );
+    }
   }
 }
 

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -22,10 +22,20 @@ const aciState: Record<
   }
 > = {};
 
+const aciRequestIds: Record<string, string[]> = {};
+
 export function assertValidAccountCopyIndex(expectedCount: number): void {
   expect(Object.keys(aciState)).to.have.length(expectedCount);
   for (const lang in aciState) {
     expect(aciState[lang].waitTaskCount).to.equal(5);
+
+    const requestIds = aciRequestIds[lang] ?? [];
+    expect(requestIds).to.not.be.empty;
+    expect(requestIds[0]).to.match(/^[0-9A-Za-z]{11}$/);
+    expect(new Set(requestIds).size).to.equal(
+      1,
+      `every accountCopyIndex request on both applications must share one Request-ID for ${lang}`,
+    );
   }
 }
 
@@ -36,6 +46,14 @@ function addRoutes(app: Express): void {
       type: ['application/json', 'text/plain'], // the js client sends the body as text/plain
     }),
   );
+
+  app.use((req, _res, next) => {
+    const lang = req.url.match(/cts_e2e_account_copy_index_(?:source|destination)_([^/?]+)/)?.[1];
+    if (lang) {
+      (aciRequestIds[lang] ??= []).push((req.headers['request-id'] as string) ?? '');
+    }
+    next();
+  });
 
   app.get('/1/indexes/:indexName/settings', (req, res) => {
     const lang = req.params.indexName.match(/^cts_e2e_account_copy_index_(source|destination)_(.*)$/)?.[2] as string;

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -74,6 +74,8 @@ function addRoutes(app: Express): void {
         waitTaskCount: 0,
         successful: false,
       };
+      // the recording middleware already ran for this request, so the new run's first
+      // request-id is the last element — keep it, drop any previous run's residue
       aciRequestIds[lang] = (aciRequestIds[lang] ?? []).slice(-1);
     } else {
       expect(aciState).to.include.keys(lang);

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -5,7 +5,7 @@ import type { Express } from 'express';
 import express from 'express';
 
 import { setupServer } from './index.ts';
-import { REQUEST_ID_FORMAT, REQUEST_ID_LANGUAGES } from './requestId.ts';
+import { observedRequestId, REQUEST_ID_FORMAT, REQUEST_ID_LANGUAGES } from './requestId.ts';
 
 const aciState: Record<
   string,
@@ -53,7 +53,7 @@ function addRoutes(app: Express): void {
   app.use((req, _res, next) => {
     const lang = req.url.match(/cts_e2e_account_copy_index_(?:source|destination)_([^/?]+)/)?.[1];
     if (lang) {
-      (aciRequestIds[lang] ??= []).push((req.headers['request-id'] as string) ?? '');
+      (aciRequestIds[lang] ??= []).push(observedRequestId(req));
     }
     next();
   });

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -5,7 +5,7 @@ import type { Express } from 'express';
 import express from 'express';
 
 import { setupServer } from './index.ts';
-import { REQUEST_ID_LANGUAGES } from './requestId.ts';
+import { REQUEST_ID_FORMAT, REQUEST_ID_LANGUAGES } from './requestId.ts';
 
 const aciState: Record<
   string,
@@ -33,7 +33,7 @@ export function assertValidAccountCopyIndex(expectedCount: number): void {
     if (REQUEST_ID_LANGUAGES.includes(lang)) {
       const requestIds = aciRequestIds[lang] ?? [];
       expect(requestIds).to.not.be.empty;
-      expect(requestIds[0]).to.match(/^[0-9A-Za-z]{11}$/);
+      expect(requestIds[0]).to.match(REQUEST_ID_FORMAT);
       expect(new Set(requestIds).size).to.equal(
         1,
         `every accountCopyIndex request on both applications must share one Request-ID for ${lang}`,
@@ -74,6 +74,7 @@ function addRoutes(app: Express): void {
         waitTaskCount: 0,
         successful: false,
       };
+      aciRequestIds[lang] = (aciRequestIds[lang] ?? []).slice(-1);
     } else {
       expect(aciState).to.include.keys(lang);
     }

--- a/scripts/cts/testServer/accountCopyIndex.ts
+++ b/scripts/cts/testServer/accountCopyIndex.ts
@@ -5,6 +5,7 @@ import type { Express } from 'express';
 import express from 'express';
 
 import { setupServer } from './index.ts';
+import { REQUEST_ID_LANGUAGES } from './requestId.ts';
 
 const aciState: Record<
   string,
@@ -24,17 +25,12 @@ const aciState: Record<
 
 const aciRequestIds: Record<string, string[]> = {};
 
-// languages that have ported Request-ID support (API-516)
-const hasRequestIdSupport = (lang: string) => {
-  return lang === 'javascript';
-};
-
 export function assertValidAccountCopyIndex(expectedCount: number): void {
   expect(Object.keys(aciState)).to.have.length(expectedCount);
   for (const lang in aciState) {
     expect(aciState[lang].waitTaskCount).to.equal(5);
 
-    if (hasRequestIdSupport(lang)) {
+    if (REQUEST_ID_LANGUAGES.includes(lang)) {
       const requestIds = aciRequestIds[lang] ?? [];
       expect(requestIds).to.not.be.empty;
       expect(requestIds[0]).to.match(/^[0-9A-Za-z]{11}$/);

--- a/scripts/cts/testServer/index.ts
+++ b/scripts/cts/testServer/index.ts
@@ -22,6 +22,7 @@ import { replaceAllObjectsServer } from './replaceAllObjects.ts';
 import { replaceAllObjectsServerFailed } from './replaceAllObjectsFailed.ts';
 import { replaceAllObjectsScopesServer } from './replaceAllObjectsScopes.ts';
 import { replaceAllObjectsWithTransformationServer } from './replaceAllObjectsWithTransformation.ts';
+import { requestIdServer, requestIdServerBis, requestIdServerTer } from './requestId.ts';
 import { successServer } from './success.ts';
 import { timeoutServer } from './timeout.ts';
 import { timeoutServerBis } from './timeoutBis.ts';
@@ -53,6 +54,9 @@ export async function startTestServer(suites: Record<CTSType, boolean>): Promise
       replaceAllObjectsWithTransformationServer(),
       chunkedPushWaitServer(),
       noContentServer(),
+      requestIdServer(),
+      requestIdServerBis(),
+      requestIdServerTer(),
     );
   }
   if (suites.benchmark) {

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -1,0 +1,140 @@
+import type { Server } from 'http';
+
+import { expect } from 'chai';
+import type { Express } from 'express';
+import express from 'express';
+
+import { setupServer } from './index.ts';
+
+const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
+
+const retryState: Record<string, string[]> = {};
+const freshState: Record<string, string[]> = {};
+const helperState: Record<string, string[]> = {};
+const smokeState: Record<string, string[]> = {};
+
+function observedRequestId(req: express.Request): string {
+  return (req.headers['request-id'] as string) ?? (req.query['x-algolia-request-id'] as string) ?? '';
+}
+
+function record(state: Record<string, string[]>, key: string, req: express.Request): void {
+  if (!state[key]) {
+    state[key] = [];
+  }
+
+  state[key].push(observedRequestId(req));
+}
+
+export function assertValidRequestIds(expectedCount: number): void {
+  expect(Object.keys(retryState)).to.have.length(expectedCount);
+  expect(Object.keys(freshState)).to.have.length(expectedCount);
+  expect(Object.keys(helperState)).to.have.length(expectedCount);
+  // recommend and composition each run one smoke test per language
+  expect(Object.keys(smokeState)).to.have.length(2 * expectedCount);
+
+  for (const [lang, ids] of Object.entries(retryState)) {
+    // python has sync and async tests
+    const suites = lang === 'python' ? 2 : 1;
+
+    expect(ids).to.have.length(3 * suites);
+    for (let i = 0; i < suites; i++) {
+      const attempts = ids.slice(3 * i, 3 * i + 3);
+      expect(attempts[0]).to.match(REQUEST_ID_FORMAT);
+      expect(new Set(attempts).size).to.equal(1, `every retry of one ${lang} call must reuse the same Request-ID`);
+    }
+    expect(new Set(ids).size).to.equal(suites, `each ${lang} test suite must mint its own Request-ID`);
+  }
+
+  for (const [lang, ids] of Object.entries(freshState)) {
+    const suites = lang === 'python' ? 2 : 1;
+
+    expect(ids).to.have.length(2 * suites);
+    for (const id of ids) {
+      expect(id).to.match(REQUEST_ID_FORMAT);
+    }
+    expect(new Set(ids).size).to.equal(ids.length, `each ${lang} call must mint a fresh Request-ID`);
+  }
+
+  for (const [lang, ids] of Object.entries(helperState)) {
+    const suites = lang === 'python' ? 2 : 1;
+
+    // one chunkedBatch call = 2 batch requests + 2 task polls
+    expect(ids).to.have.length(4 * suites);
+    for (let i = 0; i < suites; i++) {
+      const helperRun = ids.slice(4 * i, 4 * i + 4);
+      expect(helperRun[0]).to.match(REQUEST_ID_FORMAT);
+      expect(new Set(helperRun).size).to.equal(1, `every request of one ${lang} helper call must share one Request-ID`);
+    }
+  }
+
+  for (const [key, ids] of Object.entries(smokeState)) {
+    for (const id of ids) {
+      expect(id).to.match(REQUEST_ID_FORMAT, `the ${key} client must send a well-formed Request-ID`);
+    }
+  }
+}
+
+function addRoutes(app: Express): void {
+  app.use(express.urlencoded({ extended: true }));
+  app.use(
+    express.json({
+      type: ['application/json', 'text/plain'], // the js client sends the body as text/plain
+    }),
+  );
+
+  app.post('/1/test/request-id/retry/:lang', (req, res) => {
+    const lang = req.params.lang;
+    record(retryState, lang, req);
+
+    if (retryState[lang].length % 3 !== 0) {
+      res.status(500).json({ message: 'request-id retry test' });
+      return;
+    }
+
+    res.status(200).json({ status: 'ok' });
+  });
+
+  app.get('/1/test/request-id/fresh/:lang', (req, res) => {
+    record(freshState, req.params.lang, req);
+    res.status(200).json({ status: 'ok' });
+  });
+
+  app.get('/1/test/request-id/caller/:lang', (req, res) => {
+    res.status(200).json({ requestId: observedRequestId(req) });
+  });
+
+  app.get('/1/test/request-id/smoke/:client/:lang', (req, res) => {
+    record(smokeState, `${req.params.client}:${req.params.lang}`, req);
+    res.status(200).json({ status: 'ok' });
+  });
+
+  app.get('/1/test/request-id/error/:lang', (req, res) => {
+    res.setHeader('Correlation-ID', 'CtsFixedCorrelationId');
+    res.status(400).json({ message: 'request-id error test' });
+  });
+
+  app.post('/1/indexes/:indexName/batch', (req, res) => {
+    record(helperState, req.params.indexName.replace('cts_request_id_', ''), req);
+    res.json({
+      taskID: 42,
+      objectIDs: req.body.requests.map((request) => request.body.objectID),
+    });
+  });
+
+  app.get('/1/indexes/:indexName/task/42', (req, res) => {
+    record(helperState, req.params.indexName.replace('cts_request_id_', ''), req);
+    res.json({ status: 'published', updatedAt: '2021-01-01T00:00:00.000Z' });
+  });
+}
+
+export function requestIdServer(): Promise<Server> {
+  return setupServer('requestId', 6694, addRoutes);
+}
+
+export function requestIdServerBis(): Promise<Server> {
+  return setupServer('requestIdBis', 6695, addRoutes);
+}
+
+export function requestIdServerTer(): Promise<Server> {
+  return setupServer('requestIdTer', 6696, addRoutes);
+}

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -58,7 +58,7 @@ export function assertValidRequestIds(expectedCount: number): void {
   for (const [lang, ids] of Object.entries(helperState)) {
     const suites = lang === 'python' ? 2 : 1;
 
-    // one chunkedBatch call = 2 batch requests + 2 task polls
+    // one saveObjects call = 2 batch requests + 2 task polls
     expect(ids).to.have.length(4 * suites);
     for (let i = 0; i < suites; i++) {
       const helperRun = ids.slice(4 * i, 4 * i + 4);

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -8,10 +8,14 @@ import { setupServer } from './index.ts';
 
 const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
 
+// languages that have ported Request-ID support (API-516)
+export const REQUEST_ID_LANGUAGES = ['javascript'];
+
 const retryState: Record<string, string[]> = {};
 const freshState: Record<string, string[]> = {};
 const helperState: Record<string, string[]> = {};
 const smokeState: Record<string, string[]> = {};
+const negativeState: Record<string, string[]> = {};
 
 function observedRequestId(req: express.Request): string {
   return (req.headers['request-id'] as string) ?? (req.query['x-algolia-request-id'] as string) ?? '';
@@ -58,18 +62,28 @@ export function assertValidRequestIds(expectedCount: number): void {
   for (const [lang, ids] of Object.entries(helperState)) {
     const suites = lang === 'python' ? 2 : 1;
 
-    // one saveObjects call = 2 batch requests + 2 task polls
-    expect(ids).to.have.length(4 * suites);
-    for (let i = 0; i < suites; i++) {
+    // the test makes 2 saveObjects calls, each one = 2 batch requests + 2 task polls
+    expect(ids).to.have.length(8 * suites);
+    for (let i = 0; i < 2 * suites; i++) {
       const helperRun = ids.slice(4 * i, 4 * i + 4);
       expect(helperRun[0]).to.match(REQUEST_ID_FORMAT);
       expect(new Set(helperRun).size).to.equal(1, `every request of one ${lang} helper call must share one Request-ID`);
     }
+    expect(new Set(ids).size).to.equal(2 * suites, `each ${lang} helper call must mint its own Request-ID`);
   }
 
   for (const [key, ids] of Object.entries(smokeState)) {
     for (const id of ids) {
       expect(id).to.match(REQUEST_ID_FORMAT, `the ${key} client must send a well-formed Request-ID`);
+    }
+  }
+}
+
+export function assertNoRequestIdLeaks(expectedCount: number): void {
+  expect(Object.keys(negativeState)).to.have.length(expectedCount);
+  for (const [lang, ids] of Object.entries(negativeState)) {
+    for (const id of ids) {
+      expect(id).to.equal('', `the ${lang} ingestion client must not send a Request-ID`);
     }
   }
 }
@@ -105,6 +119,11 @@ function addRoutes(app: Express): void {
 
   app.get('/1/test/request-id/smoke/:client/:lang', (req, res) => {
     record(smokeState, `${req.params.client}:${req.params.lang}`, req);
+    res.status(200).json({ status: 'ok' });
+  });
+
+  app.get('/1/test/request-id/negative/:lang', (req, res) => {
+    record(negativeState, req.params.lang, req);
     res.status(200).json({ status: 'ok' });
   });
 

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -6,7 +6,7 @@ import express from 'express';
 
 import { setupServer } from './index.ts';
 
-const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
+export const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
 
 // languages that have ported Request-ID support (API-516)
 export const REQUEST_ID_LANGUAGES = ['javascript'];

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -17,7 +17,7 @@ const helperState: Record<string, string[]> = {};
 const smokeState: Record<string, string[]> = {};
 const negativeState: Record<string, string[]> = {};
 
-function observedRequestId(req: express.Request): string {
+export function observedRequestId(req: express.Request): string {
   return (req.headers['request-id'] as string) ?? (req.query['x-algolia-request-id'] as string) ?? '';
 }
 

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -96,6 +96,9 @@ function addRoutes(app: Express): void {
     }),
   );
 
+  // fails twice then succeeds, so one client test call produces exactly 3 attempts: a port's
+  // retry strategy must reach 3 attempts (the client tests configure 3 hosts). Recorder state
+  // persists across the suites of one run (python runs sync + async), which `% 3` absorbs.
   app.post('/1/test/request-id/retry/:lang', (req, res) => {
     const lang = req.params.lang;
     record(retryState, lang, req);

--- a/templates/javascript/tests/e2e/e2e.mustache
+++ b/templates/javascript/tests/e2e/e2e.mustache
@@ -29,6 +29,16 @@ describe('{{operationId}}', () => {
 
     expect(expectedBody).toEqual(union(expectedBody, resp));
     {{/body}}
+    {{#correlationIdSuffix}}
+    const httpResp = await client.transporter.requestWithHttpInfo({ method: '{{{request.method}}}', path: '{{{request.path}}}', queryParameters: {}, headers: {} }{{#hasRequestOptions}}, {
+      {{#requestOptions.headers.parameters}}
+      headers: {{{.}}},
+      {{/requestOptions.headers.parameters}}
+    }{{/hasRequestOptions}});
+
+    expect(httpResp.headers?.['correlation-id']).toBeDefined();
+    expect(httpResp.headers?.['correlation-id']?.endsWith('{{{correlationIdSuffix}}}')).toBe(true);
+    {{/correlationIdSuffix}}
     {{/response}}
   });
   {{/isStreamingTest}}

--- a/templates/javascript/tests/e2e/e2e.mustache
+++ b/templates/javascript/tests/e2e/e2e.mustache
@@ -31,6 +31,9 @@ describe('{{operationId}}', () => {
     {{/body}}
     {{#correlationIdSuffix}}
     const httpResp = await client.transporter.requestWithHttpInfo({ method: '{{{request.method}}}', path: '{{{request.path}}}', queryParameters: {}, headers: {} }{{#hasRequestOptions}}, {
+      {{#requestOptions.queryParameters.parameters}}
+      queryParameters: {{{.}}},
+      {{/requestOptions.queryParameters.parameters}}
       {{#requestOptions.headers.parameters}}
       headers: {{{.}}},
       {{/requestOptions.headers.parameters}}

--- a/tests/CTS/client/composition/requestId.json
+++ b/tests/CTS/client/composition/requestId.json
@@ -1,0 +1,34 @@
+[
+  {
+    "testName": "the composition client sends a Request-ID",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/smoke/composition/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/ingestion/requestId.json
+++ b/tests/CTS/client/ingestion/requestId.json
@@ -1,0 +1,34 @@
+[
+  {
+    "testName": "the ingestion client sends no Request-ID",
+    "autoCreateClient": false,
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "region": "us",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/negative/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/recommend/requestId.json
+++ b/tests/CTS/client/recommend/requestId.json
@@ -1,0 +1,34 @@
+[
+  {
+    "testName": "the recommend client sends a Request-ID",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/smoke/recommend/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -1,0 +1,212 @@
+[
+  {
+    "testName": "the Request-ID stays stable across retries",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            },
+            {
+              "port": 6695
+            },
+            {
+              "port": 6696
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customPost",
+        "parameters": {
+          "path": "1/test/request-id/retry/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "testName": "each call mints a fresh Request-ID",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/fresh/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/fresh/${{language}}"
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "status": "ok"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "testName": "a caller-supplied Request-ID is never overwritten",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/caller/${{language}}"
+        },
+        "requestOptions": {
+          "headers": {
+            "request-id": "CtsUserProvided"
+          }
+        },
+        "expected": {
+          "type": "response",
+          "match": {
+            "requestId": "CtsUserProvided"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "testName": "every request of one helper call shares one Request-ID",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "chunkedBatch",
+        "parameters": {
+          "indexName": "cts_request_id_${{language}}",
+          "objects": [
+            {
+              "objectID": "1",
+              "name": "Adam"
+            },
+            {
+              "objectID": "2",
+              "name": "Benoit"
+            },
+            {
+              "objectID": "3",
+              "name": "Cyril"
+            },
+            {
+              "objectID": "4",
+              "name": "David"
+            }
+          ],
+          "batchSize": 2,
+          "waitForTasks": true
+        },
+        "expected": {
+          "type": "response",
+          "match": [
+            {
+              "taskID": 42,
+              "objectIDs": ["1", "2"]
+            },
+            {
+              "taskID": 42,
+              "objectIDs": ["3", "4"]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "testName": "client errors expose the Correlation-ID",
+    "autoCreateClient": false,
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "steps": [
+      {
+        "type": "createClient",
+        "parameters": {
+          "appId": "test-app-id",
+          "apiKey": "test-api-key",
+          "customHosts": [
+            {
+              "port": 6694
+            }
+          ]
+        }
+      },
+      {
+        "type": "method",
+        "method": "customGet",
+        "parameters": {
+          "path": "1/test/request-id/error/${{language}}"
+        },
+        "expected": {
+          "error": {
+            "javascript": "request-id error test (Correlation-ID: CtsFixedCorrelationId)"
+          }
+        }
+      }
+    ]
+  }
+]

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -2,18 +2,7 @@
   {
     "testName": "the Request-ID stays stable across retries",
     "autoCreateClient": false,
-    "skipLanguages": [
-      "csharp",
-      "dart",
-      "go",
-      "java",
-      "kotlin",
-      "php",
-      "python",
-      "ruby",
-      "scala",
-      "swift"
-    ],
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -51,18 +40,7 @@
   {
     "testName": "each call mints a fresh Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": [
-      "csharp",
-      "dart",
-      "go",
-      "java",
-      "kotlin",
-      "php",
-      "python",
-      "ruby",
-      "scala",
-      "swift"
-    ],
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -107,18 +85,7 @@
   {
     "testName": "a caller-supplied Request-ID is never overwritten",
     "autoCreateClient": false,
-    "skipLanguages": [
-      "csharp",
-      "dart",
-      "go",
-      "java",
-      "kotlin",
-      "php",
-      "python",
-      "ruby",
-      "scala",
-      "swift"
-    ],
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -155,18 +122,7 @@
   {
     "testName": "every request of one helper call shares one Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": [
-      "csharp",
-      "dart",
-      "go",
-      "java",
-      "kotlin",
-      "php",
-      "python",
-      "ruby",
-      "scala",
-      "swift"
-    ],
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -231,18 +187,7 @@
   {
     "testName": "client errors expose the Correlation-ID",
     "autoCreateClient": false,
-    "skipLanguages": [
-      "csharp",
-      "dart",
-      "go",
-      "java",
-      "kotlin",
-      "php",
-      "python",
-      "ruby",
-      "scala",
-      "swift"
-    ],
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -2,7 +2,18 @@
   {
     "testName": "the Request-ID stays stable across retries",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "skipLanguages": [
+      "csharp",
+      "dart",
+      "go",
+      "java",
+      "kotlin",
+      "php",
+      "python",
+      "ruby",
+      "scala",
+      "swift"
+    ],
     "steps": [
       {
         "type": "createClient",
@@ -40,7 +51,18 @@
   {
     "testName": "each call mints a fresh Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "skipLanguages": [
+      "csharp",
+      "dart",
+      "go",
+      "java",
+      "kotlin",
+      "php",
+      "python",
+      "ruby",
+      "scala",
+      "swift"
+    ],
     "steps": [
       {
         "type": "createClient",
@@ -85,7 +107,18 @@
   {
     "testName": "a caller-supplied Request-ID is never overwritten",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "skipLanguages": [
+      "csharp",
+      "dart",
+      "go",
+      "java",
+      "kotlin",
+      "php",
+      "python",
+      "ruby",
+      "scala",
+      "swift"
+    ],
     "steps": [
       {
         "type": "createClient",
@@ -122,7 +155,18 @@
   {
     "testName": "every request of one helper call shares one Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "skipLanguages": [
+      "csharp",
+      "dart",
+      "go",
+      "java",
+      "kotlin",
+      "php",
+      "python",
+      "ruby",
+      "scala",
+      "swift"
+    ],
     "steps": [
       {
         "type": "createClient",
@@ -138,7 +182,7 @@
       },
       {
         "type": "method",
-        "method": "chunkedBatch",
+        "method": "saveObjects",
         "parameters": {
           "indexName": "cts_request_id_${{language}}",
           "objects": [
@@ -167,11 +211,17 @@
           "match": [
             {
               "taskID": 42,
-              "objectIDs": ["1", "2"]
+              "objectIDs": [
+                "1",
+                "2"
+              ]
             },
             {
               "taskID": 42,
-              "objectIDs": ["3", "4"]
+              "objectIDs": [
+                "3",
+                "4"
+              ]
             }
           ]
         }
@@ -181,7 +231,18 @@
   {
     "testName": "client errors expose the Correlation-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "skipLanguages": [
+      "csharp",
+      "dart",
+      "go",
+      "java",
+      "kotlin",
+      "php",
+      "python",
+      "ruby",
+      "scala",
+      "swift"
+    ],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -181,6 +181,52 @@
             }
           ]
         }
+      },
+      {
+        "type": "method",
+        "method": "saveObjects",
+        "parameters": {
+          "indexName": "cts_request_id_${{language}}",
+          "objects": [
+            {
+              "objectID": "5",
+              "name": "Eva"
+            },
+            {
+              "objectID": "6",
+              "name": "Fred"
+            },
+            {
+              "objectID": "7",
+              "name": "Gina"
+            },
+            {
+              "objectID": "8",
+              "name": "Hugo"
+            }
+          ],
+          "batchSize": 2,
+          "waitForTasks": true
+        },
+        "expected": {
+          "type": "response",
+          "match": [
+            {
+              "taskID": 42,
+              "objectIDs": [
+                "5",
+                "6"
+              ]
+            },
+            {
+              "taskID": 42,
+              "objectIDs": [
+                "7",
+                "8"
+              ]
+            }
+          ]
+        }
       }
     ]
   },

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -7,5 +7,31 @@
       "path": "/1/compositions/foo",
       "method": "GET"
     }
+  },
+  {
+    "testName": "the Correlation-ID ends with the sent Request-ID",
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "parameters": {
+      "compositionID": "id1"
+    },
+    "requestOptions": {
+      "headers": {
+        "request-id": "CtsE2eEcho4"
+      }
+    },
+    "request": {
+      "path": "/1/compositions/id1",
+      "method": "GET",
+      "headers": {
+        "request-id": "CtsE2eEcho4"
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "objectID": "id1"
+      },
+      "correlationIdSuffix": "CtsE2eEcho4"
+    }
   }
 ]

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -33,5 +33,31 @@
       },
       "correlationIdSuffix": "CtsE2eEcho4"
     }
+  },
+  {
+    "testName": "the Correlation-ID ends with the Request-ID sent as a query parameter",
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "parameters": {
+      "compositionID": "id1"
+    },
+    "requestOptions": {
+      "queryParameters": {
+        "x-algolia-request-id": "CtsE2eEchoQ"
+      }
+    },
+    "request": {
+      "path": "/1/compositions/id1",
+      "method": "GET",
+      "queryParameters": {
+        "x-algolia-request-id": "CtsE2eEchoQ"
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "objectID": "id1"
+      },
+      "correlationIdSuffix": "CtsE2eEchoQ"
+    }
   }
 ]

--- a/tests/CTS/requests/search/searchRules.json
+++ b/tests/CTS/requests/search/searchRules.json
@@ -49,5 +49,38 @@
         "page": 0
       }
     }
+  },
+  {
+    "testName": "the classic engine accepts a Request-ID sent as a query parameter",
+    "skipLanguages": ["csharp", "dart", "go", "java", "kotlin", "php", "python", "ruby", "scala", "swift"],
+    "parameters": {
+      "indexName": "cts_e2e_browse",
+      "searchRulesParams": {
+        "query": "zorro"
+      }
+    },
+    "requestOptions": {
+      "queryParameters": {
+        "x-algolia-request-id": "CtsE2eQry11"
+      }
+    },
+    "request": {
+      "path": "/1/indexes/cts_e2e_browse/rules/search",
+      "method": "POST",
+      "body": {
+        "query": "zorro"
+      },
+      "queryParameters": {
+        "x-algolia-request-id": "CtsE2eQry11"
+      }
+    },
+    "response": {
+      "statusCode": 200,
+      "body": {
+        "nbHits": 1,
+        "nbPages": 1,
+        "page": 0
+      }
+    }
   }
 ]


### PR DESCRIPTION
## 🧭 What

CTS foundation for the Request-ID/Correlation-ID feature ([reference implementation PR](https://github.com/algolia/api-clients-automation/pull/6747)): shared client tests that every language port inherits by un-gating, the test-server infrastructure that makes randomly-generated IDs assertable, e2es for the Correlation-ID suffix echo on both channels, and a live canary that the classic engine accepts the query-param channel.

## 🧪 How it works

Request-IDs are random, so CTS `expected` blocks cannot match them. Instead, the tests run against a stateful recorder server (`scripts/cts/testServer/requestId.ts`, ports 6694–6696) that records the ID of every request per language, and post-run assertions (`assertValidRequestIds`/`assertNoRequestIdLeaks` in `runCts.ts`) validate the recordings — the `timeout.ts`/`accountCopyIndex` pattern. Three server instances share one state module so retry attempts crossing hosts land in the same bucket.

Shared tests (`tests/CTS/client/*/requestId.json`):
- the Request-ID stays stable across retries (3 hosts, 500-500-200)
- each call mints a fresh, well-formed ID (`^[0-9A-Za-z]{11}$`)
- a caller-supplied Request-ID is never overwritten (server echoes the observed ID back)
- every request of one helper call shares one ID, and two helper calls mint distinct IDs (saveObjects twice: 2 batches + 2 task polls each)
- client errors expose the Correlation-ID (fixed-CID 400 route, per-language message assertion)
- recommend and composition smoke tests (feature is on for all three clients)
- the ingestion client sends no Request-ID — un-gated for all languages, so a port that enables the feature transporter-wide instead of per-client fails the CTS everywhere

E2E — suffix echo (`tests/CTS/requests/composition/getComposition.json`): sends a fixed 11-char Request-ID to the real API — once as the `request-id` header, once as the `x-algolia-request-id` query parameter — and asserts the returned Correlation-ID ends with it: a new `correlationIdSuffix` response prop, rendered by the JS e2e template via `requestWithHttpInfo`. Generation fails when a `correlationIdSuffix` test is not a GET whose expected query parameters all come from `requestOptions` (the request is re-issued to read the response headers, so operation-level query/header parameters would be silently dropped and non-GETs would execute twice).

E2E — classic canary (`tests/CTS/requests/search/searchRules.json`): the recorder server accepts anything the client sends, so only an e2e proves the real engines tolerate the query param that browser builds attach to every request. `searchRules` is one of the two v5-relevant endpoints that 400'd on the unknown param before SRCH-9407 (Arguments.cpp allowlist), so it succeeding with the param is the convergence signal — a server-side regression turns this red immediately. The query-param channel is no longer gated: SRCH-9380/SRCH-9406 converged on Metis 2026-07-22, and SRCH-9407 is live on the CTS app's cluster. All e2es verified live 2026-08-03 (Metis embeds and suffix-echoes on both channels; classic accepts the param — one cluster, not fleet-wide proof).

## 🚪 Gating

Every test lists the 10 unported languages in `skipLanguages`; the ported-language roster lives in one place, `REQUEST_ID_LANGUAGES` (`scripts/cts/testServer/requestId.ts`), which drives both the recorder assertion count and the accountCopyIndex Request-ID assertions. `SnippetsGenerator` propagates `skipLanguages`, so the helper-derived saveObjects snippet doesn't leak into unported languages' docs. A port un-gates by removing its language from the `requestId.json` files and the `getComposition`/`searchRules` e2e entries, adding it to `REQUEST_ID_LANGUAGES`, adding its message to the "client errors expose the Correlation-ID" error map (a missing entry fails at test runtime with `<missing error for <lang>>`), and implementing the `correlationIdSuffix` section in its e2e template — generation fails if the template never renders it (mustache drops unknown sections silently — without it the e2e passes while asserting nothing). The ingestion negative test needs no un-gating: sending nothing is correct before and after porting.

Gate verified: go CTS generation succeeds with zero request-id references in its output, and `go vet` on its client tests passes.

## ⛓️ Merge order

Stacked on #6747. Merge only after #6747 lands (its browser query-param flip additionally waits on Engines confirming classic fleet convergence), then rebase onto main.
