### PR TITLE
feat(specs): extend ABTest data model with Bayesian fields

### DIFF
--- a/specs/abtesting-v3/common/schemas/ABTest.yml
+++ b/specs/abtesting-v3/common/schemas/ABTest.yml
@@ -66,6 +66,12 @@ ABTestConfiguration:
       $ref: '#/MetricsFilters'
     errorCorrection:
       $ref: '#/ErrorCorrectionType'
+    method:
+      $ref: '#/AnalysisMethod'
+    primaryMetric:
+      type: string
+      description: Public metric name that drives the Bayesian end-test recommendation. Only relevant when `method` is `bayesian`.
+      example: conversionRate
 
 MinimumDetectableEffect:
   type: object
@@ -137,3 +143,10 @@ ErrorCorrectionType:
   enum:
     - bonferroni
     - benjamini-hochberg
+
+AnalysisMethod:
+  type: string
+  description: A/B test statistical analysis method.
+  enum:
+    - bayesian
+    - frequentist

--- a/specs/abtesting-v3/common/schemas/Variant.yml
+++ b/specs/abtesting-v3/common/schemas/Variant.yml
@@ -95,11 +95,12 @@ metricResult:
       type: boolean
       description: |
         Whether the pValue is significant or not based on the critical value and the error correction algorithm used.
+    bayesian:
+      $ref: '#/bayesianMetricResult'
   required:
     - name
     - updatedAt
     - value
-    - pValue
   example:
     - name: addToCartCount
       updatedAt: 2025-06-15T15:06:44.400601Z
@@ -121,6 +122,28 @@ metricResult:
       value: 999.66
       pValue: 0.04
       metadata: {'winsorizedValue': 888.8}
+
+bayesianMetricResult:
+  type: object
+  description: |
+    Bayesian inference results for this variant metric.
+    Absent when Bayesian inference isn't available for this metric.
+  properties:
+    probabilityToBeBetter:
+      type: number
+      format: double
+      description: Probability that this variant is better than the control.
+      example: 0.991
+    relativeEffectCILow:
+      type: number
+      format: double
+      description: Lower bound of the 95% credible interval for the relative effect (variant/control minus 1).
+      example: 0.04
+    relativeEffectCIHigh:
+      type: number
+      format: double
+      description: Upper bound of the 95% credible interval for the relative effect (variant/control minus 1).
+      example: 0.39
 
 variantMetadata:
   type: object


### PR DESCRIPTION
## 🧭 What and Why
Support the new `Bayesian` A/B test type. Users will now be able to select at test creation time between two statistical methods frequentist (default) or Bayesian (new), that will change how results are interpreted. Users can also control which type of metrics are returned in their GET responses.

🎟 JIRA Ticket: [OPTIM-2775](https://algolia.atlassian.net/browse/OPTIM-2775)

### Changes included:

- Adds new fields `method` and `primaryMetric` to `ABTestConfiguration` that specifies a test as frequentist (default) or Bayesian (new).
- Adds new `bayesian` optional field to the Get, List and Timeseries responses that contains additional Bayesian metric data when present.
- Adds new multi-value query parameter `methods` to Get, List and Timeseries requests to control if Bayesian (new), frequentist (existing) or both types of metrics are returned in the response.

## 🧪 Test
- Green CI

[OPTIM-2775]: https://algolia.atlassian.net/browse/OPTIM-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ