### PR TITLE
docs(specs): explain what migratedAbTestID actually identifies

### DIFF
--- a/specs/abtesting-v3/common/schemas/ABTest.yml
+++ b/specs/abtesting-v3/common/schemas/ABTest.yml
@@ -97,7 +97,10 @@ EffectMetric:
 
 MigratedABTestId:
   type: integer
-  description: Unique migrated A/B test identifier.
+  description: |
+    ID this A/B test had in the region it was migrated from.
+    Only set on tests that were moved between analytics regions.
+    It refers to that region's data, so it isn't a valid `abTestID` for requests to this API.
   example: 224
 
 MetricsFilter:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [OPTIM-2329](https://algolia.atlassian.net/browse/OPTIM-2329)

`migratedAbTestID` is described as "Unique migrated A/B test identifier", which says nothing about what the value is, when it appears, or what it addresses.

That ambiguity has already cost us. Two dashboard call sites passed it as the `{id}` path parameter of `GET /3/abtests/{id}/timeseries`, which authorizes and reads `abtests_variants_metrics` by primary key against the region's own database. The ID belongs to the *other* region, so the chart silently returned nothing. Fixed in [AlgoliaWeb#29783](https://github.com/algolia/AlgoliaWeb/pull/29783); this PR removes the ambiguity that allowed it.

### Changes included:

- Replaces the `MigratedABTestId` description with what the value is, when it is set, and why it is not a valid `abTestID` for this API.

No schema change: same `type: integer`, same example, still optional. Deliberately **not** marked `deprecated` — the field is staying. 1,408 A/B tests across 226 apps carry it, and it remains the only link between a migrated test and its predecessor.

## 🧪 Test

Green CI. Spec-only change, so no generated code is included, per the CI note that generated code is pushed at the end of the run.

`yaml.safe_load` on the edited file confirms the schema still resolves with the same type and example.

[OPTIM-2329]: https://algolia.atlassian.net/browse/OPTIM-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ