### PR TITLE
feat(python): Request-ID and Correlation-ID support

### DIFF
--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -33,6 +33,8 @@ class BaseConfig:
         self.compression_type: Optional[Literal["gzip"]] = None
         self.compression_threshold: int = 750
 
+        self.request_id_enabled: bool = False
+
     def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""
         self.api_key = api_key

--- a/clients/algoliasearch-client-python/algoliasearch/http/exceptions.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/exceptions.py
@@ -12,10 +12,13 @@ class MissingObjectIdException(AlgoliaException):
 
 
 class RequestException(AlgoliaException):
-    def __init__(self, message, status_code):
+    def __init__(self, message, status_code, correlation_id=None):
+        if correlation_id:
+            message = "{0} (Correlation-ID: {1})".format(message, correlation_id)
         super(AlgoliaException, self).__init__(message)
         self.status_code = status_code
         self.message = message
+        self.correlation_id = correlation_id
 
     def __hash__(self):
         return id(self)
@@ -32,7 +35,12 @@ class RequestException(AlgoliaException):
 
 
 class AlgoliaUnreachableHostException(AlgoliaException):
-    pass
+    def __init__(self, message, correlation_id=None):
+        if correlation_id:
+            message = "{0} (Correlation-ID: {1})".format(message, correlation_id)
+        super().__init__(message)
+        self.message = message
+        self.correlation_id = correlation_id
 
 
 class ObjectNotFoundException(AlgoliaException):

--- a/clients/algoliasearch-client-python/algoliasearch/http/request_id.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/request_id.py
@@ -1,0 +1,93 @@
+from copy import copy
+from secrets import choice
+from typing import Any, Dict, Optional, TypeVar, Union, cast
+
+from algoliasearch.http.base_config import BaseConfig
+from algoliasearch.http.request_options import RequestOptions
+
+REQUEST_ID_HEADER = "request-id"
+REQUEST_ID_QUERY_PARAMETER = "x-algolia-request-id"
+CORRELATION_ID_HEADER = "correlation-id"
+
+REQUEST_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+REQUEST_ID_LENGTH = 11
+
+RequestOptionsType = TypeVar(
+    "RequestOptionsType", bound=Optional[Union[dict, RequestOptions]]
+)
+
+
+def generate_request_id() -> str:
+    """Returns a fresh 11 character base62 identifier for the Request-ID header."""
+    return "".join(choice(REQUEST_ID_ALPHABET) for _ in range(REQUEST_ID_LENGTH))
+
+
+def _contains_key(mapping: Optional[Dict[str, Any]], name: str) -> bool:
+    if not mapping:
+        return False
+
+    return any(str(key).lower() == name for key in mapping)
+
+
+def has_request_id(headers: Optional[Dict[str, Any]]) -> bool:
+    """Whether the headers already carry a Request-ID entry, whatever its casing."""
+    return _contains_key(headers, REQUEST_ID_HEADER)
+
+
+def has_request_id_query_parameter(query_parameters: Optional[Dict[str, Any]]) -> bool:
+    """Whether the query parameters already carry an x-algolia-request-id entry, whatever its casing."""
+    return _contains_key(query_parameters, REQUEST_ID_QUERY_PARAMETER)
+
+
+def get_correlation_id(headers: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Reads the Correlation-ID response header, whatever its casing."""
+    if not headers:
+        return None
+
+    for key, value in headers.items():
+        if str(key).lower() == CORRELATION_ID_HEADER:
+            return value
+
+    return None
+
+
+def with_request_id(
+    request_options: RequestOptionsType, config: BaseConfig
+) -> RequestOptionsType:
+    """
+    Derives the request options carrying the Request-ID shared by every request of one
+    invocation. The given options are never modified, so a caller reusing one object across
+    calls still gets a fresh id per call. Returns them untouched when the client does not
+    support Request-ID, or when the caller already supplied one on either channel.
+    """
+    if not config.request_id_enabled:
+        return request_options
+
+    given: Any = request_options
+    is_request_options = isinstance(given, RequestOptions)
+
+    headers = given.headers if is_request_options else (given or {}).get("headers")
+    query_parameters = (
+        given.query_parameters
+        if is_request_options
+        else (given or {}).get("query_parameters")
+    )
+
+    if (
+        has_request_id(headers)
+        or has_request_id_query_parameter(query_parameters)
+        or has_request_id(config.headers)
+    ):
+        return request_options
+
+    request_id_headers = {**(headers or {}), REQUEST_ID_HEADER: generate_request_id()}
+
+    options: Any
+    if is_request_options:
+        options = copy(given)
+        options.headers = request_id_headers
+    else:
+        options = dict(given or {})
+        options["headers"] = request_id_headers
+
+    return cast(RequestOptionsType, options)

--- a/clients/algoliasearch-client-python/algoliasearch/http/request_id.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/request_id.py
@@ -1,5 +1,5 @@
 from copy import copy
-from secrets import choice
+from secrets import token_bytes
 from typing import Any, Dict, Optional, TypeVar, Union, cast
 
 from algoliasearch.http.base_config import BaseConfig
@@ -19,7 +19,10 @@ RequestOptionsType = TypeVar(
 
 def generate_request_id() -> str:
     """Returns a fresh 11 character base62 identifier for the Request-ID header."""
-    return "".join(choice(REQUEST_ID_ALPHABET) for _ in range(REQUEST_ID_LENGTH))
+    return "".join(
+        REQUEST_ID_ALPHABET[byte % len(REQUEST_ID_ALPHABET)]
+        for byte in token_bytes(REQUEST_ID_LENGTH)
+    )
 
 
 def _contains_key(mapping: Optional[Dict[str, Any]], name: str) -> bool:

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
@@ -13,6 +13,7 @@ from algoliasearch.http.exceptions import (
     RequestException,
 )
 from algoliasearch.http.hosts import Host
+from algoliasearch.http.request_id import get_correlation_id, with_request_id
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.retry import RetryOutcome, RetryStrategy
 from algoliasearch.http.sse import ServerSentEvent, aiter_sse_events
@@ -46,6 +47,8 @@ class Transporter(BaseTransporter):
                 connector=TCPConnector(use_dns_cache=False), trust_env=True
             )
 
+        request_options = with_request_id(request_options, self._config)
+
         query_parameters = self.prepare(
             request_options, verb == Verb.GET or use_read_transporter
         )
@@ -58,6 +61,8 @@ class Transporter(BaseTransporter):
         ):
             request_options.data = gzip_compress(request_options.data.encode("utf-8"))
             request_options.headers["content-encoding"] = "gzip"
+
+        last_correlation_id = None
 
         for host in self._retry_strategy.valid_hosts(self._hosts):
             url = self.build_url(host, path)
@@ -105,6 +110,9 @@ class Transporter(BaseTransporter):
                     is_timed_out_error=True,
                 )
 
+            correlation_id = get_correlation_id(response.headers)
+            last_correlation_id = correlation_id or last_correlation_id
+
             decision = self._retry_strategy.decide(host, response)
 
             if decision == RetryOutcome.SUCCESS:
@@ -114,10 +122,11 @@ class Transporter(BaseTransporter):
                 if response.data and "message" in response.data:
                     content = loads(response.data)["message"]
 
-                raise RequestException(content, response.status_code)
+                raise RequestException(content, response.status_code, correlation_id)
 
         raise AlgoliaUnreachableHostException(
-            "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support"
+            "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support",
+            last_correlation_id,
         )
 
     async def request_stream(
@@ -132,6 +141,7 @@ class Transporter(BaseTransporter):
                 connector=TCPConnector(use_dns_cache=False), trust_env=True
             )
 
+        request_options = with_request_id(request_options, self._config)
         request_options.headers["accept"] = "text/event-stream"
 
         query_parameters = self.prepare(
@@ -168,7 +178,11 @@ class Transporter(BaseTransporter):
         try:
             if resp.status >= 400:
                 error_text = await resp.text()
-                raise RequestException(error_text, resp.status)
+                raise RequestException(
+                    error_text,
+                    resp.status,
+                    get_correlation_id(resp.headers),  # pyright: ignore # insensitive dict is still a dict
+                )
 
             async for event in aiter_sse_events(resp.content.iter_any()):
                 yield event

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
@@ -21,6 +21,7 @@ from algoliasearch.http.exceptions import (
     RequestException,
 )
 from algoliasearch.http.hosts import Host
+from algoliasearch.http.request_id import get_correlation_id, with_request_id
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.retry import RetryOutcome, RetryStrategy
 from algoliasearch.http.sse import ServerSentEvent, iter_sse_events
@@ -59,6 +60,8 @@ class TransporterSync(BaseTransporter):
             self._session = Session()
             self._session.mount("https://", HTTPAdapter(max_retries=Retry(connect=0)))
 
+        request_options = with_request_id(request_options, self._config)
+
         query_parameters = self.prepare(
             request_options, verb == Verb.GET or use_read_transporter
         )
@@ -71,6 +74,8 @@ class TransporterSync(BaseTransporter):
         ):
             request_options.data = gzip_compress(request_options.data.encode("utf-8"))
             request_options.headers["content-encoding"] = "gzip"
+
+        last_correlation_id = None
 
         for host in self._retry_strategy.valid_hosts(self._hosts):
             url = self.build_url(host, path)
@@ -118,6 +123,9 @@ class TransporterSync(BaseTransporter):
                     is_timed_out_error=True,
                 )
 
+            correlation_id = get_correlation_id(response.headers)
+            last_correlation_id = correlation_id or last_correlation_id
+
             decision = self._retry_strategy.decide(host, response)
 
             if decision == RetryOutcome.SUCCESS:
@@ -127,10 +135,11 @@ class TransporterSync(BaseTransporter):
                 if response.data and "message" in response.data:
                     content = loads(response.data)["message"]
 
-                raise RequestException(content, response.status_code)
+                raise RequestException(content, response.status_code, correlation_id)
 
         raise AlgoliaUnreachableHostException(
-            "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support"
+            "Unreachable hosts. If the error persists, please visit our help center https://alg.li/support-unreachable-hosts or reach out to the Algolia Support team: https://alg.li/support",
+            last_correlation_id,
         )
 
     def request_stream(
@@ -144,6 +153,7 @@ class TransporterSync(BaseTransporter):
             self._session = Session()
             self._session.mount("https://", HTTPAdapter(max_retries=Retry(connect=0)))
 
+        request_options = with_request_id(request_options, self._config)
         request_options.headers["accept"] = "text/event-stream"
 
         query_parameters = self.prepare(
@@ -183,7 +193,11 @@ class TransporterSync(BaseTransporter):
         try:
             if resp.status_code >= 400:
                 error_text = resp.text
-                raise RequestException(error_text, resp.status_code)
+                raise RequestException(
+                    error_text,
+                    resp.status_code,
+                    get_correlation_id(resp.headers),  # type: ignore # insensitive dict is still a dict
+                )
 
             for event in iter_sse_events(resp.iter_content(chunk_size=None)):
                 yield event

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaPythonGenerator.java
@@ -27,6 +27,7 @@ public class AlgoliaPythonGenerator extends PythonClientCodegen {
     CLIENT = (String) additionalProperties.get("client");
 
     additionalProperties.put("is" + Helpers.capitalize(Helpers.camelize((String) additionalProperties.get("client"))) + "Client", true);
+    additionalProperties.put("requestIdSupport", Helpers.requestIdSupport(CLIENT));
     additionalProperties.put("packageVersion", Helpers.getClientConfigField("python", "packageVersion"));
     additionalProperties.put(CodegenConstants.EXCLUDE_TESTS, true);
 

--- a/scripts/cts/testServer/requestId.ts
+++ b/scripts/cts/testServer/requestId.ts
@@ -9,7 +9,7 @@ import { setupServer } from './index.ts';
 export const REQUEST_ID_FORMAT = /^[0-9A-Za-z]{11}$/;
 
 // languages that have ported Request-ID support (API-516)
-export const REQUEST_ID_LANGUAGES = ['csharp', 'dart', 'go', 'java', 'javascript', 'kotlin', 'scala', 'swift'];
+export const REQUEST_ID_LANGUAGES = ['csharp', 'dart', 'go', 'java', 'javascript', 'kotlin', 'python', 'scala', 'swift'];
 
 const retryState: Record<string, string[]> = {};
 const freshState: Record<string, string[]> = {};

--- a/templates/python/config.mustache
+++ b/templates/python/config.mustache
@@ -55,6 +55,10 @@ class {{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}Config(BaseConfig):
         self.write_timeout = {{x-timeouts.server.write}}
         self.connect_timeout = {{x-timeouts.server.connect}}
 
+        {{#requestIdSupport}}
+        self.request_id_enabled = True
+
+        {{/requestIdSupport}}
         self._user_agent = UserAgent()
         self.add_user_agent("{{#lambda.pascalcase}}{{client}}{{/lambda.pascalcase}}", __version__)
 

--- a/templates/python/imports.mustache
+++ b/templates/python/imports.mustache
@@ -55,6 +55,7 @@ from algoliasearch.http.base_config import BaseConfig
 from algoliasearch.http.chunked_helper_options import ChunkedHelperOptions
 from algoliasearch.http.exceptions import RequestException, ValidUntilNotFoundException
 from algoliasearch.http.helpers import create_iterable, create_iterable_sync, RetryTimeout
+from algoliasearch.http.request_id import with_request_id
 from algoliasearch.http.request_options import RequestOptions
 from algoliasearch.http.serializer import body_serializer, QueryParametersSerializer
 from algoliasearch.http.transporter import Transporter

--- a/templates/python/search_helpers.mustache
+++ b/templates/python/search_helpers.mustache
@@ -9,6 +9,7 @@
         """
         Helper: Wait for a task to be published (completed) for a given `indexName` and `taskID`.
         """
+        request_options = with_request_id(request_options, self._config)
         _retry_count = 0
 
         {{^isSyncClient}}async {{/isSyncClient}}def _func(_: Optional[GetTaskResponse]) -> GetTaskResponse:
@@ -37,6 +38,7 @@
         """
         Helper: Wait for an application-level task to complete for a given `taskID`.
         """
+        request_options = with_request_id(request_options, self._config)
         _retry_count = 0
 
         {{^isSyncClient}}async {{/isSyncClient}}def _func(_: Optional[GetTaskResponse]) -> GetTaskResponse:
@@ -67,6 +69,7 @@
         """
         Helper: Wait for an API key to be added, updated or deleted based on a given `operation`.
         """
+        request_options = with_request_id(request_options, self._config)
         _retry_count = 0
 
         if operation == "update" and api_key is None:
@@ -128,6 +131,7 @@
         """
         Helper: Iterate on the `browse` method of the client to allow aggregating objects of an index.
         """
+        request_options = with_request_id(request_options, self._config)
         if isinstance(browse_params, dict):
             browse_params = BrowseParamsObject().from_dict(browse_params)
 
@@ -162,6 +166,7 @@
         """
         Helper: Iterate on the `search_rules` method of the client to allow aggregating rules of an index.
         """
+        request_options = with_request_id(request_options, self._config)
         if isinstance(search_rules_params, dict):
             search_rules_params = SearchRulesParams().from_dict(search_rules_params)
 
@@ -197,6 +202,7 @@
         """
         Helper: Iterate on the `search_synonyms` method of the client to allow aggregating synonyms of an index.
         """
+        request_options = with_request_id(request_options, self._config)
         if isinstance(search_synonyms_params, dict):
             search_synonyms_params = SearchSynonymsParams().from_dict(search_synonyms_params)
 
@@ -400,6 +406,7 @@
         """
         if batch_size < 1:
             raise ValueError("`batch_size` must be at least 1.")
+        request_options = with_request_id(request_options, self._config)
         chunked_options = chunked_options or ChunkedHelperOptions()
         responses: List[BatchResponse] = []
         it = iter(objects)
@@ -415,7 +422,7 @@
         if wait_for_tasks:
             for response in responses:
                 {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-                    index_name=index_name, task_id=response.task_id, max_retries=chunked_options.max_retries
+                    index_name=index_name, task_id=response.task_id, max_retries=chunked_options.max_retries, request_options=request_options
                 )
         return responses
 
@@ -445,6 +452,7 @@
                 f'replace_all_objects_with_transformation was called with an empty list of objects, which will delete all records currently in the "{index_name}" index.'
             )
         chunked_options = chunked_options or ChunkedHelperOptions(max_retries=ChunkedHelperOptions.DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES)
+        search_request_options = with_request_id(request_options, self._config)
         tmp_index_name = self.create_temporary_name(index_name)
 
         try:
@@ -456,7 +464,7 @@
                       destination=tmp_index_name,
                       scope=scopes,
                   ),
-                  request_options=request_options,
+                  request_options=search_request_options,
               )
 
           copy_operation_response = {{^isSyncClient}}await {{/isSyncClient}}_copy()
@@ -472,12 +480,12 @@
           )
 
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=search_request_options
           )
 
           copy_operation_response = {{^isSyncClient}}await {{/isSyncClient}}_copy()
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=search_request_options
           )
 
           move_operation_response = {{^isSyncClient}}await {{/isSyncClient}}self.operation_index(
@@ -486,10 +494,10 @@
                   operation=OperationType.MOVE,
                   destination=index_name,
               ),
-              request_options=request_options,
+              request_options=search_request_options,
           )
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=move_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=move_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=search_request_options
           )
 
           search_watch_responses: List[WatchResponse] = [WatchResponse.model_validate(wr.model_dump()) for wr in watch_responses]
@@ -500,7 +508,7 @@
               move_operation_response=move_operation_response,
           )
         except Exception as e:
-          {{^isSyncClient}}await {{/isSyncClient}}self.delete_index(tmp_index_name)
+          {{^isSyncClient}}await {{/isSyncClient}}self.delete_index(tmp_index_name, request_options=search_request_options)
 
           raise e
 
@@ -528,6 +536,7 @@
                 f'replace_all_objects was called with an empty list of objects, which will delete all records currently in the "{index_name}" index.'
             )
         chunked_options = chunked_options or ChunkedHelperOptions(max_retries=ChunkedHelperOptions.DEFAULT_REPLACE_ALL_OBJECTS_MAX_RETRIES)
+        request_options = with_request_id(request_options, self._config)
         tmp_index_name = self.create_temporary_name(index_name)
 
         try:
@@ -554,12 +563,12 @@
           )
 
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=request_options
           )
 
           copy_operation_response = {{^isSyncClient}}await {{/isSyncClient}}_copy()
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=copy_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=request_options
           )
 
           move_operation_response = {{^isSyncClient}}await {{/isSyncClient}}self.operation_index(
@@ -571,7 +580,7 @@
               request_options=request_options,
           )
           {{^isSyncClient}}await {{/isSyncClient}}self.wait_for_task(
-              index_name=tmp_index_name, task_id=move_operation_response.task_id, max_retries=chunked_options.max_retries
+              index_name=tmp_index_name, task_id=move_operation_response.task_id, max_retries=chunked_options.max_retries, request_options=request_options
           )
 
           return ReplaceAllObjectsResponse(
@@ -580,16 +589,20 @@
               move_operation_response=move_operation_response,
           )
         except Exception as e:
-          {{^isSyncClient}}await {{/isSyncClient}}self.delete_index(tmp_index_name)
+          {{^isSyncClient}}await {{/isSyncClient}}self.delete_index(tmp_index_name, request_options=request_options)
 
           raise e
 
-    {{^isSyncClient}}async {{/isSyncClient}}def index_exists(self, index_name: str) -> bool:
+    {{^isSyncClient}}async {{/isSyncClient}}def index_exists(
+        self,
+        index_name: str,
+        request_options: Optional[Union[dict, RequestOptions]] = None,
+    ) -> bool:
         """
         Helper: Checks if the given `index_name` exists.
         """
         try:
-            {{^isSyncClient}}await {{/isSyncClient}}self.get_settings(index_name)
+            {{^isSyncClient}}await {{/isSyncClient}}self.get_settings(index_name, request_options=request_options)
         except Exception as e:
             if isinstance(e, RequestException) and e.status_code == 404:
                 return False

--- a/templates/python/tests/e2e/e2e.mustache
+++ b/templates/python/tests/e2e/e2e.mustache
@@ -39,6 +39,11 @@ class Test{{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isSyncClien
         assert raw_resp.status_code == {{statusCode}}
         {{/statusCode}}
 
+        {{#correlationIdSuffix}}
+        _correlation_id = next((_value for _key, _value in (raw_resp.headers or {}).items() if _key.lower() == "correlation-id"), None)
+        assert _correlation_id is not None
+        assert _correlation_id.endswith("{{{correlationIdSuffix}}}")
+        {{/correlationIdSuffix}}
 
         {{#body}}
         resp = {{^isSyncClient}}await {{/isSyncClient}}{{#lambda.pascalcase}}{{{client}}}{{#isSyncClient}}Sync{{/isSyncClient}}{{/lambda.pascalcase}}(self._e2e_app_id, self._e2e_api_key{{#hasRegionalHost}}, "{{{defaultRegion}}}"{{/hasRegionalHost}}).{{#lambda.snakecase}}{{method}}{{/lambda.snakecase}}({{#parametersWithDataType}}{{> tests/generateParams}}{{/parametersWithDataType}}{{#hasRequestOptions}} request_options={ {{#requestOptions.headers.parameters}}"headers":loads("""{{{.}}}"""),{{/requestOptions.headers.parameters}}{{#requestOptions.queryParameters.parameters}}"query_parameters":loads("""{{{.}}}"""),{{/requestOptions.queryParameters.parameters}} }{{/hasRequestOptions}})

--- a/tests/CTS/client/composition/requestId.json
+++ b/tests/CTS/client/composition/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the composition client sends a Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/recommend/requestId.json
+++ b/tests/CTS/client/recommend/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the recommend client sends a Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",

--- a/tests/CTS/client/search/requestId.json
+++ b/tests/CTS/client/search/requestId.json
@@ -2,7 +2,7 @@
   {
     "testName": "the Request-ID stays stable across retries",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",
@@ -40,7 +40,7 @@
   {
     "testName": "each call mints a fresh Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",
@@ -85,7 +85,7 @@
   {
     "testName": "a caller-supplied Request-ID is never overwritten",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",
@@ -122,7 +122,7 @@
   {
     "testName": "every request of one helper call shares one Request-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",
@@ -233,7 +233,7 @@
   {
     "testName": "client errors expose the Correlation-ID",
     "autoCreateClient": false,
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "steps": [
       {
         "type": "createClient",
@@ -261,6 +261,7 @@
             "java": "Status Code: 400 - {\\\"message\\\":\\\"request-id error test\\\"} (Correlation-ID: CtsFixedCorrelationId)",
             "javascript": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "kotlin": "Client request\\\\(GET http://%localhost%:6694/1/test/request-id/error/kotlin\\\\) invalid: 400 Bad Request. Text: \\\"\\\\{\\\"message\\\":\\\"request-id error test\\\"\\\\}\\\" \\\\(Correlation-ID: CtsFixedCorrelationId\\\\)",
+            "python": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "scala": "request-id error test (Correlation-ID: CtsFixedCorrelationId)",
             "swift": "HTTP error: Status code: 400 Message: request-id error test (Correlation-ID: CtsFixedCorrelationId)"
           }

--- a/tests/CTS/requests/composition/getComposition.json
+++ b/tests/CTS/requests/composition/getComposition.json
@@ -10,7 +10,7 @@
   },
   {
     "testName": "the Correlation-ID ends with the sent Request-ID",
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "parameters": {
       "compositionID": "id1"
     },
@@ -36,7 +36,7 @@
   },
   {
     "testName": "the Correlation-ID ends with the Request-ID sent as a query parameter",
-    "skipLanguages": ["php", "python", "ruby"],
+    "skipLanguages": ["php", "ruby"],
     "parameters": {
       "compositionID": "id1"
     },

--- a/tests/CTS/requests/search/searchRules.json
+++ b/tests/CTS/requests/search/searchRules.json
@@ -52,7 +52,7 @@
   },
   {
     "testName": "the classic engine accepts a Request-ID sent as a query parameter",
-    "skipLanguages": ["dart", "go", "php", "python", "ruby", "swift"],
+    "skipLanguages": ["dart", "go", "php", "ruby", "swift"],
     "parameters": {
       "indexName": "cts_e2e_browse",
       "searchRulesParams": {

--- a/tests/output/python/tests/manual/test_request_id.py
+++ b/tests/output/python/tests/manual/test_request_id.py
@@ -59,22 +59,29 @@ class RecordingSession(Session):
         self._statuses = list(statuses)
         self._headers = headers
         self.observed_request_ids: List[Optional[str]] = []
+        self.observed_urls: List[str] = []
 
     def send(self, request: PreparedRequest, **kwargs: Any) -> Response:  # type: ignore # the tests only need the recorded request
         _ = kwargs
         self.observed_request_ids.append(request.headers.get("request-id"))
+        self.observed_urls.append(request.url or "")
         return FakeResponse(self._statuses.pop(0), self._headers)
 
 
 def send(
-    config: BaseConfig, session: RecordingSession, verb: Verb = Verb.GET
+    config: BaseConfig,
+    session: RecordingSession,
+    verb: Verb = Verb.GET,
+    request_options: Optional[Dict[str, Any]] = None,
 ) -> Response:
     transporter = TransporterSync(config)
     transporter._session = session
     return transporter.request(
         verb=verb,
         path="/test",
-        request_options=RequestOptions(config).merge(),
+        request_options=RequestOptions(config).merge(
+            user_request_options=request_options
+        ),
         use_read_transporter=True,
     )
 
@@ -168,6 +175,35 @@ def test_an_unsupported_client_sends_no_request_id() -> None:
     send(create_config(request_id_enabled=False), session)
 
     assert session.observed_request_ids == [None]
+
+
+def test_a_caller_supplied_header_reaches_the_wire_untouched() -> None:
+    session = RecordingSession([200])
+
+    send(
+        create_config(),
+        session,
+        request_options={"headers": {"Request-Id": "CallerProvided"}},
+    )
+
+    assert session.observed_request_ids == ["CallerProvided"]
+
+
+def test_a_caller_supplied_query_parameter_sends_no_header() -> None:
+    session = RecordingSession([200])
+
+    send(
+        create_config(),
+        session,
+        request_options={
+            "query_parameters": {"x-algolia-request-id": "CallerProvided"}
+        },
+    )
+
+    assert session.observed_request_ids == [None]
+    assert session.observed_urls[0].endswith(
+        "/test?x-algolia-request-id=CallerProvided"
+    )
 
 
 def test_get_correlation_id_is_case_insensitive() -> None:

--- a/tests/output/python/tests/manual/test_request_id.py
+++ b/tests/output/python/tests/manual/test_request_id.py
@@ -1,0 +1,213 @@
+from re import compile
+from typing import Any, Dict, List, Optional
+
+from requests import PreparedRequest, Response, Session
+from requests.structures import CaseInsensitiveDict
+
+from algoliasearch.http.base_config import BaseConfig
+from algoliasearch.http.exceptions import (
+    AlgoliaUnreachableHostException,
+    RequestException,
+)
+from algoliasearch.http.hosts import CallType, Host, HostsCollection
+from algoliasearch.http.request_id import (
+    REQUEST_ID_HEADER,
+    generate_request_id,
+    get_correlation_id,
+    with_request_id,
+)
+from algoliasearch.http.request_options import RequestOptions
+from algoliasearch.http.transporter_sync import TransporterSync
+from algoliasearch.http.verb import Verb
+
+REQUEST_ID_FORMAT = compile(r"^[0-9A-Za-z]{11}$")
+
+
+def create_config(request_id_enabled: bool = True, hosts: int = 1) -> BaseConfig:
+    config = BaseConfig("test-app", "test-key")
+    config.request_id_enabled = request_id_enabled
+    config.hosts = HostsCollection(
+        [
+            Host("localhost{}".format(index), accept=CallType.READ | CallType.WRITE)
+            for index in range(hosts)
+        ]
+    )
+    return config
+
+
+class FakeResponse(Response):
+    def __init__(
+        self, status_code: int, headers: Optional[Dict[str, str]] = None
+    ) -> None:
+        super().__init__()
+        self.status_code = status_code
+        self.headers = CaseInsensitiveDict(headers or {})
+        self.reason = "OK"
+
+    @property
+    def text(self) -> str:
+        if self.status_code >= 400:
+            return '{"message":"request-id error test"}'
+        return '{"status":"ok"}'
+
+
+class RecordingSession(Session):
+    def __init__(
+        self, statuses: List[int], headers: Optional[Dict[str, str]] = None
+    ) -> None:
+        super().__init__()
+        self._statuses = list(statuses)
+        self._headers = headers
+        self.observed_request_ids: List[Optional[str]] = []
+
+    def send(self, request: PreparedRequest, **kwargs: Any) -> Response:  # type: ignore # the tests only need the recorded request
+        _ = kwargs
+        self.observed_request_ids.append(request.headers.get("request-id"))
+        return FakeResponse(self._statuses.pop(0), self._headers)
+
+
+def send(
+    config: BaseConfig, session: RecordingSession, verb: Verb = Verb.GET
+) -> Response:
+    transporter = TransporterSync(config)
+    transporter._session = session
+    return transporter.request(
+        verb=verb,
+        path="/test",
+        request_options=RequestOptions(config).merge(),
+        use_read_transporter=True,
+    )
+
+
+def test_generated_ids_are_base62_and_never_repeat() -> None:
+    ids = [generate_request_id() for _ in range(100)]
+
+    for request_id in ids:
+        assert REQUEST_ID_FORMAT.match(request_id) is not None
+    assert len(set(ids)) == len(ids)
+
+
+def test_mints_a_request_id_header_for_a_supported_client() -> None:
+    options = with_request_id(None, create_config())
+
+    assert options is not None
+    assert REQUEST_ID_FORMAT.match(options["headers"][REQUEST_ID_HEADER]) is not None
+
+
+def test_mints_nothing_for_an_unsupported_client() -> None:
+    assert with_request_id(None, create_config(request_id_enabled=False)) is None
+
+
+def test_a_caller_supplied_header_wins_whatever_its_casing() -> None:
+    options = with_request_id(
+        {"headers": {"Request-Id": "CallerProvided"}}, create_config()
+    )
+
+    assert options == {"headers": {"Request-Id": "CallerProvided"}}
+
+
+def test_a_caller_supplied_query_parameter_suppresses_the_header() -> None:
+    options = with_request_id(
+        {"query_parameters": {"X-Algolia-Request-Id": "CallerProvided"}},
+        create_config(),
+    )
+
+    assert options == {"query_parameters": {"X-Algolia-Request-Id": "CallerProvided"}}
+
+
+def test_a_client_level_header_wins() -> None:
+    config = create_config()
+    config.headers["REQUEST-ID"] = "ClientProvided"
+
+    assert with_request_id(None, config) is None
+
+
+def test_the_caller_options_are_never_modified() -> None:
+    config = create_config()
+
+    given_dict: Dict[str, Any] = {"headers": {"x-custom": "value"}}
+    minted_dict = with_request_id(given_dict, config)
+
+    assert given_dict == {"headers": {"x-custom": "value"}}
+    assert minted_dict is not given_dict
+    assert REQUEST_ID_HEADER in minted_dict["headers"]
+
+    given_options = RequestOptions(config, headers={"x-custom": "value"})
+    minted_options = with_request_id(given_options, config)
+
+    assert given_options.headers == {"x-custom": "value"}
+    assert minted_options is not given_options
+    assert REQUEST_ID_HEADER in minted_options.headers
+    assert config.headers.get(REQUEST_ID_HEADER) is None
+
+
+def test_one_request_id_covers_every_retry_of_one_call() -> None:
+    session = RecordingSession([500, 500, 200])
+
+    response = send(create_config(hosts=3), session)
+
+    assert response.status_code == 200
+    assert len(session.observed_request_ids) == 3
+    assert REQUEST_ID_FORMAT.match(session.observed_request_ids[0] or "") is not None
+    assert len(set(session.observed_request_ids)) == 1
+
+
+def test_each_call_mints_a_fresh_request_id() -> None:
+    config = create_config()
+    session = RecordingSession([200, 200])
+
+    send(config, session)
+    send(config, session)
+
+    assert len(set(session.observed_request_ids)) == 2
+
+
+def test_an_unsupported_client_sends_no_request_id() -> None:
+    session = RecordingSession([200])
+
+    send(create_config(request_id_enabled=False), session)
+
+    assert session.observed_request_ids == [None]
+
+
+def test_get_correlation_id_is_case_insensitive() -> None:
+    assert get_correlation_id({"CoRrElAtIoN-iD": "abc"}) == "abc"
+    assert get_correlation_id({"x-other": "abc"}) is None
+    assert get_correlation_id(None) is None
+
+
+def test_a_failed_request_exposes_the_correlation_id() -> None:
+    session = RecordingSession([400], {"Correlation-ID": "CorrelationId1"})
+
+    try:
+        send(create_config(), session)
+        raise AssertionError("expected a RequestException")
+    except RequestException as exception:
+        assert (
+            str(exception) == "request-id error test (Correlation-ID: CorrelationId1)"
+        )
+        assert exception.message == str(exception)
+        assert exception.correlation_id == "CorrelationId1"
+        assert exception.status_code == 400
+
+
+def test_a_failed_request_without_the_header_reads_as_before() -> None:
+    session = RecordingSession([400])
+
+    try:
+        send(create_config(), session)
+        raise AssertionError("expected a RequestException")
+    except RequestException as exception:
+        assert str(exception) == "request-id error test"
+        assert exception.correlation_id is None
+
+
+def test_unreachable_hosts_carry_the_last_seen_correlation_id() -> None:
+    session = RecordingSession([500, 500], {"Correlation-ID": "CorrelationId2"})
+
+    try:
+        send(create_config(hosts=2), session)
+        raise AssertionError("expected an AlgoliaUnreachableHostException")
+    except AlgoliaUnreachableHostException as exception:
+        assert exception.correlation_id == "CorrelationId2"
+        assert str(exception).endswith(" (Correlation-ID: CorrelationId2)")


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-519](https://algolia.atlassian.net/browse/API-519)

Mirrors #6747 for the python client: the search, recommend and composition clients now send a `Request-ID` header with every request, and failed responses surface the `Correlation-ID` the search clusters return. Both are tracing aids — the Request-ID ties every retry and every request of one logical operation together in Algolia's logs, the Correlation-ID is what you quote in a support ticket. Tracing only: a retried write is still applied twice.

### How it works

- New `algoliasearch/http/request_id.py`: an 11-character base62 generator, case-insensitive detection of a caller-supplied id on either channel, and `with_request_id`, which copies rather than mutates the options it is given, so a reused options object still gets a fresh id per call.
- Minting happens in `Transporter.request` / `request_stream` and their sync twins, before the host loop, so retry and host-fallback stability come for free. `EchoTransporter` is untouched. Python is server-side only, so the id travels as a header; the query channel is read but never written, because the generated requests tests assert query parameters by exact equality.
- Multi-request helpers (`wait_for_task`, `wait_for_api_key`, `browse_objects`, `chunked_batch`, `replace_all_objects`, …) call `with_request_id` once so their underlying requests share one id — which also fixed nested calls that were silently dropping `request_options`. `replace_all_objects_with_transformation` hands `chunked_push` the caller's original options: the ingestion API must never receive a search Request-ID.
- `RequestException` and `AlgoliaUnreachableHostException` gained an optional `correlation_id` and append ` (Correlation-ID: …)` to the message only when the header is present.
- Only search, recommend and composition opt in, via `BaseConfig.request_id_enabled` flipped by `config.mustache` under `{{#requestIdSupport}}`. `index_exists` gained a trailing optional `request_options`.

## 🧪 Test

- Opted python into the shared `requestId` CTS client suites, the `searchRules` query-parameter request test, and both `getComposition` Correlation-ID e2es via a new `{{#correlationIdSuffix}}` section in the python e2e template. The ingestion negative suite already ran and still reports no Request-ID.
- New `tests/output/python/tests/manual/test_request_id.py` — 16 tests over a fake session: id format, one id across three retry attempts, a fresh id per call, both caller channels asserted on the wire, minting off for unsupported clients, and `correlation_id` on both exceptions.


[API-519]: https://algolia.atlassian.net/browse/API-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
