### PR TITLE
fix(php): replace deprecated GuzzleHttp\choose_handler()

### DIFF
--- a/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
+++ b/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 
 final class GuzzleHttpClient implements HttpClientInterface
@@ -46,7 +47,7 @@ final class GuzzleHttpClient implements HttpClientInterface
 
     private static function buildClient(array $config = [])
     {
-        $handlerStack = new HandlerStack(\GuzzleHttp\choose_handler());
+        $handlerStack = new HandlerStack(Utils::chooseHandler());
         $handlerStack->push(Middleware::prepareBody(), 'prepare_body');
         $config = array_merge(['handler' => $handlerStack], $config);
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-539](https://algolia.atlassian.net/browse/API-539)

`\GuzzleHttp\choose_handler()` is deprecated since Guzzle 7.1 and removed in 8.0, so building a client emits a deprecation notice ([#761](https://github.com/algolia/algoliasearch-client-php/issues/761)).

### Changes included:

- `GuzzleHttpClient::buildClient()`: use `Utils::chooseHandler()`.

## 🧪 Test

Reproducing needs `guzzlehttp/guzzle:^7.15` — 7.15.0 is where Guzzle added the runtime `trigger_deprecation()` calls, so the 7.12.x-dev in `vendor/` can't surface this either way.

On guzzle 7.15.2, with an error handler collecting `E_USER_DEPRECATED`, calling `SearchClient::create()`:

- released 4.46.3 → `Since guzzlehttp/guzzle 7.1: GuzzleHttp\choose_handler() is deprecated and will be removed in 8.0.`
- this branch → none

Behaviour is unchanged: `choose_handler()` was a one-line wrapper around `Utils::chooseHandler()`, and both select the same handler. `Utils::chooseHandler()` exists since Guzzle 7.0, and `guzzlehttp/psr7: ^2.0` puts the effective floor at 7.3.

Also ran `tests/output/php/src/manual/TimeoutIntegrationTest.php` with Guzzle installed (normally skipped): 8/8 pass.


[API-539]: https://algolia.atlassian.net/browse/API-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
