### PR TITLE
fix(cts): make query categorization e2e assertion data-independent

### DIFF
--- a/tests/CTS/requests/search/search.json
+++ b/tests/CTS/requests/search/search.json
@@ -1172,10 +1172,7 @@
             "index": "cts_e2e_query_categorization",
             "query": "sofa",
             "extensions": {
-              "queryCategorization": {
-                "normalizedQuery": "sofa",
-                "categories": [{}]
-              }
+              "queryCategorization": {}
             }
           }
         ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket:

The `withQueryCategorization` e2e test asserted on live model output (`normalizedQuery`, `categories`), which only exists while the Query Categorization model has recent events behind it. The monthly events cron no longer keeps that alive: after the Aug 1 run the model went empty somewhere between Aug 7 and Aug 10, failing e2e in all 11 languages. The model's usable window shrank from 26+ days in July to under 9 in August, so raising the cron frequency is chasing a number we don't control.

Expecting `queryCategorization: {}` instead keeps the assertion meaningful without depending on model data. The CTS comparison only compares keys present in the expectation — a union projection in 10 languages, a json4s `diff` on `deleted`/`changed` in Scala — so the test still fails if a client drops `extensions` from the request body or fails to deserialize the field, but passes whether or not the model currently has categories.

### Changes included:

- Drop `normalizedQuery` and `categories` from the expected response of `withQueryCategorization`; the request half is unchanged, so the test still requires the server to accept `enableCategoriesRetrieval`/`enableAutoFiltering`.

## 🧪 Test

Regenerated the JS CTS for `search` and `algoliasearch` and ran both e2e files against the live API in its current data-less state: 21/21 pass, previously 2 failed.

Checked the assertion still has teeth against the real `union` helper — passes with model data present, with it empty, and in the partial state where `normalizedQuery` exists but `categories` hasn't landed; fails when `queryCategorization` or `extensions` is absent.
