### PR TITLE
test(javascript): cover Correlation-ID parse failures and reverse-channel Request-ID precedence (API-516)

### DIFF
--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/correlationId.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { createMemoryCache, createNullCache } from '../../cache';
 import { createNullLogger } from '../../logger';
-import { ApiError, DetailedApiError, RetryError, createTransporter } from '../../transporter';
+import { ApiError, DeserializationError, DetailedApiError, RetryError, createTransporter } from '../../transporter';
 import type { AlgoliaAgent, Requester, Transporter } from '../../types';
 
 describe('correlation ID on errors', () => {
@@ -182,6 +182,46 @@ describe('correlation ID on errors', () => {
     );
 
     expect(error).toBeInstanceOf(RetryError);
+    expect(error.correlationId).toBeUndefined();
+    expect(error.message).not.toContain('Correlation-ID');
+  });
+
+  test('surfaces the correlation ID when a successful response body fails to parse', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 200,
+        content: 'not json',
+        headers: { 'correlation-id': 'abc123def45' },
+        isTimedOut: false,
+      }),
+    });
+
+    const error: DeserializationError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(DeserializationError);
+    expect(error.correlationId).toBe('abc123def45');
+    expect(error.message).toContain('(Correlation-ID: abc123def45)');
+  });
+
+  test('omits the correlation ID from a parse failure when the header is absent', async () => {
+    const transporter = createTestTransporter({
+      send: async () => ({
+        status: 200,
+        content: 'not json',
+        headers: {},
+        isTimedOut: false,
+      }),
+    });
+
+    const error: DeserializationError = await transporter.request(request).then(
+      () => Promise.reject(new Error('should have thrown')),
+      (err) => err,
+    );
+
+    expect(error).toBeInstanceOf(DeserializationError);
     expect(error.correlationId).toBeUndefined();
     expect(error.message).not.toContain('Correlation-ID');
   });

--- a/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
+++ b/clients/algoliasearch-client-javascript/packages/client-common/src/__tests__/transporter/requestIdChannel.test.ts
@@ -154,6 +154,25 @@ describe('request ID channel', () => {
     expect(requests[0].headers['request-id']).toBeUndefined();
   });
 
+  test('never mints when the caller supplied a query parameter, even on the headers channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request, { queryParameters: { 'x-algolia-request-id': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBeUndefined();
+    expect(sentQueryParameterId(requests[0])).toBe('callerSuppl1');
+  });
+
+  test('detects a caller-supplied query parameter case-insensitively on the headers channel', async () => {
+    const { requester, requests } = createEchoRequester();
+    const transporter = createTestTransporter(requester, { requestIdChannel: 'headers' });
+
+    await transporter.request(request, { queryParameters: { 'X-Algolia-Request-Id': 'callerSuppl1' } });
+
+    expect(requests[0].headers['request-id']).toBeUndefined();
+  });
+
   test('leaves the cache key unchanged so cacheable calls still hit the cache', async () => {
     const { requester, requests } = createEchoRequester();
     const transporter = createTestTransporter(requester, { requestIdChannel: 'queryParameters' });


### PR DESCRIPTION
## 🧭 What and Why

🎟 [API-516](https://algolia.atlassian.net/browse/API-516)

Stacked on #6747 (targets `feat/js-request-id-correlation-id`). It adds the two test cases a review of #6747 found missing. Both cover behavior that #6747 changed but left untested.

The first is the Correlation-ID on a `DeserializationError`, the error thrown when a 2xx response body fails to parse. Commit `32d2763` added that surfacing, but nothing exercised it. The new tests check both branches of `getCorrelationId`: when the header is present the id lands on `error.correlationId` and is appended to the message; when it is absent the message stays untouched.

The second is Request-ID precedence on the reverse channel. `injectRequestId` checks for a caller-supplied `x-algolia-request-id` query parameter on every request, but only the `withRequestId` helper was tested, never the transporter itself. The new tests confirm that such a query parameter suppresses minting on the `headers` channel, including a case-insensitive match.

No source changes.

## 🧪 Test

`yarn workspace @algolia/client-common test` passes 137 tests, including `tsc --noEmit`. Each new test is mutation-verified: reverting the guarded line in `helpers.ts` (the `getCorrelationId(response.headers)` argument) or `createTransporter.ts` (the query-parameter check) fails the matching test and no other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[API-516]: https://algolia.atlassian.net/browse/API-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ