### PR TITLE
feat(specs): add complete endpoint to abtesting-v3

### DIFF
--- a/clients/algoliasearch-client-javascript/package.json
+++ b/clients/algoliasearch-client-javascript/package.json
@@ -27,7 +27,7 @@
     "files": [
       {
         "path": "packages/algoliasearch/dist/algoliasearch.umd.js",
-        "maxSize": "21.25KB"
+        "maxSize": "21.5KB"
       },
       {
         "path": "packages/algoliasearch/dist/lite/builds/browser.umd.js",

--- a/specs/abtesting-v3/paths/completeABTest.yml
+++ b/specs/abtesting-v3/paths/completeABTest.yml
@@ -1,0 +1,47 @@
+post:
+  tags:
+    - abtest
+  operationId: completeABTest
+  x-acl:
+    - analytics
+    - editSettings
+  summary: Complete an A/B test
+  description: |
+    Completes a running A/B test by its ID.
+
+    The A/B test's status becomes `expired` and its end date is set to the completion time,
+    mirroring what happens when an A/B test reaches its planned end date.
+    The variant allocation is removed from the search engine, like when stopping an A/B test.
+    Unlike stopped A/B tests, completed A/B tests are presented as finished rather than interrupted.
+
+    Only running A/B tests can be completed. Completing an A/B test that isn't running returns `409`.
+
+    You can't restart completed A/B tests.
+  parameters:
+    - $ref: '../common/parameters.yml#/ID'
+  responses:
+    '200':
+      description: OK
+      headers:
+        x-ratelimit-limit:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-limit'
+        x-ratelimit-remaining:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-remaining'
+        x-ratelimit-reset:
+          $ref: '../../common/responses/rateLimit.yml#/x-ratelimit-reset'
+      content:
+        application/json:
+          schema:
+            $ref: '../common/schemas/ABTestResponse.yml#/ABTestResponse'
+    '400':
+      $ref: '../../common/responses/BadRequest.yml'
+    '402':
+      $ref: '../../common/responses/FeatureNotEnabled.yml'
+    '403':
+      $ref: '../../common/responses/MethodNotAllowed.yml'
+    '404':
+      $ref: '../../common/responses/IndexNotFound.yml'
+    '409':
+      $ref: '../../common/responses/Conflict.yml'
+    '422':
+      $ref: '../../common/responses/UnprocessableEntity.yml'

--- a/specs/abtesting-v3/spec.yml
+++ b/specs/abtesting-v3/spec.yml
@@ -95,6 +95,8 @@ paths:
     $ref: 'paths/abtest.yml'
   /3/abtests/{id}/stop:
     $ref: 'paths/stopABTest.yml'
+  /3/abtests/{id}/complete:
+    $ref: 'paths/completeABTest.yml'
   /3/abtests/estimate:
     $ref: 'paths/estimate.yml'
   /3/abtests/{id}/timeseries:

--- a/tests/CTS/requests/abtesting-v3/completeABTest.json
+++ b/tests/CTS/requests/abtesting-v3/completeABTest.json
@@ -1,0 +1,12 @@
+[
+  {
+    "testName": "completeABTest",
+    "parameters": {
+      "id": 42
+    },
+    "request": {
+      "path": "/3/abtests/42/complete",
+      "method": "POST"
+    }
+  }
+]


### PR DESCRIPTION
## Status

Closed because the backend `/complete` endpoint was never merged. The current lifecycle flow reuses `/stop`.

## Historical proposal

- Proposed `POST /3/abtests/{id}/complete` for the A/B Testing v3 API.
- Proposed marking a completed test as expired, setting its end time, and removing its variant allocation from the engine.
- Would have returned the task response with `abTestID`, `index`, and `taskID`.
- Included a CTS request case for the proposed operation.
- Raised the JavaScript browser bundle budget from 21.25 KB to 21.5 KB for the proposed generated client change.

🎟 JIRA Ticket: [OPTIM-2803](https://algolia.atlassian.net/browse/OPTIM-2803)

## 🧪 Historical validation

- Added CTS request coverage for `completeABTest({ id: 42 })`, asserting `POST /3/abtests/42/complete`.
- `yarn specs:lint specs/abtesting-v3/`
- `yarn cli build specs abtesting-v3`


[OPTIM-2803]: https://algolia.atlassian.net/browse/OPTIM-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ