### PR TITLE
feat(csharp): Request-ID and Correlation-ID support

### DIFF
--- a/clients/algoliasearch-client-csharp/algoliasearch/Clients/AlgoliaConfig.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Clients/AlgoliaConfig.cs
@@ -82,6 +82,16 @@ namespace Algolia.Search.Clients
     public CompressionType Compression { get; set; }
 
     /// <summary>
+    /// Whether the transport sends a Request-ID header, minted once per call
+    /// and reused across its retry attempts, so that Algolia support can tie
+    /// the attempts of one request together. Forced by the generated client
+    /// configurations according to which APIs support it; a Request-ID
+    /// supplied through request options or DefaultHeaders is never
+    /// overwritten.
+    /// </summary>
+    internal bool RequestIdEnabled { get; set; }
+
+    /// <summary>
     /// Configurations hosts
     /// </summary>
     protected internal List<StatefulHost> DefaultHosts { get; set; }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Clients/AlgoliaConfig.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Clients/AlgoliaConfig.cs
@@ -84,12 +84,12 @@ namespace Algolia.Search.Clients
     /// <summary>
     /// Whether the transport sends a Request-ID header, minted once per call
     /// and reused across its retry attempts, so that Algolia support can tie
-    /// the attempts of one request together. Forced by the generated client
-    /// configurations according to which APIs support it; a Request-ID
-    /// supplied through request options or DefaultHeaders is never
-    /// overwritten.
+    /// the attempts of one request together. Defaulted by the generated client
+    /// configurations according to which APIs support it; set it to false to
+    /// disable minting entirely. A Request-ID supplied through request options
+    /// or DefaultHeaders is never overwritten.
     /// </summary>
-    internal bool RequestIdEnabled { get; set; }
+    public bool RequestIdEnabled { get; set; }
 
     /// <summary>
     /// Configurations hosts

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
@@ -13,13 +13,29 @@ public class AlgoliaApiException : Exception
   public int HttpErrorCode { get; set; }
 
   /// <summary>
+  /// The Correlation-ID header of the failed response, when present.
+  /// Quote it when contacting Algolia support.
+  /// </summary>
+  public string CorrelationId { get; }
+
+  /// <summary>
   /// Create a new AlgoliaAPIException
   /// </summary>
   /// <param name="message"></param>
   /// <param name="httpErrorCode"></param>
   public AlgoliaApiException(string message, int httpErrorCode)
-    : base(message)
+    : this(message, httpErrorCode, null) { }
+
+  /// <summary>
+  /// Create a new AlgoliaAPIException carrying the Correlation-ID of the failed response
+  /// </summary>
+  /// <param name="message"></param>
+  /// <param name="httpErrorCode"></param>
+  /// <param name="correlationId"></param>
+  public AlgoliaApiException(string message, int httpErrorCode, string correlationId)
+    : base(correlationId == null ? message : $"{message} (Correlation-ID: {correlationId})")
   {
     HttpErrorCode = httpErrorCode;
+    CorrelationId = correlationId;
   }
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
@@ -21,17 +21,17 @@ public class AlgoliaApiException : Exception
   /// <summary>
   /// Create a new AlgoliaAPIException
   /// </summary>
-  /// <param name="message"></param>
-  /// <param name="httpErrorCode"></param>
+  /// <param name="message">The raw response body of the failed request.</param>
+  /// <param name="httpErrorCode">The HTTP status code of the failed response.</param>
   public AlgoliaApiException(string message, int httpErrorCode)
     : this(message, httpErrorCode, null) { }
 
   /// <summary>
   /// Create a new AlgoliaAPIException carrying the Correlation-ID of the failed response
   /// </summary>
-  /// <param name="message"></param>
-  /// <param name="httpErrorCode"></param>
-  /// <param name="correlationId"></param>
+  /// <param name="message">The raw response body of the failed request.</param>
+  /// <param name="httpErrorCode">The HTTP status code of the failed response.</param>
+  /// <param name="correlationId">The Correlation-ID header of the failed response, or null when absent.</param>
   public AlgoliaApiException(string message, int httpErrorCode, string correlationId)
     : base(message)
   {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
@@ -19,6 +19,12 @@ public class AlgoliaApiException : Exception
   public string CorrelationId { get; }
 
   /// <summary>
+  /// The response body as received, without the Correlation-ID suffix that
+  /// Message carries, for callers that parse the error payload.
+  /// </summary>
+  public string ResponseBody { get; }
+
+  /// <summary>
   /// Create a new AlgoliaAPIException
   /// </summary>
   /// <param name="message">The raw response body of the failed request.</param>
@@ -29,22 +35,14 @@ public class AlgoliaApiException : Exception
   /// <summary>
   /// Create a new AlgoliaAPIException carrying the Correlation-ID of the failed response
   /// </summary>
-  /// <param name="message">The raw response body of the failed request.</param>
+  /// <param name="message">The raw response body of the failed request; Message carries it with the Correlation-ID appended.</param>
   /// <param name="httpErrorCode">The HTTP status code of the failed response.</param>
   /// <param name="correlationId">The Correlation-ID header of the failed response, or null when absent.</param>
   public AlgoliaApiException(string message, int httpErrorCode, string correlationId)
-    : base(message)
+    : base(correlationId == null ? message : $"{message} (Correlation-ID: {correlationId})")
   {
     HttpErrorCode = httpErrorCode;
     CorrelationId = correlationId;
+    ResponseBody = message;
   }
-
-  /// <summary>
-  /// Appends the Correlation-ID to the formatted string when one is known;
-  /// Message stays the raw response body.
-  /// </summary>
-  public override string ToString() =>
-    CorrelationId == null
-      ? base.ToString()
-      : $"{base.ToString()} (Correlation-ID: {CorrelationId})";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
@@ -19,6 +19,11 @@ public class AlgoliaApiException : Exception
   public string CorrelationId { get; }
 
   /// <summary>
+  /// The raw response body, unmodified, for callers that parse the server payload.
+  /// </summary>
+  public string ResponseBody { get; }
+
+  /// <summary>
   /// Create a new AlgoliaAPIException
   /// </summary>
   /// <param name="message"></param>
@@ -37,5 +42,6 @@ public class AlgoliaApiException : Exception
   {
     HttpErrorCode = httpErrorCode;
     CorrelationId = correlationId;
+    ResponseBody = message;
   }
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaApiException.cs
@@ -19,11 +19,6 @@ public class AlgoliaApiException : Exception
   public string CorrelationId { get; }
 
   /// <summary>
-  /// The raw response body, unmodified, for callers that parse the server payload.
-  /// </summary>
-  public string ResponseBody { get; }
-
-  /// <summary>
   /// Create a new AlgoliaAPIException
   /// </summary>
   /// <param name="message"></param>
@@ -38,10 +33,18 @@ public class AlgoliaApiException : Exception
   /// <param name="httpErrorCode"></param>
   /// <param name="correlationId"></param>
   public AlgoliaApiException(string message, int httpErrorCode, string correlationId)
-    : base(correlationId == null ? message : $"{message} (Correlation-ID: {correlationId})")
+    : base(message)
   {
     HttpErrorCode = httpErrorCode;
     CorrelationId = correlationId;
-    ResponseBody = message;
   }
+
+  /// <summary>
+  /// Appends the Correlation-ID to the formatted string when one is known;
+  /// Message stays the raw response body.
+  /// </summary>
+  public override string ToString() =>
+    CorrelationId == null
+      ? base.ToString()
+      : $"{base.ToString()} (Correlation-ID: {CorrelationId})";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaException.cs
@@ -8,6 +8,12 @@ namespace Algolia.Search.Exceptions;
 public class AlgoliaException : Exception
 {
   /// <summary>
+  /// The Correlation-ID header of the response whose handling failed, when
+  /// present. Quote it when contacting Algolia support.
+  /// </summary>
+  public string CorrelationId { get; internal set; }
+
+  /// <summary>
   /// Create a new Algolia exception.
   /// </summary>
   /// <param name="message">The exception details.</param>
@@ -21,4 +27,12 @@ public class AlgoliaException : Exception
   /// <param name="inner"></param>
   public AlgoliaException(string message, Exception inner)
     : base(message, inner) { }
+
+  /// <summary>
+  /// Appends the Correlation-ID to the formatted string when one is known.
+  /// </summary>
+  public override string ToString() =>
+    CorrelationId == null
+      ? base.ToString()
+      : $"{base.ToString()} (Correlation-ID: {CorrelationId})";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaException.cs
@@ -29,10 +29,10 @@ public class AlgoliaException : Exception
     : base(message, inner) { }
 
   /// <summary>
-  /// Appends the Correlation-ID to the formatted string when one is known.
+  /// The exception details, with the Correlation-ID appended when one is
+  /// known. CorrelationId is set after construction, so the suffix cannot be
+  /// baked in through the base constructor.
   /// </summary>
-  public override string ToString() =>
-    CorrelationId == null
-      ? base.ToString()
-      : $"{base.ToString()} (Correlation-ID: {CorrelationId})";
+  public override string Message =>
+    CorrelationId == null ? base.Message : $"{base.Message} (Correlation-ID: {CorrelationId})";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaUnreachableHostException.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Exceptions/AlgoliaUnreachableHostException.cs
@@ -8,9 +8,27 @@ namespace Algolia.Search.Exceptions;
 public class AlgoliaUnreachableHostException : Exception
 {
   /// <summary>
+  /// The Correlation-ID header of the last retried attempt whose response
+  /// carried one, or null when no attempt did. Quote it when contacting
+  /// Algolia support.
+  /// </summary>
+  public string CorrelationId { get; }
+
+  /// <summary>
   /// Create a new AlgoliaUnreachableHostException.
   /// </summary>
   /// <param name="message">The exception details.</param>
   public AlgoliaUnreachableHostException(string message)
-    : base(message) { }
+    : this(message, null) { }
+
+  /// <summary>
+  /// Create a new AlgoliaUnreachableHostException carrying the Correlation-ID of the last retried attempt.
+  /// </summary>
+  /// <param name="message">The exception details.</param>
+  /// <param name="correlationId">The Correlation-ID of the last retried attempt whose response carried one.</param>
+  public AlgoliaUnreachableHostException(string message, string correlationId)
+    : base(correlationId == null ? message : $"{message} (Correlation-ID: {correlationId})")
+  {
+    CorrelationId = correlationId;
+  }
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Http/RequestOptions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Http/RequestOptions.cs
@@ -42,4 +42,10 @@ public class RequestOptions
     QueryParameters = new Dictionary<string, object>();
     Headers = new Dictionary<string, string>();
   }
+
+  /// <summary>
+  /// Returns a shallow copy carrying every property, present and future, so
+  /// helpers can adjust options without mutating the caller's instance.
+  /// </summary>
+  internal RequestOptions ShallowCopy() => (RequestOptions)MemberwiseClone();
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -117,6 +117,19 @@ internal class HttpTransport : IDisposable
       Compression = _algoliaConfig.Compression,
     };
 
+    if (_algoliaConfig.RequestIdEnabled && !RequestIdHelper.HasRequestId(request.Headers))
+    {
+      // The ID is minted once per execution, before the host loop, so that
+      // every retry attempt shares the same value and each subsequent call
+      // gets a fresh one. GenerateHeaders returns the live DefaultHeaders
+      // dictionary on the no-options path, so it must be copied before
+      // injecting or the ID would be pinned into the client configuration.
+      request.Headers = new Dictionary<string, string>(request.Headers)
+      {
+        [Defaults.RequestIdHeader.ToLowerInvariant()] = RequestIdHelper.Generate(),
+      };
+    }
+
     var callType =
       (requestOptions?.UseReadTransporter != null && requestOptions.UseReadTransporter.Value)
       || method == HttpMethod.Get
@@ -273,7 +286,11 @@ internal class HttpTransport : IDisposable
             );
           }
 
-          throw new AlgoliaApiException(response.Error, response.HttpStatusCode);
+          throw new AlgoliaApiException(
+            response.Error,
+            response.HttpStatusCode,
+            GetCorrelationId(response)
+          );
         default:
           throw new ArgumentOutOfRangeException();
       }
@@ -358,6 +375,30 @@ internal class HttpTransport : IDisposable
 
     var builder = new UriBuilder(uri) { Query = string.Join("&", sanitized) };
     return builder.Uri.ToString();
+  }
+
+  /// <summary>
+  /// Read the Correlation-ID header of a failed response, case-insensitively:
+  /// the response dictionary keeps the server's casing. The unrelated
+  /// X-Algolia-RequestID edge header must never be read instead. Headers are
+  /// null on timeout and network failures.
+  /// </summary>
+  private static string GetCorrelationId(AlgoliaHttpResponse response)
+  {
+    if (response.ResponseHeaders == null)
+    {
+      return null;
+    }
+
+    foreach (var header in response.ResponseHeaders)
+    {
+      if (header.Key.Equals(Defaults.CorrelationIdHeader, StringComparison.OrdinalIgnoreCase))
+      {
+        return header.Value;
+      }
+    }
+
+    return null;
   }
 
   /// <summary>

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -140,6 +140,9 @@ internal class HttpTransport : IDisposable
     var maxAttempts = tryableHosts.Count;
     var attemptNumber = 0;
     var overallStopwatch = Stopwatch.StartNew();
+    // The Correlation-ID of the last attempt whose response carried one,
+    // surfaced on the exhaustion exception for support tickets.
+    string lastCorrelationId = null;
 
     foreach (var host in tryableHosts)
     {
@@ -184,6 +187,7 @@ internal class HttpTransport : IDisposable
       requestStopwatch.Stop();
 
       _errorMessage = response.Error;
+      lastCorrelationId = GetCorrelationId(response) ?? lastCorrelationId;
 
       switch (_retryStrategy.Decide(host, response))
       {
@@ -307,7 +311,8 @@ internal class HttpTransport : IDisposable
 
     throw new AlgoliaUnreachableHostException(
       "RetryStrategy failed to connect to Algolia. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support Reason: "
-        + _errorMessage
+        + _errorMessage,
+      lastCorrelationId
     );
   }
 

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -123,11 +123,7 @@ internal class HttpTransport : IDisposable
       && !RequestIdHelper.HasRequestIdQueryParameter(requestOptions?.QueryParameters)
     )
     {
-      // The ID is minted once per execution, before the host loop, so that
-      // every retry attempt shares the same value and each subsequent call
-      // gets a fresh one. GenerateHeaders returns the live DefaultHeaders
-      // dictionary on the no-options path, so it must be copied before
-      // injecting or the ID would be pinned into the client configuration.
+      // GenerateHeaders returns the live DefaultHeaders alias, so copy before injecting.
       request.Headers = new Dictionary<string, string>(request.Headers)
       {
         [Defaults.RequestIdHeader.ToLowerInvariant()] = RequestIdHelper.Generate(),
@@ -387,8 +383,7 @@ internal class HttpTransport : IDisposable
   }
 
   /// <summary>
-  /// Read the Correlation-ID header of a failed response, case-insensitively:
-  /// the response dictionary keeps the server's casing. The unrelated
+  /// Read the Correlation-ID header of a failed response; the unrelated
   /// X-Algolia-RequestID edge header must never be read instead. Headers are
   /// null on timeout and network failures.
   /// </summary>

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -117,7 +117,11 @@ internal class HttpTransport : IDisposable
       Compression = _algoliaConfig.Compression,
     };
 
-    if (_algoliaConfig.RequestIdEnabled && !RequestIdHelper.HasRequestId(request.Headers))
+    if (
+      _algoliaConfig.RequestIdEnabled
+      && !RequestIdHelper.HasRequestId(request.Headers)
+      && !RequestIdHelper.HasRequestIdQueryParameter(requestOptions?.QueryParameters)
+    )
     {
       // The ID is minted once per execution, before the host loop, so that
       // every retry attempt shares the same value and each subsequent call

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -26,7 +26,6 @@ internal class HttpTransport : IDisposable
   private readonly ISerializer _serializer;
   private readonly RetryStrategy _retryStrategy;
   internal AlgoliaConfig _algoliaConfig;
-  private string _errorMessage;
   private readonly ILogger<HttpTransport> _logger;
 
   private class VoidResult { }
@@ -141,8 +140,10 @@ internal class HttpTransport : IDisposable
     var attemptNumber = 0;
     var overallStopwatch = Stopwatch.StartNew();
     // The Correlation-ID of the last attempt whose response carried one,
-    // surfaced on the exhaustion exception for support tickets.
+    // surfaced on the exhaustion exception for support tickets. Both are
+    // locals so concurrent requests on one client cannot mix their values.
     string lastCorrelationId = null;
+    string errorMessage = null;
 
     foreach (var host in tryableHosts)
     {
@@ -186,7 +187,7 @@ internal class HttpTransport : IDisposable
         .ConfigureAwait(false);
       requestStopwatch.Stop();
 
-      _errorMessage = response.Error;
+      errorMessage = response.Error;
       lastCorrelationId = GetCorrelationId(response) ?? lastCorrelationId;
 
       switch (_retryStrategy.Decide(host, response))
@@ -314,13 +315,13 @@ internal class HttpTransport : IDisposable
       _logger.LogError(
         "Request failed after {MaxAttempts} attempts: {ErrorMessage}",
         maxAttempts,
-        _errorMessage
+        errorMessage
       );
     }
 
     throw new AlgoliaUnreachableHostException(
       "RetryStrategy failed to connect to Algolia. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support Reason: "
-        + _errorMessage,
+        + errorMessage,
       lastCorrelationId
     );
   }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Transport/HttpTransport.cs
@@ -126,7 +126,7 @@ internal class HttpTransport : IDisposable
       // GenerateHeaders returns the live DefaultHeaders alias, so copy before injecting.
       request.Headers = new Dictionary<string, string>(request.Headers)
       {
-        [Defaults.RequestIdHeader.ToLowerInvariant()] = RequestIdHelper.Generate(),
+        [Defaults.RequestIdHeader] = RequestIdHelper.Generate(),
       };
     }
 
@@ -248,9 +248,18 @@ internal class HttpTransport : IDisposable
             return response as TResult;
           }
 
-          var deserialized = await _serializer
-            .Deserialize<TResult>(response.Body)
-            .ConfigureAwait(false);
+          TResult deserialized;
+          try
+          {
+            deserialized = await _serializer
+              .Deserialize<TResult>(response.Body)
+              .ConfigureAwait(false);
+          }
+          catch (AlgoliaException ex)
+          {
+            ex.CorrelationId = GetCorrelationId(response);
+            throw;
+          }
 
           if (_logger.IsEnabled(LogLevel.Debug))
           {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/Defaults.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/Defaults.cs
@@ -31,4 +31,6 @@ internal static class Defaults
   public const string ContentType = "Content-Type";
   public const string ApplicationJson = "application/json; charset=utf-8";
   public const string GzipEncoding = "gzip";
+  public const string RequestIdHeader = "Request-ID";
+  public const string CorrelationIdHeader = "Correlation-ID";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/Defaults.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/Defaults.cs
@@ -31,6 +31,6 @@ internal static class Defaults
   public const string ContentType = "Content-Type";
   public const string ApplicationJson = "application/json; charset=utf-8";
   public const string GzipEncoding = "gzip";
-  public const string RequestIdHeader = "Request-ID";
+  public const string RequestIdHeader = "request-id";
   public const string CorrelationIdHeader = "Correlation-ID";
 }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
@@ -14,9 +14,7 @@ internal static class RequestIdHelper
   private const int Length = 11;
 
   /// <summary>
-  /// Returns a fresh 11-character base62 identifier suitable for the
-  /// Request-ID header. The modulo bias of the byte mapping is acceptable:
-  /// the ID is a tracing breadcrumb, not a secret.
+  /// Returns a fresh 11-character base62 identifier for the Request-ID header.
   /// </summary>
   internal static string Generate()
   {
@@ -38,10 +36,7 @@ internal static class RequestIdHelper
   private const string QueryParameter = "x-algolia-request-id";
 
   /// <summary>
-  /// Whether the given query parameters already carry an x-algolia-request-id
-  /// entry, whatever its casing. The server consults the query parameter only
-  /// when the Request-ID header is absent, so minting a header would override
-  /// a caller who supplied their ID through this channel.
+  /// Whether the query parameters already carry an x-algolia-request-id entry, whatever its casing.
   /// </summary>
   internal static bool HasRequestIdQueryParameter<TValue>(IDictionary<string, TValue> queryParameters)
   {
@@ -62,9 +57,7 @@ internal static class RequestIdHelper
   }
 
   /// <summary>
-  /// Whether the given header dictionary already carries a Request-ID entry,
-  /// whatever its casing. Plain header dictionaries keep the caller's literal
-  /// casing, so the lookup must not assume a canonical form.
+  /// Whether the headers already carry a Request-ID entry, whatever its casing.
   /// </summary>
   internal static bool HasRequestId(IDictionary<string, string> headers)
   {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
@@ -35,6 +35,32 @@ internal static class RequestIdHelper
     return new string(id);
   }
 
+  private const string QueryParameter = "x-algolia-request-id";
+
+  /// <summary>
+  /// Whether the given query parameters already carry an x-algolia-request-id
+  /// entry, whatever its casing. The server consults the query parameter only
+  /// when the Request-ID header is absent, so minting a header would override
+  /// a caller who supplied their ID through this channel.
+  /// </summary>
+  internal static bool HasRequestIdQueryParameter<TValue>(IDictionary<string, TValue> queryParameters)
+  {
+    if (queryParameters == null)
+    {
+      return false;
+    }
+
+    foreach (var parameter in queryParameters)
+    {
+      if (parameter.Key.Equals(QueryParameter, StringComparison.OrdinalIgnoreCase))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /// <summary>
   /// Whether the given header dictionary already carries a Request-ID entry,
   /// whatever its casing. Plain header dictionaries keep the caller's literal

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
@@ -13,16 +13,16 @@ internal static class RequestIdHelper
 
   private const int Length = 11;
 
+  // Shared across requests; GetBytes is thread-safe.
+  private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
+
   /// <summary>
   /// Returns a fresh 11-character base62 identifier for the Request-ID header.
   /// </summary>
   internal static string Generate()
   {
     var bytes = new byte[Length];
-    using (var rng = RandomNumberGenerator.Create())
-    {
-      rng.GetBytes(bytes);
-    }
+    Rng.GetBytes(bytes);
 
     var id = new char[Length];
     for (var i = 0; i < Length; i++)
@@ -38,7 +38,9 @@ internal static class RequestIdHelper
   /// <summary>
   /// Whether the query parameters already carry an x-algolia-request-id entry, whatever its casing.
   /// </summary>
-  internal static bool HasRequestIdQueryParameter<TValue>(IDictionary<string, TValue> queryParameters)
+  internal static bool HasRequestIdQueryParameter<TValue>(
+    IDictionary<string, TValue> queryParameters
+  )
   {
     if (queryParameters == null)
     {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/RequestIdHelper.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace Algolia.Search.Utils;
+
+/// <summary>
+/// Mints the Request-ID tracing header sent by the clients that support it.
+/// </summary>
+internal static class RequestIdHelper
+{
+  private const string Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  private const int Length = 11;
+
+  /// <summary>
+  /// Returns a fresh 11-character base62 identifier suitable for the
+  /// Request-ID header. The modulo bias of the byte mapping is acceptable:
+  /// the ID is a tracing breadcrumb, not a secret.
+  /// </summary>
+  internal static string Generate()
+  {
+    var bytes = new byte[Length];
+    using (var rng = RandomNumberGenerator.Create())
+    {
+      rng.GetBytes(bytes);
+    }
+
+    var id = new char[Length];
+    for (var i = 0; i < Length; i++)
+    {
+      id[i] = Alphabet[bytes[i] % Alphabet.Length];
+    }
+
+    return new string(id);
+  }
+
+  /// <summary>
+  /// Whether the given header dictionary already carries a Request-ID entry,
+  /// whatever its casing. Plain header dictionaries keep the caller's literal
+  /// casing, so the lookup must not assume a canonical form.
+  /// </summary>
+  internal static bool HasRequestId(IDictionary<string, string> headers)
+  {
+    if (headers == null)
+    {
+      return false;
+    }
+
+    foreach (var header in headers)
+    {
+      if (header.Key.Equals(Defaults.RequestIdHeader, StringComparison.OrdinalIgnoreCase))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -559,6 +559,37 @@ public partial class SearchClient : ISearchClient
   /// </summary>
   public const int DefaultMaxRetries = RetryHelper.DefaultMaxRetries;
 
+  /// <summary>
+  /// Derives the request options carrying the Request-ID shared by every
+  /// request of one helper invocation. Returns the options untouched when the
+  /// client does not support Request-ID or the caller already supplied one
+  /// through the options or DefaultHeaders, which also makes nested helpers
+  /// reuse the ID minted by their caller.
+  /// </summary>
+  private RequestOptions WithRequestId(RequestOptions options)
+  {
+    if (
+      !_transport._algoliaConfig.RequestIdEnabled
+      || RequestIdHelper.HasRequestId(options?.Headers)
+      || RequestIdHelper.HasRequestId(_transport._algoliaConfig.DefaultHeaders)
+    )
+    {
+      return options;
+    }
+
+    return new RequestOptions
+    {
+      Headers = new Dictionary<string, string>(options?.Headers ?? new Dictionary<string, string>())
+      {
+        [Defaults.RequestIdHeader.ToLowerInvariant()] = RequestIdHelper.Generate(),
+      },
+      QueryParameters = options?.QueryParameters ?? new Dictionary<string, object>(),
+      ReadTimeout = options?.ReadTimeout,
+      WriteTimeout = options?.WriteTimeout,
+      ConnectTimeout = options?.ConnectTimeout,
+    };
+  }
+
   /// <inheritdoc/>
   public async Task<GetTaskResponse> WaitForTaskAsync(
     string indexName,
@@ -567,8 +598,11 @@ public partial class SearchClient : ISearchClient
     Func<int, int> timeout = null,
     RequestOptions requestOptions = null,
     CancellationToken ct = default
-  ) =>
-    await RetryHelper
+  )
+  {
+    requestOptions = WithRequestId(requestOptions);
+
+    return await RetryHelper
       .RetryUntil(
         async () => await GetTaskAsync(indexName, taskId, requestOptions, ct),
         resp => resp.Status == Models.Search.TaskStatus.Published,
@@ -577,6 +611,7 @@ public partial class SearchClient : ISearchClient
         ct
       )
       .ConfigureAwait(false);
+  }
 
   /// <inheritdoc/>
   public GetTaskResponse WaitForTask(
@@ -598,8 +633,11 @@ public partial class SearchClient : ISearchClient
     Func<int, int> timeout = null,
     RequestOptions requestOptions = null,
     CancellationToken ct = default
-  ) =>
-    await RetryHelper
+  )
+  {
+    requestOptions = WithRequestId(requestOptions);
+
+    return await RetryHelper
       .RetryUntil(
         async () => await GetAppTaskAsync(taskId, requestOptions, ct),
         resp => resp.Status == Models.Search.TaskStatus.Published,
@@ -608,6 +646,7 @@ public partial class SearchClient : ISearchClient
         ct
       )
       .ConfigureAwait(false);
+  }
 
   /// <inheritdoc/>
   public GetTaskResponse WaitForAppTask(
@@ -630,6 +669,8 @@ public partial class SearchClient : ISearchClient
     CancellationToken ct = default
   )
   {
+    requestOptions = WithRequestId(requestOptions);
+
     if (operation == ApiKeyOperation.Update)
     {
       if (apiKey == null)
@@ -719,6 +760,7 @@ public partial class SearchClient : ISearchClient
     RequestOptions requestOptions = null
   )
   {
+    requestOptions = WithRequestId(requestOptions);
     browseParams.HitsPerPage = 1000;
     var all = await CreateIterable<BrowseResponse<T>>(
         async prevResp =>
@@ -747,6 +789,7 @@ public partial class SearchClient : ISearchClient
     RequestOptions requestOptions = null
   )
   {
+    requestOptions = WithRequestId(requestOptions);
     const int hitsPerPage = 1000;
     searchRulesParams.HitsPerPage = hitsPerPage;
 
@@ -782,6 +825,7 @@ public partial class SearchClient : ISearchClient
     RequestOptions requestOptions = null
   )
   {
+    requestOptions = WithRequestId(requestOptions);
     const int hitsPerPage = 1000;
     var page = synonymsParams.Page ?? 0;
     synonymsParams.HitsPerPage = hitsPerPage;
@@ -916,6 +960,7 @@ public partial class SearchClient : ISearchClient
   )
     where T : class
   {
+    options = WithRequestId(options);
     chunkedOptions ??= new ChunkedHelperOptions
     {
       MaxRetries = ChunkedHelperOptions.DefaultReplaceAllObjectsMaxRetries,
@@ -1037,8 +1082,7 @@ public partial class SearchClient : ISearchClient
     }
     catch (Exception ex)
     {
-      await DeleteIndexAsync(tmpIndexName, cancellationToken: cancellationToken)
-        .ConfigureAwait(false);
+      await DeleteIndexAsync(tmpIndexName, options, cancellationToken).ConfigureAwait(false);
 
       throw;
     }
@@ -1080,6 +1124,7 @@ public partial class SearchClient : ISearchClient
   )
     where T : class
   {
+    options = WithRequestId(options);
     var maxRetries = chunkedOptions?.MaxRetries ?? RetryHelper.DefaultMaxRetries;
     var objectsList = objects.ToList();
     var totalObjects = objectsList.Count;
@@ -1529,6 +1574,9 @@ public partial class SearchClient : ISearchClient
       MaxRetries = ChunkedHelperOptions.DefaultReplaceAllObjectsMaxRetries,
     };
     var maxRetries = chunkedOptions.MaxRetries;
+    // The shared Request-ID only covers the search-side calls: the ingestion
+    // push goes to an API that must not receive the header.
+    var searchOptions = WithRequestId(options);
     if (_ingestionTransporter == null)
     {
       throw new AlgoliaException(
@@ -1562,7 +1610,7 @@ public partial class SearchClient : ISearchClient
       var copyOperationResponse = await OperationIndexAsync(
           indexName,
           new OperationIndexParams(OperationType.Copy, tmpIndexName) { Scope = scopes },
-          options,
+          searchOptions,
           cancellationToken
         )
         .ConfigureAwait(false);
@@ -1587,7 +1635,7 @@ public partial class SearchClient : ISearchClient
           tmpIndexName,
           copyOperationResponse.TaskID,
           maxRetries: maxRetries,
-          requestOptions: options,
+          requestOptions: searchOptions,
           ct: cancellationToken
         )
         .ConfigureAwait(false);
@@ -1596,7 +1644,7 @@ public partial class SearchClient : ISearchClient
       copyOperationResponse = await OperationIndexAsync(
           indexName,
           new OperationIndexParams(OperationType.Copy, tmpIndexName) { Scope = scopes },
-          options,
+          searchOptions,
           cancellationToken
         )
         .ConfigureAwait(false);
@@ -1605,7 +1653,7 @@ public partial class SearchClient : ISearchClient
           tmpIndexName,
           copyOperationResponse.TaskID,
           maxRetries: maxRetries,
-          requestOptions: options,
+          requestOptions: searchOptions,
           ct: cancellationToken
         )
         .ConfigureAwait(false);
@@ -1614,7 +1662,7 @@ public partial class SearchClient : ISearchClient
       var moveOperationResponse = await OperationIndexAsync(
           tmpIndexName,
           new OperationIndexParams(OperationType.Move, indexName),
-          options,
+          searchOptions,
           cancellationToken
         )
         .ConfigureAwait(false);
@@ -1623,7 +1671,7 @@ public partial class SearchClient : ISearchClient
           tmpIndexName,
           moveOperationResponse.TaskID,
           maxRetries: maxRetries,
-          requestOptions: options,
+          requestOptions: searchOptions,
           ct: cancellationToken
         )
         .ConfigureAwait(false);
@@ -1639,7 +1687,7 @@ public partial class SearchClient : ISearchClient
       // Clean up temp index on error
       try
       {
-        await DeleteIndexAsync(tmpIndexName, cancellationToken: cancellationToken)
+        await DeleteIndexAsync(tmpIndexName, searchOptions, cancellationToken)
           .ConfigureAwait(false);
       }
       catch

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -1095,7 +1095,9 @@ public partial class SearchClient : ISearchClient
     }
     catch (Exception ex)
     {
-      await DeleteIndexAsync(tmpIndexName, options, cancellationToken).ConfigureAwait(false);
+      // The failure may be the caller's own cancellation, and the cleanup
+      // must still delete the temporary index.
+      await DeleteIndexAsync(tmpIndexName, options, CancellationToken.None).ConfigureAwait(false);
 
       throw;
     }
@@ -1707,10 +1709,11 @@ public partial class SearchClient : ISearchClient
     }
     catch
     {
-      // Clean up temp index on error
+      // Clean up temp index on error; the failure may be the caller's own
+      // cancellation, and the cleanup must still delete the temporary index.
       try
       {
-        await DeleteIndexAsync(tmpIndexName, searchOptions, cancellationToken)
+        await DeleteIndexAsync(tmpIndexName, searchOptions, CancellationToken.None)
           .ConfigureAwait(false);
       }
       catch

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -603,6 +603,23 @@ public partial class SearchClient : ISearchClient
     return copy;
   }
 
+  /// <summary>
+  /// Derives the options for a rescue cleanup: the headers survive, the
+  /// caller's timeouts do not, so a timeout that killed the main operation
+  /// cannot also kill the cleanup and leak the temporary index.
+  /// </summary>
+  private static RequestOptions WithoutTimeouts(RequestOptions options)
+  {
+    var copy = options?.ShallowCopy();
+    if (copy != null)
+    {
+      copy.ReadTimeout = null;
+      copy.WriteTimeout = null;
+      copy.ConnectTimeout = null;
+    }
+    return copy;
+  }
+
   /// <inheritdoc/>
   public async Task<GetTaskResponse> WaitForTaskAsync(
     string indexName,
@@ -1093,13 +1110,14 @@ public partial class SearchClient : ISearchClient
         BatchResponses = batchResponse,
       };
     }
-    catch (Exception ex)
+    catch
     {
-      // The failure may be the caller's own cancellation, and the cleanup
-      // must still delete the temporary index.
+      // The failure may be the caller's own cancellation or timeout, and the
+      // cleanup must still delete the temporary index.
       try
       {
-        await DeleteIndexAsync(tmpIndexName, options, CancellationToken.None).ConfigureAwait(false);
+        await DeleteIndexAsync(tmpIndexName, WithoutTimeouts(options), CancellationToken.None)
+          .ConfigureAwait(false);
       }
       catch
       {
@@ -1720,7 +1738,7 @@ public partial class SearchClient : ISearchClient
       // cancellation, and the cleanup must still delete the temporary index.
       try
       {
-        await DeleteIndexAsync(tmpIndexName, searchOptions, CancellationToken.None)
+        await DeleteIndexAsync(tmpIndexName, WithoutTimeouts(searchOptions), CancellationToken.None)
           .ConfigureAwait(false);
       }
       catch

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -571,6 +571,7 @@ public partial class SearchClient : ISearchClient
     if (
       !_transport._algoliaConfig.RequestIdEnabled
       || RequestIdHelper.HasRequestId(options?.Headers)
+      || RequestIdHelper.HasRequestIdQueryParameter(options?.QueryParameters)
       || RequestIdHelper.HasRequestId(_transport._algoliaConfig.DefaultHeaders)
     )
     {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -560,11 +560,7 @@ public partial class SearchClient : ISearchClient
   public const int DefaultMaxRetries = RetryHelper.DefaultMaxRetries;
 
   /// <summary>
-  /// Derives the request options carrying the Request-ID shared by every
-  /// request of one helper invocation. Returns the options untouched when the
-  /// client does not support Request-ID or the caller already supplied one
-  /// through the options or DefaultHeaders, which also makes nested helpers
-  /// reuse the ID minted by their caller.
+  /// Derives the request options carrying the shared per-invocation Request-ID; untouched when unsupported or the caller already supplied one.
   /// </summary>
   private RequestOptions WithRequestId(RequestOptions options)
   {

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -1097,7 +1097,14 @@ public partial class SearchClient : ISearchClient
     {
       // The failure may be the caller's own cancellation, and the cleanup
       // must still delete the temporary index.
-      await DeleteIndexAsync(tmpIndexName, options, CancellationToken.None).ConfigureAwait(false);
+      try
+      {
+        await DeleteIndexAsync(tmpIndexName, options, CancellationToken.None).ConfigureAwait(false);
+      }
+      catch
+      {
+        // A failing cleanup must not replace the root cause.
+      }
 
       throw;
     }

--- a/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
+++ b/clients/algoliasearch-client-csharp/algoliasearch/Utils/SearchClientExtensions.cs
@@ -440,8 +440,27 @@ public partial interface ISearchClient
   /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
   Task<bool> IndexExistsAsync(string indexName, CancellationToken cancellationToken = default);
 
+  /// <summary>
+  /// Helper: Check if an index exists.
+  /// </summary>
+  /// <param name="indexName">The index in which to check.</param>
+  /// <param name="options">Add extra http header or query parameters to Algolia.</param>
+  /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+  Task<bool> IndexExistsAsync(
+    string indexName,
+    RequestOptions options,
+    CancellationToken cancellationToken = default
+  );
+
   /// <inheritdoc cref="IndexExistsAsync(string, CancellationToken)"/>
   bool IndexExists(string indexName, CancellationToken cancellationToken = default);
+
+  /// <inheritdoc cref="IndexExistsAsync(string, RequestOptions, CancellationToken)"/>
+  bool IndexExists(
+    string indexName,
+    RequestOptions options,
+    CancellationToken cancellationToken = default
+  );
 
   /// <summary>
   /// Helper: Similar to the `SaveObjects` method but requires a Push connector to be created first,
@@ -574,17 +593,14 @@ public partial class SearchClient : ISearchClient
       return options;
     }
 
-    return new RequestOptions
+    var copy = options?.ShallowCopy() ?? new RequestOptions();
+    copy.Headers = new Dictionary<string, string>(
+      options?.Headers ?? new Dictionary<string, string>()
+    )
     {
-      Headers = new Dictionary<string, string>(options?.Headers ?? new Dictionary<string, string>())
-      {
-        [Defaults.RequestIdHeader.ToLowerInvariant()] = RequestIdHelper.Generate(),
-      },
-      QueryParameters = options?.QueryParameters ?? new Dictionary<string, object>(),
-      ReadTimeout = options?.ReadTimeout,
-      WriteTimeout = options?.WriteTimeout,
-      ConnectTimeout = options?.ConnectTimeout,
+      [Defaults.RequestIdHeader] = RequestIdHelper.Generate(),
     };
+    return copy;
   }
 
   /// <inheritdoc/>
@@ -1406,27 +1422,37 @@ public partial class SearchClient : ISearchClient
   public async Task<bool> IndexExistsAsync(
     string indexName,
     CancellationToken cancellationToken = default
+  ) => await IndexExistsAsync(indexName, null, cancellationToken).ConfigureAwait(false);
+
+  /// <inheritdoc/>
+  public async Task<bool> IndexExistsAsync(
+    string indexName,
+    RequestOptions options,
+    CancellationToken cancellationToken = default
   )
   {
     try
     {
-      await GetSettingsAsync(indexName, null, null, cancellationToken);
+      await GetSettingsAsync(indexName, null, options, cancellationToken);
     }
     catch (AlgoliaApiException ex) when (ex.HttpErrorCode == 404)
     {
-      return await Task.FromResult(false);
-    }
-    catch (Exception ex)
-    {
-      throw;
+      return false;
     }
 
-    return await Task.FromResult(true);
+    return true;
   }
 
   /// <inheritdoc/>
   public bool IndexExists(string indexName, CancellationToken cancellationToken = default) =>
     AsyncHelper.RunSync(() => IndexExistsAsync(indexName, cancellationToken));
+
+  /// <inheritdoc/>
+  public bool IndexExists(
+    string indexName,
+    RequestOptions options,
+    CancellationToken cancellationToken = default
+  ) => AsyncHelper.RunSync(() => IndexExistsAsync(indexName, options, cancellationToken));
 
   // ==================== SaveObjectsWithTransformation ====================
 

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
@@ -45,7 +45,7 @@ public class AlgoliaCSharpGenerator extends CSharpClientCodegen {
     additionalProperties.put("netCoreProjectFile", true);
     additionalProperties.put("targetFramework", "netstandard2.1;netstandard2.0");
     additionalProperties.put("is" + Helpers.capitalize(Helpers.camelize((String) additionalProperties.get("client"))) + "Client", true);
-    additionalProperties.put("requestIdSupport", client.equals("search") || client.equals("recommend") || client.equals("composition"));
+    additionalProperties.put("requestIdSupport", Helpers.requestIdSupport(client));
     additionalProperties.put("apiPackageName", getClientName(client));
     additionalProperties.put("equatable", false);
     additionalProperties.put("disallowAdditionalPropertiesIfNotPresent", true);

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaCSharpGenerator.java
@@ -45,6 +45,7 @@ public class AlgoliaCSharpGenerator extends CSharpClientCodegen {
     additionalProperties.put("netCoreProjectFile", true);
     additionalProperties.put("targetFramework", "netstandard2.1;netstandard2.0");
     additionalProperties.put("is" + Helpers.capitalize(Helpers.camelize((String) additionalProperties.get("client"))) + "Client", true);
+    additionalProperties.put("requestIdSupport", client.equals("search") || client.equals("recommend") || client.equals("composition"));
     additionalProperties.put("apiPackageName", getClientName(client));
     additionalProperties.put("equatable", false);
     additionalProperties.put("disallowAdditionalPropertiesIfNotPresent", true);

--- a/generators/src/main/java/com/algolia/codegen/cts/tests/RequestProp.java
+++ b/generators/src/main/java/com/algolia/codegen/cts/tests/RequestProp.java
@@ -1,6 +1,7 @@
 package com.algolia.codegen.cts.tests;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.List;
 
 public class RequestProp {
 
@@ -16,6 +17,10 @@ public class RequestProp {
   @JsonDeserialize(using = RawDeserializer.class)
   public String headers;
 
+  // header keys that must NOT reach the wire, e.g. a minted request-id when
+  // the caller supplied one through another channel
+  public List<String> absentHeaders;
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -25,6 +30,7 @@ public class RequestProp {
     sb.append("    body: ").append(body).append("\n");
     sb.append("    queryParameters: ").append(queryParameters).append("\n");
     sb.append("    headers: ").append(headers).append("\n");
+    sb.append("    absentHeaders: ").append(absentHeaders).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -9,7 +9,7 @@ import { setupServer } from './index.ts';
 export const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
 
 // languages that have ported Request-ID support (API-516)
-export const REQUEST_ID_LANGUAGES = ['go', 'java', 'javascript', 'kotlin', 'scala'];
+export const REQUEST_ID_LANGUAGES = ['csharp', 'go', 'java', 'javascript', 'kotlin', 'scala'];
 
 const retryState: Record<string, string[]> = {};
 const freshState: Record<string, string[]> = {};

--- a/templates/csharp/Configuration.mustache
+++ b/templates/csharp/Configuration.mustache
@@ -28,6 +28,9 @@ public sealed class {{apiPackageName}}Config : AlgoliaConfig
     ReadTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.read}});
     WriteTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.write}});
     ConnectTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.connect}});
+    // Request-ID tracing is only supported by the search, recommend and
+    // composition APIs.
+    RequestIdEnabled = {{#requestIdSupport}}true{{/requestIdSupport}}{{^requestIdSupport}}false{{/requestIdSupport}};
   }
 {{/hasRegionalHost}}
 {{^hasRegionalHost}}
@@ -44,6 +47,9 @@ public sealed class {{apiPackageName}}Config : AlgoliaConfig
     ReadTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.read}});
     WriteTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.write}});
     ConnectTimeout = TimeSpan.FromMilliseconds({{x-timeouts.server.connect}});
+    // Request-ID tracing is only supported by the search, recommend and
+    // composition APIs.
+    RequestIdEnabled = {{#requestIdSupport}}true{{/requestIdSupport}}{{^requestIdSupport}}false{{/requestIdSupport}};
   }
 {{/hasRegionalHost}}
 {{#hostWithAppID}}

--- a/templates/csharp/tests/e2e/e2e.mustache
+++ b/templates/csharp/tests/e2e/e2e.mustache
@@ -66,6 +66,25 @@ public class {{client}}RequestTestsE2E
       {{#body}}
           TestHelpers.LenientJsonAssert("{{#lambda.escapeQuotes}}{{{.}}}{{/lambda.escapeQuotes}}", JsonSerializer.Serialize(resp, JsonConfig.Options));
       {{/body}}
+      {{#correlationIdSuffix}}
+          // Re-issue the request through customGet to read the response
+          // headers; customGet prepends the leading slash of request.path.
+          var httpResp = await client.CustomGetWithHTTPInfoAsync("{{{request.path}}}".TrimStart('/'){{#hasRequestOptions}}, options: new RequestOptionBuilder()
+          {{#requestOptions.queryParameters.parametersWithDataType}}
+            .AddExtraQueryParameters("{{{key}}}", {{> tests/requests/requestOptionsParams}} )
+          {{/requestOptions.queryParameters.parametersWithDataType}}
+          {{#requestOptions.headers.parametersWithDataType}}
+            .AddExtraHeader("{{{key}}}", {{#isVerbatim}}{{{value}}}{{/isVerbatim}}{{^isVerbatim}}"{{{value}}}"{{/isVerbatim}})
+          {{/requestOptions.headers.parametersWithDataType}}
+            .Build(){{/hasRequestOptions}});
+
+          var correlationId = httpResp.ResponseHeaders?
+            .Where(h => h.Key.Equals("Correlation-ID", StringComparison.OrdinalIgnoreCase))
+            .Select(h => h.Value)
+            .SingleOrDefault();
+          Assert.False(string.IsNullOrEmpty(correlationId), "the response must carry a Correlation-ID header");
+          Assert.EndsWith("{{{correlationIdSuffix}}}", correlationId);
+      {{/correlationIdSuffix}}
       } catch (Exception e)
       {
         Assert.Fail("An exception was thrown: " + e.Message);

--- a/templates/csharp/tests/e2e/e2e.mustache
+++ b/templates/csharp/tests/e2e/e2e.mustache
@@ -69,6 +69,8 @@ public class {{client}}RequestTestsE2E
       {{#correlationIdSuffix}}
           // Re-issue the request through customGet to read the response
           // headers; customGet prepends the leading slash of request.path.
+          // Generation already hard-fails non-GET correlationIdSuffix tests
+          // (TestsRequest.java enforces GET-only), so the hard-coded GET is safe by construction.
           var httpResp = await client.CustomGetWithHTTPInfoAsync("{{{request.path}}}".TrimStart('/'){{#hasRequestOptions}}, options: new RequestOptionBuilder()
           {{#requestOptions.queryParameters.parametersWithDataType}}
             .AddExtraQueryParameters("{{{key}}}", {{> tests/requests/requestOptionsParams}} )

--- a/templates/csharp/tests/method.mustache
+++ b/templates/csharp/tests/method.mustache
@@ -1,3 +1,4 @@
+{{! Request options are passed as a named argument so they cannot land in an optional parameter slot (like customGet's query dictionary). The argument name must match the target method's parameter: every generated operation and the helpers exercised by the CTS name it `options`, but some hand-written helpers (WaitFor*, Browse*) name it `requestOptions` — a CTS test passing request options to one of those will not compile until the names are aligned. }}
 {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{#isAsyncMethod}}Async{{/isAsyncMethod}}{{#isGeneric}}<Hit>{{/isGeneric}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#hasRequestOptions}}, options: new RequestOptionBuilder()
 {{#requestOptions.queryParameters.parametersWithDataType}}
     .AddExtraQueryParameters("{{{key}}}", {{> tests/requests/requestOptionsParams}} )

--- a/templates/csharp/tests/method.mustache
+++ b/templates/csharp/tests/method.mustache
@@ -1,4 +1,4 @@
-{{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{#isAsyncMethod}}Async{{/isAsyncMethod}}{{#isGeneric}}<Hit>{{/isGeneric}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#hasRequestOptions}}, new RequestOptionBuilder()
+{{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{#isAsyncMethod}}Async{{/isAsyncMethod}}{{#isGeneric}}<Hit>{{/isGeneric}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#hasRequestOptions}}, options: new RequestOptionBuilder()
 {{#requestOptions.queryParameters.parametersWithDataType}}
     .AddExtraQueryParameters("{{{key}}}", {{> tests/requests/requestOptionsParams}} )
 {{/requestOptions.queryParameters.parametersWithDataType}}

--- a/templates/csharp/tests/method.mustache
+++ b/templates/csharp/tests/method.mustache
@@ -1,4 +1,4 @@
-{{! Request options are passed as a named argument so they cannot land in an optional parameter slot (like customGet's query dictionary). The argument name must match the target method's parameter: every generated operation and the helpers exercised by the CTS name it `options`, but some hand-written helpers (WaitFor*, Browse*) name it `requestOptions` — a CTS test passing request options to one of those will not compile until the names are aligned. }}
+{{! Named argument so options cannot land in an optional parameter slot; helpers named requestOptions would need renaming if the CTS ever passes them options. }}
 {{#isAsyncMethod}}await {{/isAsyncMethod}}client.{{#lambda.pascalcase}}{{method}}{{/lambda.pascalcase}}{{#isAsyncMethod}}Async{{/isAsyncMethod}}{{#isGeneric}}<Hit>{{/isGeneric}}({{#parametersWithDataType}}{{> tests/generateParams}}{{^-last}},{{/-last}}{{/parametersWithDataType}}{{#hasRequestOptions}}, options: new RequestOptionBuilder()
 {{#requestOptions.queryParameters.parametersWithDataType}}
     .AddExtraQueryParameters("{{{key}}}", {{> tests/requests/requestOptionsParams}} )

--- a/templates/csharp/tests/requests/requests.mustache
+++ b/templates/csharp/tests/requests/requests.mustache
@@ -83,6 +83,9 @@ private readonly {{client}} client;
           Assert.Equal(expectedHeader.Value, actualHeaderValue);
         }
     {{/headers}}
+    {{#absentHeaders}}
+        Assert.DoesNotContain(req.Headers, h => h.Key.Equals("{{{.}}}", StringComparison.OrdinalIgnoreCase));
+    {{/absentHeaders}}
     {{/request}}
   }
   {{/tests}}

--- a/templates/javascript/tests/requests/requests.mustache
+++ b/templates/javascript/tests/requests/requests.mustache
@@ -28,6 +28,9 @@ describe('{{operationId}}', () => {
       expect.objectContaining({{{request.headers}}})
     );
     {{/request.headers}}
+    {{#request.absentHeaders}}
+    expect(Object.keys(req.headers ?? {}).map((key) => key.toLowerCase())).not.toContain('{{{.}}}'.toLowerCase());
+    {{/request.absentHeaders}}
   });
   {{/isStreamingTest}}
 
@@ -58,6 +61,9 @@ describe('{{operationId}}', () => {
       expect.objectContaining({{{request.headers}}})
     );
     {{/request.headers}}
+    {{#request.absentHeaders}}
+    expect(Object.keys(req.headers ?? {}).map((key) => key.toLowerCase())).not.toContain('{{{.}}}'.toLowerCase());
+    {{/request.absentHeaders}}
   });
   {{/isStreamingTest}}
 

--- a/templates/kotlin/tests/intercept.mustache
+++ b/templates/kotlin/tests/intercept.mustache
@@ -4,6 +4,9 @@
                 {{#headers}}
                 assertContainsAll("""{{{.}}}""", it.headers)
                 {{/headers}}
+                {{#absentHeaders}}
+                assertFalse(it.headers.contains("{{{.}}}"), "the {{{.}}} header must not be sent")
+                {{/absentHeaders}}
                 {{#queryParameters}}
                 assertQueryParams("""{{{.}}}""", it.url.encodedParameters)
                 {{/queryParameters}}

--- a/templates/scala/tests/requests/requests.mustache
+++ b/templates/scala/tests/requests/requests.mustache
@@ -78,6 +78,9 @@ class {{clientPrefix}}Test extends AnyFunSuite {
       assert(actualHeaders(k) == v.asInstanceOf[JString].s)
     }
     {{/headers}}
+    {{#absentHeaders}}
+    assert(!res.headers.keys.exists(_.equalsIgnoreCase("{{{.}}}")))
+    {{/absentHeaders}}
     {{/request}}
   }
   

--- a/tests/CTS/client/composition/requestId.json
+++ b/tests/CTS/client/composition/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the composition client sends a Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/recommend/requestId.json
+++ b/tests/CTS/client/recommend/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the recommend client sends a Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -255,7 +255,7 @@
         },
         "expected": {
           "error": {
-            "csharp": "{\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
+            "csharp": "{\\\"message\\\":\\\"request-id error test\\\"}",
             "go": "API error [400] request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "java": "Status Code: 400 - {\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "javascript": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -255,7 +255,7 @@
         },
         "expected": {
           "error": {
-            "csharp": "{\\\"message\\\":\\\"request-id error test\\\"}",
+            "csharp": "{\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "go": "API error [400] request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "java": "Status Code: 400 - {\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "javascript": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the Request-ID stays stable across retries",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -40,7 +40,7 @@
   {
     "testName": "each call mints a fresh Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -85,7 +85,7 @@
   {
     "testName": "a caller-supplied Request-ID is never overwritten",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -122,7 +122,7 @@
   {
     "testName": "every request of one helper call shares one Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -233,7 +233,7 @@
   {
     "testName": "client errors expose the Correlation-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "steps": [
       {
         "type": "createClient",
@@ -255,6 +255,7 @@
         },
         "expected": {
           "error": {
+            "csharp": "{\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "go": "API error [400] request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "java": "Status Code: 400 - {\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "javascript": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -50,7 +50,8 @@
       "method": "GET",
       "queryParameters": {
         "x-algolia-request-id": "CtsE2eEchoQ"
-      }
+      },
+      "absentHeaders": ["request-id"]
     },
     "response": {
       "statusCode": 200,

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -10,7 +10,7 @@
   },
   {
     "testName": "the Correlation-ID ends with the sent Request-ID",
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "parameters": {
       "compositionID": "id1"
     },

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -36,7 +36,7 @@
   },
   {
     "testName": "the Correlation-ID ends with the Request-ID sent as a query parameter",
-    "skipLanguages": ["csharp", "dart", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "php", "python", "ruby", "swift"],
     "parameters": {
       "compositionID": "id1"
     },

--- a/tests/CTS/requests/search/searchRules.json
+++ b/tests/CTS/requests/search/searchRules.json
@@ -52,7 +52,7 @@
   },
   {
     "testName": "the classic engine accepts a Request-ID sent as a query parameter",
-    "skipLanguages": ["csharp", "dart", "go", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "go", "php", "python", "ruby", "swift"],
     "parameters": {
       "indexName": "cts_e2e_browse",
       "searchRulesParams": {

--- a/tests/CTS/requests/search/searchRules.json
+++ b/tests/CTS/requests/search/searchRules.json
@@ -72,7 +72,8 @@
       },
       "queryParameters": {
         "x-algolia-request-id": "CtsE2eQry11"
-      }
+      },
+      "absentHeaders": ["request-id"]
     },
     "response": {
       "statusCode": 200,

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
@@ -341,6 +342,115 @@ public class RequestIdTests
     Assert.Equal("CorrTest123", ex.CorrelationId);
     Assert.Equal(400, ex.HttpErrorCode);
     Assert.Equal("{\"message\":\"boom\"} (Correlation-ID: CorrTest123)", ex.Message);
+  }
+
+  [Fact]
+  public async Task ShouldExposeRawResponseBodyOnApiErrors()
+  {
+    const string rawBody = "{\"message\":\"boom\",\"status\":400}";
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns(() =>
+        Task.FromResult(
+          new AlgoliaHttpResponse
+          {
+            HttpStatusCode = 400,
+            Error = rawBody,
+            ResponseHeaders = new Dictionary<string, string> { { "Correlation-ID", "CorrTest123" } },
+          }
+        )
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaApiException>(async () =>
+      await client.CustomGetAsync("1/test")
+    );
+
+    // Message carries the Correlation-ID suffix; ResponseBody stays the exact raw body.
+    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.Message);
+    Assert.Equal(rawBody, ex.ResponseBody);
+    var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(ex.ResponseBody);
+    Assert.Equal("boom", parsed["message"].GetString());
+    Assert.Equal(400, parsed["status"].GetInt32());
+  }
+
+  [Fact]
+  public async Task ShouldPreserveAllRequestOptionsWhenHelperMintsRequestId()
+  {
+    var recorded = new List<(Request Request, TimeSpan RequestTimeout, TimeSpan ConnectTimeout)>();
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, requestTimeout, connectTimeout, _) =>
+        {
+          recorded.Add((rq, requestTimeout, connectTimeout));
+          return Task.FromResult(
+            rq.Uri.AbsolutePath.EndsWith("/batch")
+              ? JsonResponse("{\"taskID\":42,\"objectIDs\":[\"1\"]}")
+              : JsonResponse("{\"status\":\"published\",\"pendingTask\":false}")
+          );
+        }
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    // All five RequestOptions properties set, no request-id: WithRequestId
+    // takes the hand-copy branch and must not drop any of them.
+    var options = new RequestOptions
+    {
+      Headers = new Dictionary<string, string> { { "X-Caller-Header", "kept" } },
+      QueryParameters = new Dictionary<string, object> { { "callerParam", "kept" } },
+      ReadTimeout = TimeSpan.FromSeconds(41),
+      WriteTimeout = TimeSpan.FromSeconds(42),
+      ConnectTimeout = TimeSpan.FromSeconds(43),
+    };
+
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "1" } },
+      Action.AddObject,
+      waitForTasks: true,
+      options: options
+    );
+
+    // One batch write plus one task poll, both built from the copied options.
+    Assert.Equal(2, recorded.Count);
+    var mintedId = ObservedRequestId(recorded[0].Request);
+    Assert.Matches(RequestIdFormat, mintedId);
+    foreach (var (request, _, connectTimeout) in recorded)
+    {
+      Assert.Equal(mintedId, ObservedRequestId(request));
+      Assert.Equal(
+        "kept",
+        request
+          .Headers.Where(h => h.Key.Equals("X-Caller-Header", StringComparison.OrdinalIgnoreCase))
+          .Select(h => h.Value)
+          .Single()
+      );
+      Assert.Contains("callerParam=kept", request.Uri.Query);
+      Assert.Equal(TimeSpan.FromSeconds(43), connectTimeout);
+    }
+
+    // The batch is a write call, the task poll a read call.
+    Assert.Equal(TimeSpan.FromSeconds(42), recorded[0].RequestTimeout);
+    Assert.Equal(TimeSpan.FromSeconds(41), recorded[1].RequestTimeout);
   }
 
   [Fact]

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -361,12 +361,11 @@ public class RequestIdTests
 
     Assert.Equal("CorrTest123", ex.CorrelationId);
     Assert.Equal(400, ex.HttpErrorCode);
-    Assert.Equal("{\"message\":\"boom\"}", ex.Message);
-    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.ToString());
+    Assert.Equal("{\"message\":\"boom\"} (Correlation-ID: CorrTest123)", ex.Message);
   }
 
   [Fact]
-  public async Task ShouldKeepApiErrorMessageMachineParsable()
+  public async Task ShouldExposeRawResponseBodyOnApiErrors()
   {
     const string rawBody = "{\"message\":\"boom\",\"status\":400}";
     var httpMock = new Mock<IHttpRequester>();
@@ -399,10 +398,10 @@ public class RequestIdTests
       await client.CustomGetAsync("1/test")
     );
 
-    // Message stays the exact raw body; the Correlation-ID only decorates ToString().
-    Assert.Equal(rawBody, ex.Message);
-    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.ToString());
-    var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(ex.Message);
+    // Message carries the Correlation-ID suffix; ResponseBody stays the exact raw body.
+    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.Message);
+    Assert.Equal(rawBody, ex.ResponseBody);
+    var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(ex.ResponseBody);
     Assert.Equal("boom", parsed["message"].GetString());
     Assert.Equal(400, parsed["status"].GetInt32());
   }
@@ -441,8 +440,7 @@ public class RequestIdTests
     );
 
     Assert.Equal("CorrDeser123", ex.CorrelationId);
-    Assert.EndsWith(" (Correlation-ID: CorrDeser123)", ex.ToString());
-    Assert.DoesNotContain("Correlation-ID", ex.Message);
+    Assert.EndsWith(" (Correlation-ID: CorrDeser123)", ex.Message);
   }
 
   [Fact]
@@ -548,6 +546,7 @@ public class RequestIdTests
 
     Assert.Null(ex.CorrelationId);
     Assert.Equal("{\"message\":\"boom\"}", ex.Message);
+    Assert.Equal(ex.Message, ex.ResponseBody);
     Assert.DoesNotContain("Correlation-ID", ex.ToString());
   }
 

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -183,6 +183,24 @@ public class RequestIdTests
   }
 
   [Fact]
+  public async Task ShouldAllowCallersToDisableMinting()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+    config.RequestIdEnabled = false;
+    await client.CustomGetAsync("1/test");
+
+    // The first call guards against a vacuous pass with minting off entirely.
+    Assert.Equal(2, observedIds.Count);
+    Assert.Matches(RequestIdFormat, observedIds[0]);
+    Assert.Null(observedIds[1]);
+  }
+
+  [Fact]
   public async Task ShouldNeverMintForIngestion()
   {
     var observedIds = new List<string>();
@@ -573,5 +591,64 @@ public class RequestIdTests
         .Select(h => h.Value)
         .Single()
     );
+  }
+
+  [Fact]
+  public async Task ShouldCleanUpTmpIndexWhenCallerCancels()
+  {
+    var deletes = new List<string>();
+    using var cts = new CancellationTokenSource();
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, ct) =>
+        {
+          // A real requester observes the token before sending.
+          ct.ThrowIfCancellationRequested();
+          if (rq.Method == HttpMethod.Delete)
+          {
+            deletes.Add(rq.Uri.AbsolutePath);
+            return Task.FromResult(
+              JsonResponse("{\"taskID\":42,\"deletedAt\":\"2021-01-01T00:00:00Z\"}")
+            );
+          }
+          if (rq.Uri.AbsolutePath.EndsWith("/batch"))
+          {
+            cts.Cancel();
+            ct.ThrowIfCancellationRequested();
+          }
+          if (rq.Uri.AbsolutePath.Contains("/task/"))
+          {
+            return Task.FromResult(
+              JsonResponse("{\"status\":\"published\",\"pendingTask\":false}")
+            );
+          }
+          return Task.FromResult(
+            JsonResponse("{\"taskID\":42,\"updatedAt\":\"2021-01-01T00:00:00Z\"}")
+          );
+        }
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+      await client.ReplaceAllObjectsAsync(
+        "test-index",
+        new List<object> { new { objectID = "1" } },
+        cancellationToken: cts.Token
+      )
+    );
+
+    // The cleanup delete must go through even though the caller's token is canceled.
+    var deletedPath = Assert.Single(deletes);
+    Assert.StartsWith("/1/indexes/test-index_tmp_", deletedPath);
   }
 }

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -590,6 +590,22 @@ public class RequestIdTests
         .Select(h => h.Value)
         .Single()
     );
+
+    // The sync twin is a RunSync delegate; smoke it end to end as well.
+    observed = null;
+    Assert.True(
+      client.IndexExists(
+        "test-index",
+        new RequestOptions
+        {
+          Headers = new Dictionary<string, string> { { "X-Caller-Header", "kept" } },
+        }
+      )
+    );
+    Assert.Contains(
+      observed.Headers,
+      h => h.Key.Equals("X-Caller-Header", StringComparison.OrdinalIgnoreCase) && h.Value == "kept"
+    );
   }
 
   [Fact]

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -5,6 +5,7 @@ using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
 using Algolia.Search.Http;
 using Algolia.Search.Models.Search;
+using Algolia.Search.Utils;
 using Moq;
 using Xunit;
 using Action = Algolia.Search.Models.Search.Action;
@@ -611,7 +612,7 @@ public class RequestIdTests
   [Fact]
   public async Task ShouldCleanUpTmpIndexWhenCallerCancels()
   {
-    var deletes = new List<string>();
+    var deletes = new List<(Request Request, TimeSpan RequestTimeout, TimeSpan ConnectTimeout)>();
     using var cts = new CancellationTokenSource();
     var httpMock = new Mock<IHttpRequester>();
     httpMock
@@ -624,13 +625,13 @@ public class RequestIdTests
         )
       )
       .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
-        (rq, _, _, ct) =>
+        (rq, requestTimeout, connectTimeout, ct) =>
         {
           // A real requester observes the token before sending.
           ct.ThrowIfCancellationRequested();
           if (rq.Method == HttpMethod.Delete)
           {
-            deletes.Add(rq.Uri.AbsolutePath);
+            deletes.Add((rq, requestTimeout, connectTimeout));
             return Task.FromResult(
               JsonResponse("{\"taskID\":42,\"deletedAt\":\"2021-01-01T00:00:00Z\"}")
             );
@@ -658,13 +659,25 @@ public class RequestIdTests
       await client.ReplaceAllObjectsAsync(
         "test-index",
         new List<object> { new { objectID = "1" } },
+        options: new RequestOptions
+        {
+          ReadTimeout = TimeSpan.FromMilliseconds(41),
+          WriteTimeout = TimeSpan.FromMilliseconds(42),
+          ConnectTimeout = TimeSpan.FromMilliseconds(43),
+        },
         cancellationToken: cts.Token
       )
     );
 
     // The cleanup delete must go through even though the caller's token is canceled.
-    var deletedPath = Assert.Single(deletes);
-    Assert.StartsWith("/1/indexes/test-index_tmp_", deletedPath);
+    var (deleteRequest, deleteRequestTimeout, deleteConnectTimeout) = Assert.Single(deletes);
+    Assert.StartsWith("/1/indexes/test-index_tmp_", deleteRequest.Uri.AbsolutePath);
+
+    // The caller's timeouts that killed the main operation must not also
+    // govern the cleanup; the shared trace header survives the strip.
+    Assert.Equal(Defaults.WriteTimeout, deleteRequestTimeout);
+    Assert.Equal(Defaults.ConnectTimeout, deleteConnectTimeout);
+    Assert.Matches(RequestIdFormat, ObservedRequestId(deleteRequest));
   }
 
   [Fact]

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -213,6 +213,54 @@ public class RequestIdTests
   }
 
   [Fact]
+  public async Task ShouldExposeLastCorrelationIdOnExhaustion()
+  {
+    var observedIds = new List<string>();
+    var attempts = 0;
+    var httpMock = RecordingMock(
+      observedIds,
+      _ =>
+        new AlgoliaHttpResponse
+        {
+          HttpStatusCode = 500,
+          Error = "unavailable",
+          ResponseHeaders = new Dictionary<string, string>
+          {
+            { "Correlation-ID", $"CorrAttempt{++attempts}" },
+          },
+        }
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaUnreachableHostException>(async () =>
+      await client.CustomGetAsync("1/test")
+    );
+
+    Assert.Equal($"CorrAttempt{attempts}", ex.CorrelationId);
+    Assert.EndsWith($"(Correlation-ID: CorrAttempt{attempts})", ex.Message);
+  }
+
+  [Fact]
+  public async Task ShouldLeaveExhaustionUntouchedWithoutCorrelationId()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(
+      observedIds,
+      _ => new AlgoliaHttpResponse { HttpStatusCode = 500, Error = "unavailable" }
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaUnreachableHostException>(async () =>
+      await client.CustomGetAsync("1/test")
+    );
+
+    Assert.Null(ex.CorrelationId);
+    Assert.DoesNotContain("Correlation-ID", ex.Message);
+  }
+
+  [Fact]
   public async Task ShouldExposeCorrelationIdOnApiErrors()
   {
     var httpMock = new Mock<IHttpRequester>();

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -666,4 +666,93 @@ public class RequestIdTests
     var deletedPath = Assert.Single(deletes);
     Assert.StartsWith("/1/indexes/test-index_tmp_", deletedPath);
   }
+
+  [Fact]
+  public async Task ShouldKeepRootCauseWhenCleanupDeleteFails()
+  {
+    var deletes = new List<string>();
+    using var cts = new CancellationTokenSource();
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, ct) =>
+        {
+          ct.ThrowIfCancellationRequested();
+          if (rq.Method == HttpMethod.Delete)
+          {
+            deletes.Add(rq.Uri.AbsolutePath);
+            return Task.FromResult(
+              new AlgoliaHttpResponse
+              {
+                HttpStatusCode = 403,
+                Error = "{\"message\":\"forbidden\"}",
+              }
+            );
+          }
+          if (rq.Uri.AbsolutePath.EndsWith("/batch"))
+          {
+            cts.Cancel();
+            ct.ThrowIfCancellationRequested();
+          }
+          if (rq.Uri.AbsolutePath.Contains("/task/"))
+          {
+            return Task.FromResult(
+              JsonResponse("{\"status\":\"published\",\"pendingTask\":false}")
+            );
+          }
+          return Task.FromResult(
+            JsonResponse("{\"taskID\":42,\"updatedAt\":\"2021-01-01T00:00:00Z\"}")
+          );
+        }
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    // The forbidden cleanup delete must not replace the caller's cancellation.
+    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+      await client.ReplaceAllObjectsAsync(
+        "test-index",
+        new List<object> { new { objectID = "1" } },
+        cancellationToken: cts.Token
+      )
+    );
+
+    Assert.Single(deletes);
+  }
+
+  [Fact]
+  public async Task ShouldKeepDefaultHeadersRequestIdInHelpers()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(
+      observedIds,
+      rq =>
+        rq.Uri.AbsolutePath.EndsWith("/batch")
+          ? JsonResponse("{\"taskID\":42,\"objectIDs\":[\"1\"]}")
+          : JsonResponse("{\"status\":\"published\",\"pendingTask\":false}")
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    config.DefaultHeaders["REQUEST-ID"] = "DefaultOwned";
+    var client = new SearchClient(config, httpMock.Object);
+
+    // A helper mint into request options would override DefaultHeaders in the
+    // merge, so WithRequestId must not mint at all here.
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "1" } },
+      Action.AddObject,
+      waitForTasks: true
+    );
+
+    Assert.Equal(2, observedIds.Count);
+    Assert.All(observedIds, id => Assert.Equal("DefaultOwned", id));
+  }
 }

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -5,7 +5,6 @@ using Algolia.Search.Clients;
 using Algolia.Search.Exceptions;
 using Algolia.Search.Http;
 using Algolia.Search.Models.Search;
-using Algolia.Search.Utils;
 using Moq;
 using Xunit;
 using Action = Algolia.Search.Models.Search.Action;
@@ -326,6 +325,52 @@ public class RequestIdTests
   }
 
   [Fact]
+  public async Task ShouldKeepCallerQueryParameterRequestIdInHelpers()
+  {
+    var observedIds = new List<string>();
+    var observedUris = new List<Uri>();
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, _) =>
+        {
+          observedIds.Add(ObservedRequestId(rq));
+          observedUris.Add(rq.Uri);
+          return Task.FromResult(JsonResponse("{\"taskID\":42,\"objectIDs\":[\"1\"]}"));
+        }
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    // A helper mint would land in the headers, which the server prefers over
+    // the caller's query parameter, so WithRequestId must not mint at all.
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "1" } },
+      Action.AddObject,
+      options: new RequestOptions
+      {
+        QueryParameters = new Dictionary<string, object>
+        {
+          { "X-Algolia-Request-Id", "QueryOwned" },
+        },
+      }
+    );
+
+    // The URI check keeps this from passing vacuously when minting is off.
+    Assert.Contains("QueryOwned", Assert.Single(observedUris).Query);
+    Assert.Equal(new List<string> { null }, observedIds);
+  }
+
+  [Fact]
   public async Task ShouldExposeCorrelationIdOnApiErrors()
   {
     var httpMock = new Mock<IHttpRequester>();
@@ -613,6 +658,7 @@ public class RequestIdTests
   public async Task ShouldCleanUpTmpIndexWhenCallerCancels()
   {
     var deletes = new List<(Request Request, TimeSpan RequestTimeout, TimeSpan ConnectTimeout)>();
+    string mainRequestId = null;
     using var cts = new CancellationTokenSource();
     var httpMock = new Mock<IHttpRequester>();
     httpMock
@@ -636,6 +682,7 @@ public class RequestIdTests
               JsonResponse("{\"taskID\":42,\"deletedAt\":\"2021-01-01T00:00:00Z\"}")
             );
           }
+          mainRequestId ??= ObservedRequestId(rq);
           if (rq.Uri.AbsolutePath.EndsWith("/batch"))
           {
             cts.Cancel();
@@ -674,10 +721,15 @@ public class RequestIdTests
     Assert.StartsWith("/1/indexes/test-index_tmp_", deleteRequest.Uri.AbsolutePath);
 
     // The caller's timeouts that killed the main operation must not also
-    // govern the cleanup; the shared trace header survives the strip.
-    Assert.Equal(Defaults.WriteTimeout, deleteRequestTimeout);
-    Assert.Equal(Defaults.ConnectTimeout, deleteConnectTimeout);
-    Assert.Matches(RequestIdFormat, ObservedRequestId(deleteRequest));
+    // govern the cleanup: the delete falls back to the SearchConfig
+    // constructor timeouts (30s write, 2s connect).
+    Assert.Equal(TimeSpan.FromMilliseconds(30000), deleteRequestTimeout);
+    Assert.Equal(TimeSpan.FromMilliseconds(2000), deleteConnectTimeout);
+
+    // The delete reuses the invocation's shared Request-ID; a format-only
+    // check would also pass on a fresh transport-level mint.
+    Assert.Matches(RequestIdFormat, mainRequestId);
+    Assert.Equal(mainRequestId, ObservedRequestId(deleteRequest));
   }
 
   [Fact]

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -156,7 +156,10 @@ public class RequestIdTests
       "1/test",
       options: new RequestOptions
       {
-        QueryParameters = new Dictionary<string, object> { { "X-Algolia-Request-Id", "QueryOwned" } },
+        QueryParameters = new Dictionary<string, object>
+        {
+          { "X-Algolia-Request-Id", "QueryOwned" },
+        },
       }
     );
 
@@ -262,16 +265,15 @@ public class RequestIdTests
     var attempts = 0;
     var httpMock = RecordingMock(
       observedIds,
-      _ =>
-        new AlgoliaHttpResponse
+      _ => new AlgoliaHttpResponse
+      {
+        HttpStatusCode = 500,
+        Error = "unavailable",
+        ResponseHeaders = new Dictionary<string, string>
         {
-          HttpStatusCode = 500,
-          Error = "unavailable",
-          ResponseHeaders = new Dictionary<string, string>
-          {
-            { "Correlation-ID", $"CorrAttempt{++attempts}" },
-          },
-        }
+          { "Correlation-ID", $"CorrAttempt{++attempts}" },
+        },
+      }
     );
     var config = new SearchConfig("test-app-id", "test-api-key");
     var client = new SearchClient(config, httpMock.Object);
@@ -341,11 +343,12 @@ public class RequestIdTests
 
     Assert.Equal("CorrTest123", ex.CorrelationId);
     Assert.Equal(400, ex.HttpErrorCode);
-    Assert.Equal("{\"message\":\"boom\"} (Correlation-ID: CorrTest123)", ex.Message);
+    Assert.Equal("{\"message\":\"boom\"}", ex.Message);
+    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.ToString());
   }
 
   [Fact]
-  public async Task ShouldExposeRawResponseBodyOnApiErrors()
+  public async Task ShouldKeepApiErrorMessageMachineParsable()
   {
     const string rawBody = "{\"message\":\"boom\",\"status\":400}";
     var httpMock = new Mock<IHttpRequester>();
@@ -364,7 +367,10 @@ public class RequestIdTests
           {
             HttpStatusCode = 400,
             Error = rawBody,
-            ResponseHeaders = new Dictionary<string, string> { { "Correlation-ID", "CorrTest123" } },
+            ResponseHeaders = new Dictionary<string, string>
+            {
+              { "Correlation-ID", "CorrTest123" },
+            },
           }
         )
       );
@@ -375,12 +381,50 @@ public class RequestIdTests
       await client.CustomGetAsync("1/test")
     );
 
-    // Message carries the Correlation-ID suffix; ResponseBody stays the exact raw body.
-    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.Message);
-    Assert.Equal(rawBody, ex.ResponseBody);
-    var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(ex.ResponseBody);
+    // Message stays the exact raw body; the Correlation-ID only decorates ToString().
+    Assert.Equal(rawBody, ex.Message);
+    Assert.EndsWith(" (Correlation-ID: CorrTest123)", ex.ToString());
+    var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(ex.Message);
     Assert.Equal("boom", parsed["message"].GetString());
     Assert.Equal(400, parsed["status"].GetInt32());
+  }
+
+  [Fact]
+  public async Task ShouldExposeCorrelationIdOnDeserializationErrors()
+  {
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns(() =>
+        Task.FromResult(
+          new AlgoliaHttpResponse
+          {
+            HttpStatusCode = 200,
+            Body = new MemoryStream(Encoding.UTF8.GetBytes("{not json")),
+            ResponseHeaders = new Dictionary<string, string>
+            {
+              { "Correlation-ID", "CorrDeser123" },
+            },
+          }
+        )
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaException>(async () =>
+      await client.GetSettingsAsync("test-index")
+    );
+
+    Assert.Equal("CorrDeser123", ex.CorrelationId);
+    Assert.EndsWith(" (Correlation-ID: CorrDeser123)", ex.ToString());
+    Assert.DoesNotContain("Correlation-ID", ex.Message);
   }
 
   [Fact]
@@ -412,7 +456,7 @@ public class RequestIdTests
     var client = new SearchClient(config, httpMock.Object);
 
     // All five RequestOptions properties set, no request-id: WithRequestId
-    // takes the hand-copy branch and must not drop any of them.
+    // takes the copy branch and must not drop any of them.
     var options = new RequestOptions
     {
       Headers = new Dictionary<string, string> { { "X-Caller-Header", "kept" } },
@@ -486,5 +530,48 @@ public class RequestIdTests
 
     Assert.Null(ex.CorrelationId);
     Assert.Equal("{\"message\":\"boom\"}", ex.Message);
+    Assert.DoesNotContain("Correlation-ID", ex.ToString());
+  }
+
+  [Fact]
+  public async Task ShouldForwardRequestOptionsFromIndexExists()
+  {
+    Request observed = null;
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, _) =>
+        {
+          observed = rq;
+          return Task.FromResult(JsonResponse("{}"));
+        }
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var exists = await client.IndexExistsAsync(
+      "test-index",
+      new RequestOptions
+      {
+        Headers = new Dictionary<string, string> { { "X-Caller-Header", "kept" } },
+      }
+    );
+
+    Assert.True(exists);
+    Assert.Equal(
+      "kept",
+      observed
+        .Headers.Where(h => h.Key.Equals("X-Caller-Header", StringComparison.OrdinalIgnoreCase))
+        .Select(h => h.Value)
+        .Single()
+    );
   }
 }

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -1,0 +1,289 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Algolia.Search.Clients;
+using Algolia.Search.Exceptions;
+using Algolia.Search.Http;
+using Algolia.Search.Models.Search;
+using Moq;
+using Xunit;
+using Action = Algolia.Search.Models.Search.Action;
+
+namespace Algolia.Search.Tests;
+
+public class RequestIdTests
+{
+  private static readonly Regex RequestIdFormat = new("^[0-9A-Za-z]{11}$");
+
+  private static string ObservedRequestId(Request request) =>
+    request
+      .Headers.Where(h => h.Key.Equals("request-id", StringComparison.OrdinalIgnoreCase))
+      .Select(h => h.Value)
+      .SingleOrDefault();
+
+  private static AlgoliaHttpResponse JsonResponse(string json, int statusCode = 200) =>
+    new()
+    {
+      HttpStatusCode = statusCode,
+      Body = json == null ? null : new MemoryStream(Encoding.UTF8.GetBytes(json)),
+    };
+
+  private static Mock<IHttpRequester> RecordingMock(
+    List<string> observedIds,
+    Func<Request, AlgoliaHttpResponse> respond
+  )
+  {
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, _) =>
+        {
+          observedIds.Add(ObservedRequestId(rq));
+          return Task.FromResult(respond(rq));
+        }
+      );
+    return httpMock;
+  }
+
+  [Fact]
+  public async Task ShouldMintFreshRequestIdPerCall()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+    await client.CustomGetAsync("1/test");
+
+    Assert.Equal(2, observedIds.Count);
+    Assert.All(observedIds, id => Assert.Matches(RequestIdFormat, id));
+    Assert.NotEqual(observedIds[0], observedIds[1]);
+  }
+
+  [Fact]
+  public async Task ShouldNotMutateDefaultHeadersWhenMinting()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+
+    Assert.DoesNotContain(
+      config.DefaultHeaders.Keys,
+      k => k.Equals("request-id", StringComparison.OrdinalIgnoreCase)
+    );
+  }
+
+  [Fact]
+  public async Task ShouldReuseRequestIdAcrossRetries()
+  {
+    var observedIds = new List<string>();
+    var attempts = 0;
+    var httpMock = RecordingMock(
+      observedIds,
+      _ => ++attempts < 3 ? JsonResponse(null, 500) : JsonResponse("{}")
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+
+    Assert.Equal(3, observedIds.Count);
+    Assert.Matches(RequestIdFormat, observedIds[0]);
+    Assert.All(observedIds, id => Assert.Equal(observedIds[0], id));
+  }
+
+  [Fact]
+  public async Task ShouldKeepCallerSuppliedRequestId()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync(
+      "1/test",
+      options: new RequestOptions
+      {
+        Headers = new Dictionary<string, string> { { "ReQuEsT-iD", "CallerOwnedId" } },
+      }
+    );
+
+    Assert.Equal(new List<string> { "CallerOwnedId" }, observedIds);
+  }
+
+  [Fact]
+  public async Task ShouldKeepDefaultHeadersRequestId()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    config.DefaultHeaders["REQUEST-ID"] = "DefaultOwned";
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+
+    Assert.Equal(new List<string> { "DefaultOwned" }, observedIds);
+  }
+
+  [Fact]
+  public async Task ShouldNeverMintForIngestion()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new IngestionConfig("test-app-id", "test-api-key", "us");
+    var client = new IngestionClient(config, httpMock.Object);
+
+    await client.CustomGetAsync("1/test");
+
+    Assert.Equal(new List<string> { null }, observedIds);
+  }
+
+  [Fact]
+  public async Task ShouldShareOneRequestIdPerHelperInvocation()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(
+      observedIds,
+      rq =>
+        rq.Uri.AbsolutePath.EndsWith("/batch")
+          ? JsonResponse("{\"taskID\":42,\"objectIDs\":[\"1\"]}")
+          : JsonResponse("{\"status\":\"published\",\"pendingTask\":false}")
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    // batchSize 1 over two objects: 2 batch calls + 2 task polls.
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "1" }, new { objectID = "2" } },
+      Action.AddObject,
+      waitForTasks: true,
+      batchSize: 1
+    );
+
+    Assert.Equal(4, observedIds.Count);
+    Assert.Matches(RequestIdFormat, observedIds[0]);
+    Assert.All(observedIds, id => Assert.Equal(observedIds[0], id));
+
+    // A second helper invocation mints a fresh ID.
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "3" } },
+      Action.AddObject
+    );
+
+    Assert.Equal(5, observedIds.Count);
+    Assert.Matches(RequestIdFormat, observedIds[4]);
+    Assert.NotEqual(observedIds[0], observedIds[4]);
+  }
+
+  [Fact]
+  public async Task ShouldKeepCallerRequestIdInHelpers()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(
+      observedIds,
+      _ => JsonResponse("{\"taskID\":42,\"objectIDs\":[\"1\"]}")
+    );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    await client.ChunkedBatchAsync(
+      "test-index",
+      new List<object> { new { objectID = "1" } },
+      Action.AddObject,
+      options: new RequestOptions
+      {
+        Headers = new Dictionary<string, string> { { "Request-ID", "HelperCaller" } },
+      }
+    );
+
+    Assert.Equal(new List<string> { "HelperCaller" }, observedIds);
+  }
+
+  [Fact]
+  public async Task ShouldExposeCorrelationIdOnApiErrors()
+  {
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns(() =>
+        Task.FromResult(
+          new AlgoliaHttpResponse
+          {
+            HttpStatusCode = 400,
+            Error = "{\"message\":\"boom\"}",
+            ResponseHeaders = new Dictionary<string, string>
+            {
+              { "cOrReLaTiOn-Id", "CorrTest123" },
+              // The unrelated edge header must never be surfaced instead.
+              { "X-Algolia-RequestID", "EdgePopValue" },
+            },
+          }
+        )
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaApiException>(async () =>
+      await client.CustomGetAsync("1/test")
+    );
+
+    Assert.Equal("CorrTest123", ex.CorrelationId);
+    Assert.Equal(400, ex.HttpErrorCode);
+    Assert.Equal("{\"message\":\"boom\"} (Correlation-ID: CorrTest123)", ex.Message);
+  }
+
+  [Fact]
+  public async Task ShouldLeaveApiErrorsUntouchedWithoutCorrelationId()
+  {
+    var httpMock = new Mock<IHttpRequester>();
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns(() =>
+        Task.FromResult(
+          new AlgoliaHttpResponse
+          {
+            HttpStatusCode = 400,
+            Error = "{\"message\":\"boom\"}",
+            // Timeout and network paths leave ResponseHeaders null.
+            ResponseHeaders = null,
+          }
+        )
+      );
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    var ex = await Assert.ThrowsAsync<AlgoliaApiException>(async () =>
+      await client.CustomGetAsync("1/test")
+    );
+
+    Assert.Null(ex.CorrelationId);
+    Assert.Equal("{\"message\":\"boom\"}", ex.Message);
+  }
+}

--- a/tests/output/csharp/src/RequestIdTests.cs
+++ b/tests/output/csharp/src/RequestIdTests.cs
@@ -123,6 +123,48 @@ public class RequestIdTests
   }
 
   [Fact]
+  public async Task ShouldKeepCallerSuppliedQueryParameterRequestId()
+  {
+    var observedIds = new List<string>();
+    var httpMock = RecordingMock(observedIds, _ => JsonResponse("{}"));
+    var config = new SearchConfig("test-app-id", "test-api-key");
+    var client = new SearchClient(config, httpMock.Object);
+
+    // The server consults the query parameter only when the header is absent,
+    // so minting a header would silently override the caller's ID.
+    Uri observedUri = null;
+    httpMock
+      .Setup(c =>
+        c.SendRequestAsync(
+          It.IsAny<Request>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<TimeSpan>(),
+          It.IsAny<CancellationToken>()
+        )
+      )
+      .Returns<Request, TimeSpan, TimeSpan, CancellationToken>(
+        (rq, _, _, _) =>
+        {
+          observedIds.Add(ObservedRequestId(rq));
+          observedUri = rq.Uri;
+          return Task.FromResult(JsonResponse("{}"));
+        }
+      );
+
+    await client.CustomGetAsync(
+      "1/test",
+      options: new RequestOptions
+      {
+        QueryParameters = new Dictionary<string, object> { { "X-Algolia-Request-Id", "QueryOwned" } },
+      }
+    );
+
+    // The URI check keeps this from passing vacuously when minting is off.
+    Assert.Contains("QueryOwned", observedUri.Query);
+    Assert.Equal(new List<string> { null }, observedIds);
+  }
+
+  [Fact]
   public async Task ShouldKeepDefaultHeadersRequestId()
   {
     var observedIds = new List<string>();
@@ -237,6 +279,7 @@ public class RequestIdTests
       await client.CustomGetAsync("1/test")
     );
 
+    Assert.True(attempts > 1, "last-wins needs more than one attempt to prove anything");
     Assert.Equal($"CorrAttempt{attempts}", ex.CorrelationId);
     Assert.EndsWith($"(Correlation-ID: CorrAttempt{attempts})", ex.Message);
   }


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-518](https://algolia.atlassian.net/browse/API-518)

C# port of the JS Request-ID/Correlation-ID reference implementation (#6747), second of the three ports after Go (#6868).

### Changes included:

- The transport mints an 11-char base62 Request-ID once per execution and reuses it across retries, a caller-supplied ID always wins (`algoliasearch/Transport/HttpTransport.cs`, `algoliasearch/Utils/RequestIdHelper.cs`). The injected headers dictionary is copied first because `GenerateHeaders` returns the live `DefaultHeaders` on the no-options path.
- Failed responses expose the Correlation-ID as `AlgoliaApiException.CorrelationId` and as a ` (Correlation-ID: X)` suffix on `Message`, matching JS, Kotlin and Scala; the new `AlgoliaApiException.ResponseBody` keeps the raw body unmodified for callers that parse the error payload (`algoliasearch/Exceptions/AlgoliaApiException.cs`).
- Deserialization failures and host exhaustion carry it too: the transport tags `AlgoliaException.CorrelationId` on decode errors and its `Message` override appends the same suffix, and `AlgoliaUnreachableHostException.CorrelationId` holds the last retried attempt's value (`algoliasearch/Exceptions/`, `algoliasearch/Transport/HttpTransport.cs`).
- Search helpers derive one shared Request-ID per invocation through `WithRequestId`, built on a `MemberwiseClone` copy so future `RequestOptions` properties cannot be dropped, and forward options to the cleanup `DeleteIndexAsync` calls; the ingestion leg of `ReplaceAllObjectsWithTransformationAsync` stays untouched (`algoliasearch/Utils/SearchClientExtensions.cs`, `algoliasearch/Http/RequestOptions.cs`).
- The `ReplaceAllObjects` failure-path cleanups delete the temporary index with `CancellationToken.None`, so a caller's own cancellation no longer leaks the temp index (`algoliasearch/Utils/SearchClientExtensions.cs`).
- `IndexExistsAsync`/`IndexExists` gain overloads taking `RequestOptions`, so timeouts and custom headers can reach the underlying `GetSettingsAsync` call. The existing signatures stay untouched; note the new `ISearchClient` members compile-break external implementors of the interface, which this repo accepts with every helper addition (`algoliasearch/Utils/SearchClientExtensions.cs`).
- Enabled only for search, recommend and composition via `requestIdSupport` and a public `RequestIdEnabled` config flag defaulted by the generated configurations; callers can set it to false to disable minting, mirroring the caller-overridable flag the Go port adopted (`AlgoliaCSharpGenerator.java`, `templates/csharp/Configuration.mustache`, `algoliasearch/Clients/AlgoliaConfig.cs`).
- CTS: csharp removed from `skipLanguages`, the C# expected error asserts the decorated message including the Correlation-ID suffix, `REQUEST_ID_LANGUAGES` gains csharp, e2e `correlationIdSuffix` block added via `CustomGetWithHTTPInfoAsync` (`templates/csharp/tests/e2e/e2e.mustache`).
- Fixes a latent bug in the C# test method partial: request options were passed positionally and landed in `customGet`'s optional query-parameters slot, hit for the first time by the caller-precedence test; they are now passed as a named argument (`templates/csharp/tests/method.mustache`).

## 🧪 Test

- `dotnet test --filter RequestIdTests` passes with 19 transport tests (freshness, retry reuse, caller and default-headers precedence, no DefaultHeaders mutation, caller opt-out, helper sharing, options preservation, ingestion no-mint, error CID with and without header, raw response body, decode-error CID, IndexExists options forwarding, cleanup on caller cancellation).
- `yarn cli cts run csharp --no-e2e` green with the requestId tests enabled, including the recorder assertions and the ingestion no-leak check.
- E2e (CID suffix echo against the real API) runs on CI.

[API-518]: https://algolia.atlassian.net/browse/API-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


**Changelog note:** `AlgoliaApiException.Message` now carries a ` (Correlation-ID: X)` suffix when the failed response includes one; callers that parse the error payload should use the new `AlgoliaApiException.ResponseBody`, which holds the raw response body unmodified.
