### PR TITLE
fix(scripts): strip >LOG markers from bundled doc snippets

### DIFF
--- a/scripts/specs/__tests__/snippets.test.ts
+++ b/scripts/specs/__tests__/snippets.test.ts
@@ -103,6 +103,41 @@ Console.WriteLine(response);
   });
 });
 
+describe('streaming', () => {
+  it('strips `>LOG` markers from snippets without a `Call the API` section', () => {
+    expect(
+      JSON.stringify(
+        generateSnippetsJSON({
+          python: {
+            ope: {
+              default: `# Initialize the client
+client = AgentStudioClientSync("ALGOLIA_APPLICATION_ID", "ALGOLIA_API_KEY")
+
+# Use the streaming variant to iterate over events
+for event in client.create_agent_completion_stream(
+    agent_id="agent-id",
+):
+    # >LOG
+    print(event.data)
+`,
+            },
+          },
+        } as unknown as CodeSamples),
+        null,
+        2,
+      ),
+    ).toMatchInlineSnapshot(`
+      "{
+        "python": {
+          "ope": {
+            "default": "# Initialize the client\\nclient = AgentStudioClientSync(\\"ALGOLIA_APPLICATION_ID\\", \\"ALGOLIA_API_KEY\\")\\n\\n# Use the streaming variant to iterate over events\\nfor event in client.create_agent_completion_stream(\\n    agent_id=\\"agent-id\\",\\n):\\n    print(event.data)\\n"
+          }
+        }
+      }"
+    `);
+  });
+});
+
 describe('initialize', () => {
   it("doesn't stop at `client`", () => {
     expect(

--- a/scripts/specs/snippets.ts
+++ b/scripts/specs/snippets.ts
@@ -36,6 +36,9 @@ export function generateSnippetsJSON(codeSamples: CodeSamples): CodeSamples {
           /.*Initialize the client.*([\s\S]*?)(#|\/\/) Call the API([\s\S]*?)(#|\/\/) >LOG/,
         );
         if (!sampleMatch) {
+          // snippets without a `Call the API` section (e.g. streaming) are kept
+          // whole, but the `>LOG` markers still must not reach the doc
+          codeSamples[language][operation][sampleName] = sample.replace(/^[ \t]*(#|\/\/) >LOG\n/gm, '');
           continue;
         }
 


### PR DESCRIPTION
## 🧭 What and Why

`generateSnippetsJSON` (in `scripts/specs/snippets.ts`) only strips the `>LOG` generator marker for snippets that contain a `// Call the API` comment. Streaming snippets say `// Use the streaming variant…` instead, so they're passed through verbatim — and since the bundled `docs/bundled/*-snippets.json` files are written *before* the marker-stripping loop in `transformGeneratedSnippetsToCodeSamples` runs, the JSON consumed by the docs now leaks literal `// >LOG` / `# >LOG` lines in the Go and Python streaming snippets (JavaScript templates don't emit the marker).

Visible today in `docs/bundled/agent-studio-snippets.json` on `main`, e.g. the `go` → `createAgentCompletion` streaming entries. These would render as literal comments in the docs once synced via `push-to-repository` (algolia/docs-new#1027 stripped them manually in the meantime).

## 🧪 Fix

Strip the `>LOG` marker lines from pass-through snippets in `generateSnippetsJSON` too, and add a test for the streaming-snippet shape.

The committed bundles regenerate on merge via the generated-files CI commit.

Follow-up to #6726 / #6734.