### PR TITLE
feat(specs): add agentic analytics support to insights spec

### DIFF
--- a/specs/insights/common/schemas/EventAttributes.yml
+++ b/specs/insights/common/schemas/EventAttributes.yml
@@ -51,15 +51,30 @@ timestamp:
 
 queryID:
   type: string
-  pattern: '[0-9a-f]{32}'
-  minLength: 32
-  maxLength: 32
-  description: |
+  pattern: '^([0-9a-f]{32}|message_[!-~]+)$'
+  maxLength: 128
+  description: >
     Unique identifier for a search query.
 
+
     The query ID is required for events related to search or browse requests.
-    If you add `clickAnalytics: true` as a search request parameter, the query ID is included in the API response.
-  example: 3e48cd0616e466948dd85abf5c3fbbe2
+
+    If you add `clickAnalytics: true` as a search request parameter, the
+    query ID is included in the API response.
+
+    For agentic analytics events, the query ID may be prefixed with
+    `message_` followed by any printable string.
+  examples:
+    - 3e48cd0616e466948dd85abf5c3fbbe2
+    - message_my-custom-query-id
+
+agentID:
+  type: string
+  minLength: 1
+  description: >
+    Unique identifier for an agent session.
+    Used to correlate instantsearch events with a specific agent interaction.
+  example: agent-session-123
 
 objectIDs:
   type: array

--- a/specs/insights/common/schemas/EventsItems.yml
+++ b/specs/insights/common/schemas/EventsItems.yml
@@ -11,3 +11,4 @@ oneOf:
   - $ref: './ConvertedFilters.yml'
   - $ref: './ViewedObjectIDs.yml'
   - $ref: './ViewedFilters.yml'
+  - $ref: './Instantsearch.yml'

--- a/specs/insights/common/schemas/Instantsearch.yml
+++ b/specs/insights/common/schemas/Instantsearch.yml
@@ -1,0 +1,19 @@
+properties:
+  eventName:
+    $ref: './EventAttributes.yml#/eventName'
+  eventType:
+    $ref: './InstantsearchEvent.yml'
+  userToken:
+    $ref: './EventAttributes.yml#/userToken'
+  authenticatedUserToken:
+    $ref: './EventAttributes.yml#/authenticatedUserToken'
+  timestamp:
+    $ref: './EventAttributes.yml#/timestamp'
+  agentID:
+    $ref: './EventAttributes.yml#/agentID'
+required:
+  - eventName
+  - eventType
+  - userToken
+x-discriminator-fields:
+  - eventType

--- a/specs/insights/common/schemas/Instantsearch.yml
+++ b/specs/insights/common/schemas/Instantsearch.yml
@@ -1,3 +1,4 @@
+type: object
 properties:
   eventName:
     $ref: './EventAttributes.yml#/eventName'

--- a/specs/insights/common/schemas/InstantsearchEvent.yml
+++ b/specs/insights/common/schemas/InstantsearchEvent.yml
@@ -1,0 +1,3 @@
+type: string
+enum:
+  - instantsearch

--- a/specs/insights/paths/pushEvents.yml
+++ b/specs/insights/paths/pushEvents.yml
@@ -185,6 +185,27 @@ post:
                   userToken: anonymous-user-1
                   authenticatedUserToken: user-1
                   filters: ['category:books']
+          InstantsearchMinimum:
+            summary: Minimum instantsearch event
+            description: >
+              Minimum valid instantsearch event for agentic analytics
+              telemetry.
+            value:
+              events:
+                - eventName: Instantsearch Telemetry
+                  eventType: instantsearch
+                  userToken: anonymous-user-1
+          InstantsearchWithAgentID:
+            summary: Instantsearch event with agentID
+            description: >
+              Instantsearch event with agentID to correlate events within
+              a single agent session.
+            value:
+              events:
+                - eventName: Instantsearch Telemetry
+                  eventType: instantsearch
+                  userToken: anonymous-user-1
+                  agentID: agent-session-123
 
   responses:
     '200':
@@ -313,7 +334,7 @@ post:
               summary: Wrong event type
               value:
                 status: 422
-                message: EventType must be one of "click", "conversion" or "view"
+                message: EventType must be one of "click", "conversion", "view" or "instantsearch"
             IndexRequired:
               summary: Missing index attribute
               value:


### PR DESCRIPTION
## Summary

Adds agentic analytics support to the Insights API spec (VNTS-166). These changes are non-breaking and have already been incorporated into and tested in the insights-api.

- **InstantsearchEvent** — new event type enum (`instantsearch`)
- **Instantsearch** — new event schema with `eventName`, `eventType`, `userToken`, `authenticatedUserToken`, `timestamp`, and `agentID`
- **agentID** — new field for correlating events within an agent session
- **queryID** — extended pattern to accept `message_` prefix for agentic events (`maxLength` 128, removed `minLength`)
- **EventsItems** — added `Instantsearch` to the `oneOf` union
- **pushEvents** — added two request examples (`InstantsearchMinimum`, `InstantsearchWithAgentID`) and updated `WrongEventType` error message

Bundled output verified against the draft spec in `go/internal/insights/api/spec/insights_draft.yml` — all schemas, examples, and error messages match.

## Test plan

- [ ] CI passes (spec linting, client generation)
- [ ] Generated clients include `Instantsearch` event type and `agentID` field
- [ ] Bundled spec matches `insights_draft.yml` in the go repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)