### PR TITLE
chore(ci): enable yarn hardened mode and immutable installs (API-476)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,7 @@ runs:
 
     - name: Install JavaScript dependencies
       shell: bash
-      run: YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn install
+      run: YARN_ENABLE_HARDENED_MODE=1 yarn install
 
     # Csharp
     - name: Install dotnet
@@ -107,7 +107,7 @@ runs:
     - name: Install JavaScript client dependencies
       if: ${{ inputs.language == 'javascript' }}
       shell: bash
-      run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn install
+      run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=1 yarn install
 
     # PHP
     - name: Install PHP

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,7 @@ runs:
 
     - name: Install JavaScript dependencies
       shell: bash
-      run: YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+      run: YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn install
 
     # Csharp
     - name: Install dotnet
@@ -107,7 +107,7 @@ runs:
     - name: Install JavaScript client dependencies
       if: ${{ inputs.language == 'javascript' }}
       shell: bash
-      run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+      run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn install
 
     # PHP
     - name: Install PHP

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -220,7 +220,7 @@ jobs:
         run: yarn cli generate javascript
 
       - name: Update `yarn.lock` for JavaScript
-        run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=0 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+        run: cd clients/algoliasearch-client-javascript && YARN_ENABLE_HARDENED_MODE=1 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
       - name: Build clients
         run: cd clients/algoliasearch-client-javascript && yarn build

--- a/clients/algoliasearch-client-javascript/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-javascript/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install JavaScript dependencies
         shell: bash
-        run: yarn install
+        run: YARN_ENABLE_HARDENED_MODE=1 yarn install
 
       - name: Build clients
         shell: bash

--- a/scripts/buildLanguages.ts
+++ b/scripts/buildLanguages.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 
-import { CI, createClientName, run, toAbsolutePath } from './common.ts';
+import { YARN_HARDENED_MODE_PREFIX, createClientName, run, toAbsolutePath } from './common.ts';
 import { getLanguageFolder, getSwiftBuildFolder } from './config.ts';
 import { formatter } from './formatter.ts';
 import { updatePlaygroundLanguageVersion } from './playground.ts';
@@ -54,7 +54,7 @@ async function buildLanguage(
       await run('go build -o /dev/null ./...', { cwd, language });
       break;
     case 'javascript':
-      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
+      await run(`${YARN_HARDENED_MODE_PREFIX}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
         cwd,
         language,
       });

--- a/scripts/buildLanguages.ts
+++ b/scripts/buildLanguages.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 
-import { createClientName, run, toAbsolutePath } from './common.ts';
+import { CI, createClientName, run, toAbsolutePath } from './common.ts';
 import { getLanguageFolder, getSwiftBuildFolder } from './config.ts';
 import { formatter } from './formatter.ts';
 import { updatePlaygroundLanguageVersion } from './playground.ts';
@@ -54,7 +54,10 @@ async function buildLanguage(
       await run('go build -o /dev/null ./...', { cwd, language });
       break;
     case 'javascript':
-      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', { cwd, language });
+      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
+        cwd,
+        language,
+      });
       if (buildType === 'client') {
         await run(`yarn build`, { cwd, language });
         break;

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -26,6 +26,9 @@ export const TODAY = new Date().toISOString().split('T')[0];
 
 export const CI = Boolean(process.env.CI);
 
+// command prefix for yarn installs, `run` has no env option so it must be part of the command string (API-476)
+export const YARN_HARDENED_MODE_PREFIX = CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : '';
+
 // This script is run by `yarn workspace ...`, which means the current working directory is `./script`
 export const ROOT_DIR = path.resolve(process.cwd(), '..');
 

--- a/scripts/cts/generate.ts
+++ b/scripts/cts/generate.ts
@@ -1,4 +1,4 @@
-import { callGenerator, isWSL, run, setupAndGen } from '../common.ts';
+import { CI, callGenerator, isWSL, run, setupAndGen } from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
@@ -28,7 +28,7 @@ export async function ctsGenerateMany(
     }
 
     if (lang === 'javascript') {
-      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', {
+      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
         cwd: 'tests/output/javascript',
       });
     }

--- a/scripts/cts/generate.ts
+++ b/scripts/cts/generate.ts
@@ -1,4 +1,4 @@
-import { CI, callGenerator, isWSL, run, setupAndGen } from '../common.ts';
+import { YARN_HARDENED_MODE_PREFIX, callGenerator, isWSL, run, setupAndGen } from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
@@ -28,7 +28,7 @@ export async function ctsGenerateMany(
     }
 
     if (lang === 'javascript') {
-      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
+      await run(`${YARN_HARDENED_MODE_PREFIX}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
         cwd: 'tests/output/javascript',
       });
     }

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -1,6 +1,6 @@
 import fsp from 'fs/promises';
 
-import { exists, isVerbose, run, runComposerInstall, toAbsolutePath } from '../common.ts';
+import { CI, exists, isVerbose, run, runComposerInstall, toAbsolutePath } from '../common.ts';
 import { getSwiftBuildFolder, getTestOutputFolder } from '../config.ts';
 import { createSpinner } from '../spinners.ts';
 import type { Language } from '../types.ts';
@@ -88,10 +88,13 @@ async function runCtsOne(language: Language, suites: Record<CTSType, boolean>): 
       break;
     }
     case 'javascript':
-      await run(`YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn test ${filter((f) => `src/${f}`)}`, {
-        cwd,
-        language,
-      });
+      await run(
+        `${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn test ${filter((f) => `src/${f}`)}`,
+        {
+          cwd,
+          language,
+        },
+      );
       break;
     case 'kotlin':
       await run(`./gradle/gradlew -p tests/output/kotlin jvmTest ${filter((f) => `--tests 'com.algolia.${f}*'`)}`, {

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -1,6 +1,6 @@
 import fsp from 'fs/promises';
 
-import { CI, exists, isVerbose, run, runComposerInstall, toAbsolutePath } from '../common.ts';
+import { exists, isVerbose, run, runComposerInstall, toAbsolutePath, YARN_HARDENED_MODE_PREFIX } from '../common.ts';
 import { getSwiftBuildFolder, getTestOutputFolder } from '../config.ts';
 import { createSpinner } from '../spinners.ts';
 import type { Language } from '../types.ts';
@@ -89,7 +89,7 @@ async function runCtsOne(language: Language, suites: Record<CTSType, boolean>): 
     }
     case 'javascript':
       await run(
-        `${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn test ${filter((f) => `src/${f}`)}`,
+        `${YARN_HARDENED_MODE_PREFIX}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install && yarn test ${filter((f) => `src/${f}`)}`,
         {
           cwd,
           language,

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1,4 +1,12 @@
-import { CI, callGenerator, exists, isWSL, run, setupAndGen, toAbsolutePath } from '../common.ts';
+import {
+  YARN_HARDENED_MODE_PREFIX,
+  callGenerator,
+  exists,
+  isWSL,
+  run,
+  setupAndGen,
+  toAbsolutePath,
+} from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
@@ -29,7 +37,7 @@ export async function docsGenerateMany(
     const docsPath = `docs/${scope}/${lang}`;
 
     if (lang === 'javascript') {
-      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
+      await run(`${YARN_HARDENED_MODE_PREFIX}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
         cwd: docsPath,
       });
     }

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1,4 +1,4 @@
-import { callGenerator, exists, isWSL, run, setupAndGen, toAbsolutePath } from '../common.ts';
+import { CI, callGenerator, exists, isWSL, run, setupAndGen, toAbsolutePath } from '../common.ts';
 import { getTestOutputFolder } from '../config.ts';
 import { formatter } from '../formatter.ts';
 import type { Generator } from '../types.ts';
@@ -29,7 +29,7 @@ export async function docsGenerateMany(
     const docsPath = `docs/${scope}/${lang}`;
 
     if (lang === 'javascript') {
-      await run('YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install', {
+      await run(`${CI ? 'YARN_ENABLE_HARDENED_MODE=1 ' : ''}YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`, {
         cwd: docsPath,
       });
     }

--- a/scripts/website/build.sh
+++ b/scripts/website/build.sh
@@ -6,5 +6,8 @@ touch website/yarn.lock
 # Generate the file with constants
 cat config/clients.config.json | jq -r 'del(."$schema") | "export const versions = \(map_values(.packageVersion))"' > website/src/generated/variables.js
 
-# install website deps and build
+# install website deps and build, with yarn supply-chain checks on CI
+if [ -n "$CI" ]; then
+  export YARN_ENABLE_HARDENED_MODE=1
+fi
 cd website && yarn install && yarn build

--- a/scripts/website/build.sh
+++ b/scripts/website/build.sh
@@ -7,7 +7,4 @@ touch website/yarn.lock
 cat config/clients.config.json | jq -r 'del(."$schema") | "export const versions = \(map_values(.packageVersion))"' > website/src/generated/variables.js
 
 # install website deps and build, with yarn supply-chain checks on CI
-if [ -n "$CI" ]; then
-  export YARN_ENABLE_HARDENED_MODE=1
-fi
-cd website && yarn install && yarn build
+cd website && env ${CI:+YARN_ENABLE_HARDENED_MODE=1} yarn install && yarn build


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-476](https://algolia.atlassian.net/browse/API-476)

### Changes included:

- Turn on yarn hardened mode and remove the explicit immutable install opt-outs on the two CI installs in the setup action (`.github/actions/setup/action.yml:49` and `:110`). Immutable installs are already yarn's default when CI is set, the old lines were opting out of it.
- The post codegen step that updates `yarn.lock` keeps immutable installs off since it intentionally rewrites the lockfile, but now runs with hardened mode (`.github/workflows/check.yml:223`).

- Also enable hardened mode on the post codegen install spawned by `yarn cli build` (`scripts/buildLanguages.ts:57`), CI only so local builds keep their speed.

- Same treatment for the remaining CI install sites found on a full sweep: CTS runs and generation (`scripts/cts/runCts.ts:92`, `scripts/cts/generate.ts:31`), docs generation (`scripts/docs/generate.ts:32`) and the website build (`scripts/website/build.sh:11`), all gated on CI so local runs are unchanged. The TS sites share a `YARN_HARDENED_MODE_PREFIX` constant from `scripts/common.ts`.
- Behavior note: with the root install strictly immutable, a PR that leaves a lockfile desynced now fails at the Setup step across the job matrix instead of being silently auto-repaired. That is the intent of the change, but the first dependency bump after merge will surface it as multiple red jobs.


- Hardened mode also on the standalone JS client release workflow install (`clients/algoliasearch-client-javascript/.github/workflows/release.yml:30`). It runs on push where yarn's default leaves hardened mode off, and it feeds the npm publish.

## 🧪 Test

- Ran both installs locally with the new flags against the committed lockfiles: repo root done in 45s, JS client in 32s, both exit code 0.
- actionlint is clean on the changed lines (remaining warnings are pre-existing shellcheck findings on untouched lines).

[API-476]: https://algolia.atlassian.net/browse/API-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





