### PR TITLE
fix(ci): switch back to upstream swift-actions/setup-swift

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -173,11 +173,7 @@ runs:
     # Swift deps
     - name: Install swift
       if: ${{ inputs.language == 'swift' }}
-      # WORKAROUND for: https://github.com/swift-actions/setup-swift/issues/591
-      # BY GitHub Staff developer: redsun82
-      # IN pull request: https://github.com/github/codeql/pull/16153
-      # uses: swift-actions/setup-swift@v2
-      uses: redsun82/setup-swift@b2b6f77ab14f6a9b136b520dc53ec8eca27d2b99
+      uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
       with:
         swift-version: ${{ inputs.version }}
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-475](https://algolia.atlassian.net/browse/API-475)

Follow up to #6819. The Swift install step uses the redsun82 fork of setup-swift, added in #2989 as a workaround for swift-actions/setup-swift#591. Upstream closed that issue on 2025-11-18 and shipped v2.4.0 the next day, so we can return to the maintained action. The fork has no release tags so Renovate cannot manage its pin, while the upstream pin carries a version comment and stays managed.

### Changes included:

- `.github/actions/setup/action.yml` line 176: replaced `redsun82/setup-swift@b2b6f77` with `swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0` and removed the workaround comment block.

## 🧪 Test

- Verified the SHA with git ls-remote: refs/tags/v2.4.0 in swift-actions/setup-swift points to 7ca6abe (lightweight tag).
- zizmor unpinned-uses reports zero findings after the change.
- The real validation is the swift client job on this PR's CI, since the action only runs when the language is swift.

[API-475]: https://algolia.atlassian.net/browse/API-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ