### PR TITLE
feat(specs): add A/B test settings endpoints to abtesting-v3

### DIFF
--- a/generators/src/main/java/com/algolia/codegen/cts/tests/Snippet.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/Snippet.java
@@ -7,7 +7,6 @@ import com.algolia.codegen.utils.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.*;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenResponse;
 
 public class Snippet {
 
@@ -97,14 +96,7 @@ public class Snippet {
         context.put("requestOptions", requestOptionsContext);
       }
 
-      // Determines whether the endpoint is expected to return a response payload deserialized
-      // and therefore a variable to store it into.
-      context.put("hasResponse", true);
-      for (CodegenResponse response : ope.responses) {
-        if (response.code.equals("204")) {
-          context.put("hasResponse", false);
-        }
-      }
+      context.put("hasResponse", ope.returnType != null && !ope.returnType.isEmpty());
 
       paramsType.enhanceParameters(parameters, context, ope);
     } catch (CTSException e) {

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsClient.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.SupportingFile;
 
 public class TestsClient extends TestsGenerator {
@@ -156,14 +155,7 @@ public class TestsClient extends TestsGenerator {
               // default to true because most api calls are asynchronous
               stepOut.put("isAsyncMethod", (boolean) ope.vendorExtensions.getOrDefault("x-asynchronous-helper", true));
 
-              // Determines whether the endpoint is expected to return a response payload
-              // deserialized and therefore a variable to store it into.
-              stepOut.put("hasResponse", true);
-              for (CodegenResponse response : ope.responses) {
-                if (response.code.equals("204")) {
-                  stepOut.put("hasResponse", false);
-                }
-              }
+              stepOut.put("hasResponse", ope.returnType != null && !ope.returnType.isEmpty());
 
               // set on testOut because we need to wrap everything for java.
               testOut.put("isHelper", isHelper);

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/TestsRequest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.util.*;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.SupportingFile;
 
 public class TestsRequest extends TestsGenerator {
@@ -257,15 +256,7 @@ public class TestsRequest extends TestsGenerator {
 
           addRequestOptions(paramsType, req.requestOptions, test);
 
-          // Determines whether the endpoint is expected to return a response payload deserialized
-          // and therefore a variable to store it into.
-          test.put("hasResponse", true);
-
-          for (CodegenResponse response : ope.responses) {
-            if (response.code.equals("204")) {
-              test.put("hasResponse", false);
-            }
-          }
+          test.put("hasResponse", ope.returnType != null && !ope.returnType.isEmpty());
 
           paramsType.enhanceParameters(req.parameters, test, ope);
           tests.add(test);

--- a/playground/javascript/node/abtestingV3.ts
+++ b/playground/javascript/node/abtestingV3.ts
@@ -1,38 +1,95 @@
+import type { ABTestSettingsResponse, Region } from '@algolia/abtesting';
 import { abtestingV3Client } from '@algolia/abtesting';
-import { ApiError } from '@algolia/client-common';
+import { ApiError, RetryError } from '@algolia/client-common';
 
 const appId = process.env.ALGOLIA_APPLICATION_ID || '**** APP_ID *****';
-const apiKey = process.env.ALGOLIA_ANALYTICS_KEY || '**** ANALYTICS_API_KEY *****';
+const adminKey = process.env.ALGOLIA_ADMIN_KEY || '**** ADMIN_API_KEY *****';
+const region = (process.env.ALGOLIA_ABTESTING_REGION || 'de') as Region;
 
-// Init client with appId and apiKey
-const client = abtestingV3Client(appId, apiKey, 'de');
+const abTestId = Number(process.env.ABTEST_ID || 0);
+const variantId = Number(process.env.ABTEST_VARIANT_ID || 2);
+const saveFeaturesSettings = process.env.ABTEST_SAVE_FEATURE_SETTINGS === 'true';
 
-async function testABTesting() {
-  try {
-    const res = await client.addABTests({
-      endAt: '2022-02-01',
-      name: 'testing',
-      metrics: [],
-      variants: [
-        {
-          index: 'test1',
-          trafficPercentage: 30,
-        },
-        {
-          index: 'test2',
-          trafficPercentage: 50,
-        },
-      ],
-    });
+const client = abtestingV3Client(appId, adminKey, region);
 
-    console.log(`[OK]`, res);
-  } catch (e) {
-    if (e instanceof ApiError) {
-      return console.log(`[${e.status}] ${e.message}`, e.stackTrace, e);
-    }
-
-    console.log('[ERROR]', e);
-  }
+function printSettings(label: string, response: ABTestSettingsResponse): void {
+  console.log(label, JSON.stringify(response, null, 2));
 }
 
-testABTesting();
+async function getSettings(): Promise<void> {
+  printSettings('getABTestSettings', await client.getABTestSettings({ id: abTestId }));
+}
+
+async function saveSettings(): Promise<void> {
+  await client.saveVariantSettings({
+    id: abTestId,
+    variantId,
+    saveSettingsRequest: { saveFeaturesSettings },
+  });
+  console.log(`saved settings for variant ${variantId}`);
+}
+
+async function applySettings(variantIdToApply = variantId): Promise<void> {
+  await client.applyVariantSettings({ id: abTestId, variantId: variantIdToApply });
+  console.log(`applied settings for variant ${variantIdToApply}`);
+}
+
+async function lifecycle(): Promise<void> {
+  try {
+    await client.getABTestSettings({ id: abTestId });
+    throw new Error('settings were already captured for this A/B test');
+  } catch (error) {
+    if (!(error instanceof ApiError) || error.status !== 404) {
+      throw error;
+    }
+
+    console.log('settings are not captured yet');
+  }
+
+  await saveSettings();
+  printSettings('after capture', await client.getABTestSettings({ id: abTestId }));
+
+  await applySettings();
+  printSettings('after apply', await client.getABTestSettings({ id: abTestId }));
+
+  await applySettings(1);
+  printSettings('after revert', await client.getABTestSettings({ id: abTestId }));
+}
+
+const scenarios: Record<string, () => Promise<void>> = {
+  get: getSettings,
+  save: saveSettings,
+  apply: applySettings,
+  revert: () => applySettings(1),
+  lifecycle,
+};
+
+const requested = process.env.ABTEST_SCENARIO || 'get';
+const scenario = scenarios[requested];
+
+if (!abTestId) {
+  console.error('set ABTEST_ID to an existing A/B test owned by this application');
+  process.exit(1);
+}
+
+if (!scenario) {
+  console.error(`unknown scenario '${requested}'. available: ${Object.keys(scenarios).join(', ')}`);
+  process.exit(1);
+}
+
+console.log(
+  `running '${requested}' against ${appId} (${region}), abTestId=${abTestId}, ` +
+    `variantId=${variantId}, saveFeaturesSettings=${saveFeaturesSettings}`,
+);
+
+scenario().catch((error: unknown) => {
+  if (error instanceof ApiError) {
+    console.error(`[${error.status}] ${error.message}`, error.stackTrace);
+  } else if (error instanceof RetryError) {
+    console.error(error.message, error.stackTrace);
+  } else {
+    console.error(error);
+  }
+
+  process.exitCode = 1;
+});

--- a/specs/abtesting-v3/common/parameters.yml
+++ b/specs/abtesting-v3/common/parameters.yml
@@ -163,3 +163,13 @@ direction:
     - asc
     - desc
   example: desc
+
+VariantID:
+  in: path
+  name: variantId
+  description: One-based index of the A/B test variant. The control is variant 1.
+  required: true
+  schema:
+    type: integer
+    minimum: 1
+    example: 2

--- a/specs/abtesting-v3/common/schemas/ABTestSettings.yml
+++ b/specs/abtesting-v3/common/schemas/ABTestSettings.yml
@@ -1,0 +1,81 @@
+FeatureSettings:
+  type: object
+  description: Feature-specific settings captured for a variant.
+  additionalProperties: false
+  properties:
+    name:
+      type: string
+      description: Name of the feature the settings belong to.
+      example: 'reranking'
+    settings:
+      description: Feature settings payload. The shape depends on the feature.
+  required:
+    - name
+    - settings
+
+VariantSettings:
+  type: object
+  description: Settings captured for one A/B test variant.
+  additionalProperties: false
+  properties:
+    variantId:
+      type: integer
+      description: One-based index of the variant within the A/B test. The control is variant 1.
+      example: 2
+    applied:
+      type: boolean
+      description: Whether the variant's settings have been applied to the control index.
+    featuresSettings:
+      type: array
+      description: Feature-specific settings captured for the variant.
+      items:
+        $ref: '#/FeatureSettings'
+    indexSettings:
+      type: object
+      description: Index settings captured for the variant.
+    applyTimestamp:
+      type: string
+      description: Date and time when the variant's settings were applied to the control index, in RFC 3339 format.
+      example: 2023-06-17T00:00:00Z
+    revertTimestamp:
+      type: string
+      description: Date and time when the applied settings were reverted on the control index, in RFC 3339 format.
+      example: 2023-06-18T00:00:00Z
+    declaredTimestamp:
+      type: string
+      description: Date and time when the variant's settings were captured, in RFC 3339 format.
+      example: 2023-06-16T00:00:00Z
+    expiredTimestamp:
+      type: string
+      description: Date and time when the captured settings expired, in RFC 3339 format.
+      example: 2023-07-16T00:00:00Z
+  required:
+    - variantId
+    - applied
+
+ABTestSettingsResponse:
+  type: object
+  description: Captured settings of an A/B test.
+  additionalProperties: false
+  properties:
+    abtestSettings:
+      type: array
+      description: Captured settings for each variant of the A/B test.
+      items:
+        $ref: '#/VariantSettings'
+    controlIndexInUse:
+      type: boolean
+      description: Whether another active A/B test is using the control index.
+  required:
+    - abtestSettings
+    - controlIndexInUse
+
+SaveSettingsRequest:
+  type: object
+  description: Options for capturing a variant's settings.
+  additionalProperties: false
+  properties:
+    saveFeaturesSettings:
+      type: boolean
+      description: Whether to also capture feature-specific settings for the variant.
+      default: false

--- a/specs/abtesting-v3/paths/applyVariantSettings.yml
+++ b/specs/abtesting-v3/paths/applyVariantSettings.yml
@@ -1,0 +1,41 @@
+post:
+  tags:
+    - abtest
+  operationId: applyVariantSettings
+  x-acl:
+    - analytics
+    - editSettings
+  summary: Apply a variant's captured settings to the control index
+  description: |
+    Applies the captured settings of the given variant to the control index.
+
+    The settings must first be captured with the `saveVariantSettings` operation. To revert previously applied settings on the control index, use this operation with the control variant (variant 1).
+
+    Settings can be applied up to 14 days after the A/B test ends, and reverted up to 15 days after. Later requests return `400`.
+
+    Each set of captured settings can only be applied once, and settings that were reverted can't be applied again. Both cases return `400`.
+
+    The control index must not be in use by an active A/B test. Otherwise, the request returns `422`.
+  parameters:
+    - $ref: '../common/parameters.yml#/ID'
+    - $ref: '../common/parameters.yml#/VariantID'
+  responses:
+    '200':
+      description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
+    '400':
+      $ref: '../../common/responses/BadRequest.yml'
+    '402':
+      $ref: '../../common/responses/FeatureNotEnabled.yml'
+    '403':
+      $ref: '../../common/responses/MethodNotAllowed.yml'
+    '404':
+      $ref: '../../common/responses/IndexNotFound.yml'
+    '422':
+      $ref: '../../common/responses/UnprocessableEntity.yml'

--- a/specs/abtesting-v3/paths/settings.yml
+++ b/specs/abtesting-v3/paths/settings.yml
@@ -1,0 +1,39 @@
+get:
+  tags:
+    - abtest
+  operationId: getABTestSettings
+  x-acl:
+    - analytics
+  summary: Retrieve captured A/B test settings
+  description: |
+    Retrieves the settings captured for each variant of an A/B test, and whether another active A/B test is using the control index.
+
+    Settings are captured by the `saveVariantSettings` operation. The response includes an entry for the control (variant 1) alongside the captured variant, so the control's original configuration can be restored later.
+
+    Returns `404` if no settings have been captured for the A/B test.
+  parameters:
+    - $ref: '../common/parameters.yml#/ID'
+  responses:
+    '200':
+      description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
+      content:
+        application/json:
+          schema:
+            $ref: '../common/schemas/ABTestSettings.yml#/ABTestSettingsResponse'
+    '400':
+      $ref: '../../common/responses/BadRequest.yml'
+    '402':
+      $ref: '../../common/responses/FeatureNotEnabled.yml'
+    '403':
+      $ref: '../../common/responses/MethodNotAllowed.yml'
+    '404':
+      $ref: '../../common/responses/IndexNotFound.yml'
+    '422':
+      $ref: '../../common/responses/UnprocessableEntity.yml'

--- a/specs/abtesting-v3/paths/variantSettings.yml
+++ b/specs/abtesting-v3/paths/variantSettings.yml
@@ -1,0 +1,49 @@
+post:
+  tags:
+    - abtest
+  operationId: saveVariantSettings
+  x-acl:
+    - analytics
+    - editSettings
+  summary: Capture a variant's settings and stop the A/B test
+  description: |
+    Captures the settings of the given variant and of the control, then stops the A/B test.
+
+    The captured settings can later be applied to the control index with the `applyVariantSettings` operation, and read back with the `getABTestSettings` operation.
+
+    The A/B test must have reached 80% of its planned duration. Earlier requests return `400`.
+
+    Settings can only be captured once per A/B test. A second request returns `409`.
+
+    `synonyms` and `enableRules` are not captured, so applying the captured settings never changes them on the control index.
+  parameters:
+    - $ref: '../common/parameters.yml#/ID'
+    - $ref: '../common/parameters.yml#/VariantID'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../common/schemas/ABTestSettings.yml#/SaveSettingsRequest'
+  responses:
+    '200':
+      description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
+    '400':
+      $ref: '../../common/responses/BadRequest.yml'
+    '402':
+      $ref: '../../common/responses/FeatureNotEnabled.yml'
+    '403':
+      $ref: '../../common/responses/MethodNotAllowed.yml'
+    '404':
+      $ref: '../../common/responses/IndexNotFound.yml'
+    '409':
+      $ref: '../../common/responses/Conflict.yml'
+    '422':
+      $ref: '../../common/responses/UnprocessableEntity.yml'

--- a/specs/abtesting-v3/spec.yml
+++ b/specs/abtesting-v3/spec.yml
@@ -99,6 +99,12 @@ paths:
     $ref: 'paths/estimate.yml'
   /3/abtests/{id}/timeseries:
     $ref: 'paths/timeseries.yml'
+  /3/abtests/{id}/settings:
+    $ref: 'paths/settings.yml'
+  /3/abtests/{id}/settings/{variantId}:
+    $ref: 'paths/variantSettings.yml'
+  /3/abtests/{id}/settings/{variantId}/apply:
+    $ref: 'paths/applyVariantSettings.yml'
 
   # ###############
   # ### Helpers ###

--- a/tests/CTS/requests/abtesting-v3/applyVariantSettings.json
+++ b/tests/CTS/requests/abtesting-v3/applyVariantSettings.json
@@ -1,0 +1,24 @@
+[
+  {
+    "testName": "applyVariantSettings",
+    "parameters": {
+      "id": 42,
+      "variantId": 2
+    },
+    "request": {
+      "path": "/3/abtests/42/settings/2/apply",
+      "method": "POST"
+    }
+  },
+  {
+    "testName": "revert applied settings via the control variant",
+    "parameters": {
+      "id": 42,
+      "variantId": 1
+    },
+    "request": {
+      "path": "/3/abtests/42/settings/1/apply",
+      "method": "POST"
+    }
+  }
+]

--- a/tests/CTS/requests/abtesting-v3/getABTestSettings.json
+++ b/tests/CTS/requests/abtesting-v3/getABTestSettings.json
@@ -1,0 +1,12 @@
+[
+  {
+    "testName": "getABTestSettings",
+    "parameters": {
+      "id": 42
+    },
+    "request": {
+      "path": "/3/abtests/42/settings",
+      "method": "GET"
+    }
+  }
+]

--- a/tests/CTS/requests/abtesting-v3/saveVariantSettings.json
+++ b/tests/CTS/requests/abtesting-v3/saveVariantSettings.json
@@ -1,0 +1,30 @@
+[
+  {
+    "testName": "saveVariantSettings",
+    "parameters": {
+      "id": 42,
+      "variantId": 2,
+      "saveSettingsRequest": {
+        "saveFeaturesSettings": true
+      }
+    },
+    "request": {
+      "path": "/3/abtests/42/settings/2",
+      "method": "POST",
+      "body": { "saveFeaturesSettings": true }
+    }
+  },
+  {
+    "testName": "saveVariantSettingsWithoutFeatures",
+    "parameters": {
+      "id": 42,
+      "variantId": 2,
+      "saveSettingsRequest": {}
+    },
+    "request": {
+      "path": "/3/abtests/42/settings/2",
+      "method": "POST",
+      "body": {}
+    }
+  }
+]


### PR DESCRIPTION
## 🧭 What and Why

Declares the three settings endpoints served by the A/B Tests API so generated clients can call them without custom requests.

🎟 JIRA Ticket: N/A

### Changes included:

- **GET** `/3/abtests/{id}/settings` (`getSettings`): returns captured variant settings and `controlIndexInUse`.
- **POST** `/3/abtests/{id}/settings/{variantId}` (`saveVariantSettings`): captures control and variant settings and stops the test.
- **POST** `/3/abtests/{id}/settings/{variantId}/apply` (`applyVariantSettings`): applies captured settings to the control index. Calling it with the control variant reverts previously applied settings.

The current Go handlers and response structs were rechecked. No contract changes were required.

## 🧪 Test
Green CI.

## PR Stack

1. **#6786** ⬅
2. #6829
3. #6834
4. #6879
