### PR TITLE
chore(javascript): raise abtesting bundle budget

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -35,7 +35,7 @@
       },
       {
         "path": "packages/abtesting/dist/builds/browser.umd.js",
-        "maxSize": "6.25KB"
+        "maxSize": "6.5KB"
       },
       {
         "path": "packages/client-abtesting/dist/builds/browser.umd.js",


### PR DESCRIPTION
## 🧭 What and Why

The A/B Testing v3 JavaScript browser bundle is now 6.33 KB gzip after adding the settings endpoints in #6786, which exceeds its current 6.25 KB budget. The increase is intentional and limited to the generated client methods for those endpoints.

🎟 JIRA Ticket: N/A

### Changes included:

- Increase the `@algolia/abtesting` browser bundle budget from 6.25 KB to 6.5 KB.
- Keep the size guard active with 0.17 KB of remaining headroom.

## 🧪 Test

- `jq empty clients/algoliasearch-client-javascript/package.json`
- `git diff --check`

## PR Stack

1. **#6884** ⬅
2. #6786
3. #6829
4. #6834
5. #6879
