### PR TITLE
chore(ci): fail CI when an action ref is not pinned to a commit SHA

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -681,6 +681,15 @@ jobs:
             exit 1
           fi
 
+      - name: Check that action refs in workflow templates are pinned to a commit SHA
+        run: |
+          grep -rnE 'uses:.*@' templates | grep -vE 'uses:\s*[^@]+@[0-9a-f]{40}(\s|$)' > unpinned-templates.txt || true
+          if [[ -s unpinned-templates.txt ]]; then
+            echo "The following action refs in templates/ are not pinned to a commit SHA:"
+            cat unpinned-templates.txt
+            exit 1
+          fi
+
   check_green:
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -674,7 +674,7 @@ jobs:
       - name: Check that every action ref is pinned to a commit SHA
         run: |
           zizmor --no-progress --no-exit-codes --format json .github clients/*/.github > zizmor.json
-          jq -r '.[] | select(.ident == "unpinned-uses") | "\(.locations[0].symbolic.key.Local.verbatim_path): \(.locations[0].symbolic.annotation)"' zizmor.json | sort -u > unpinned.txt
+          jq -r '.[] | select(.ident == "unpinned-uses") | "\(.locations[0].symbolic.key.Local.verbatim_path):\(.locations[0].concrete.location.start_point.row + 1): \(.locations[0].concrete.feature)"' zizmor.json | sort -u > unpinned.txt
           if [[ -s unpinned.txt ]]; then
             echo "The following action refs are not pinned to a commit SHA:"
             cat unpinned.txt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -662,6 +662,25 @@ jobs:
         id: setoutput
         run: echo "success=true" >> "$GITHUB_OUTPUT"
 
+  action_pins:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install zizmor
+        run: pipx install zizmor==1.29.0
+
+      - name: Check that every action ref is pinned to a commit SHA
+        run: |
+          zizmor --no-progress --no-exit-codes --format json .github clients/*/.github > zizmor.json
+          jq -r '.[] | select(.ident == "unpinned-uses") | "\(.locations[0].symbolic.key.Local.verbatim_path): \(.locations[0].symbolic.annotation)"' zizmor.json | sort -u > unpinned.txt
+          if [[ -s unpinned.txt ]]; then
+            echo "The following action refs are not pinned to a commit SHA:"
+            cat unpinned.txt
+            exit 1
+          fi
+
   check_green:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -669,10 +688,11 @@ jobs:
       - codegen
       - swift_build_linux
       - kotlin_build_macos
+      - action_pins
     if: always()
     steps:
       - run: |
-          if [[ ("${{ needs.codegen.outputs.success }}" != "true") || ("${{ needs.swift_build_linux.result }}" != "skipped" && "${{ needs.swift_build_linux.outputs.success }}" != "true") || ("${{ needs.kotlin_build_macos.result }}" != "skipped" && "${{ needs.kotlin_build_macos.outputs.success }}" != "true")]]; then
+          if [[ ("${{ needs.codegen.outputs.success }}" != "true") || ("${{ needs.swift_build_linux.result }}" != "skipped" && "${{ needs.swift_build_linux.outputs.success }}" != "true") || ("${{ needs.kotlin_build_macos.result }}" != "skipped" && "${{ needs.kotlin_build_macos.outputs.success }}" != "true") || ("${{ needs.action_pins.result }}" != "success") ]]; then
             echo "a needed step failed"
             exit 1
           fi


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-475](https://algolia.atlassian.net/browse/API-475)

Follow up to #6819. Now that every action ref is pinned to a commit SHA, this adds a CI guard so an unpinned ref cannot sneak back in through a future workflow change.

### Changes included:

- New `action_pins` job in `.github/workflows/check.yml` (line 665) that runs zizmor 1.29.0 and fails if the `unpinned-uses` audit reports anything under `.github/` or `clients/*/.github/`. Other zizmor audits are not gated here, they need their own cleanup first.
- Failure output lists each finding as `file:line: action@ref` (from the finding's concrete location) instead of the generic per-file annotation, which collapsed to one line per file under `sort -u`.
- Added the job to the `check_green` needs and failure condition (lines 691 and 695) so it blocks the merge gate.
- Added a second step to the job that greps `templates/` for `uses:` refs not pinned to a 40-hex SHA (line 684). zizmor only scans `.github` directories, and the generator copies `templates/issue.yml` and `templates/do-not-edit-this-repository.yml` into every client's workflows at generation time, so an unpinned ref there would otherwise only surface after regeneration on main, blamed on an unrelated PR.

## 🧪 Test

- Ran the exact guard script locally on this branch: zero findings, the job passes.
- Ran it against main, which still has floating tags: it lists 93 unpinned refs and exits 1, so the failure path works. With the new output format each line reads like `.github/actions/setup/action.yml:22: actions/setup-java@v5`, verified against zizmor 1.29.0 JSON locally (rows are 0-indexed, hence the `+ 1`).
- Ran the templates grep on this branch (empty output, passes) and against the pre-#6819 `templates/issue.yml` (reports the unpinned `actions/github-script@v9` line and exits 1).
- actionlint on the modified check.yml reports only the pre-existing shellcheck notes, nothing new.

[API-475]: https://algolia.atlassian.net/browse/API-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

