### PR TITLE
feat(specs): add A/B testing hypothesis

### DIFF
--- a/specs/abtesting-v3/common/parameters.yml
+++ b/specs/abtesting-v3/common/parameters.yml
@@ -44,6 +44,11 @@ name:
   description: A/B test name.
   example: Custom ranking sales rank test
 
+hypothesis:
+  type: string
+  description: Expected outcome of the A/B test.
+  example: Enabling the feature increases conversion rate
+
 description:
   type: string
   description: Description for this variant.

--- a/specs/abtesting-v3/common/schemas/ABTest.yml
+++ b/specs/abtesting-v3/common/schemas/ABTest.yml
@@ -37,6 +37,7 @@ ABTest:
   required:
     - status
     - name
+    - hypothesis
     - createdAt
     - endAt
     - updatedAt

--- a/specs/abtesting-v3/common/schemas/ABTest.yml
+++ b/specs/abtesting-v3/common/schemas/ABTest.yml
@@ -22,6 +22,8 @@ ABTest:
       $ref: '../parameters.yml#/stoppedAt'
     name:
       $ref: '../parameters.yml#/name'
+    hypothesis:
+      $ref: '../parameters.yml#/hypothesis'
     status:
       $ref: '#/Status'
     variants:

--- a/specs/abtesting-v3/paths/abtests.yml
+++ b/specs/abtesting-v3/paths/abtests.yml
@@ -17,6 +17,8 @@ post:
           properties:
             name:
               $ref: '../common/parameters.yml#/name'
+            hypothesis:
+              $ref: '../common/parameters.yml#/hypothesis'
             variants:
               type: array
               description: A/B test variants.


### PR DESCRIPTION
## 🧭 What and Why

The unified A/B test creation flow collects an optional hypothesis, but the A/B Testing v3 client contract does not expose it yet. This adds the field to create requests and A/B test responses so generated clients can carry the value end to end.

🎟 JIRA Ticket:

### Changes included:

- Add the optional `hypothesis` request parameter.
- Require `hypothesis` on A/B test responses while keeping it optional in create requests.

## 🧪 Test

- `yarn cli build specs abtesting-v3`
- `yarn specs:lint specs/abtesting-v3/`
- Generated and built the JavaScript A/B Testing v3 client locally.

## PR Stack

1. #6884
2. #6786
3. **#6829** ⬅
4. #6834
5. #6879
