### PR TITLE
fix(cts): make agent-studio conversation e2e data-independent

### DIFF
--- a/tests/CTS/requests/agent-studio/getConversation.json
+++ b/tests/CTS/requests/agent-studio/getConversation.json
@@ -9,24 +9,5 @@
       "path": "/1/agents/76710f1b-8231-42e5-b0d1-f43aac618e15/conversations/test-conversation-id",
       "method": "GET"
     }
-  },
-  {
-    "testName": "e2e get conversation",
-    "parameters": {
-      "conversationId": "alg_cnv_miss_yqcZtaOSPTF8bJsJ",
-      "agentId": "76710f1b-8231-42e5-b0d1-f43aac618e15"
-    },
-    "request": {
-      "path": "/1/agents/76710f1b-8231-42e5-b0d1-f43aac618e15/conversations/alg_cnv_miss_yqcZtaOSPTF8bJsJ",
-      "method": "GET"
-    },
-    "response": {
-      "statusCode": 200,
-      "body": {
-        "id": "alg_cnv_miss_yqcZtaOSPTF8bJsJ",
-        "agentId": "76710f1b-8231-42e5-b0d1-f43aac618e15",
-        "title": "General Greeting"
-      }
-    }
   }
 ]

--- a/tests/CTS/requests/agent-studio/listAgentConversations.json
+++ b/tests/CTS/requests/agent-studio/listAgentConversations.json
@@ -56,16 +56,7 @@
       "method": "GET"
     },
     "response": {
-      "statusCode": 200,
-      "body": {
-        "data": [
-          {
-            "id": "alg_cnv_miss_yqcZtaOSPTF8bJsJ",
-            "agentId": "76710f1b-8231-42e5-b0d1-f43aac618e15",
-            "title": "General Greeting"
-          }
-        ]
-      }
+      "statusCode": 200
     }
   }
 ]


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-550](https://algolia.atlassian.net/browse/API-550)

Two agent-studio e2e tests pinned a specific conversation in the CTS e2e app (`alg_cnv_miss_yqcZtaOSPTF8bJsJ`), added with Agent Studio v1 in #6097. Conversations are retention-bound: the agent was seeded `2026-05-21T18:16:00Z`, `maxRetentionDays` is 90, and the row was purged on 2026-08-19, failing e2e in all 25 client jobs and blocking `check_green` on every open PR. Agents themselves are config and survive, which is why only these two tests broke.

Re-pinning a fresh id is not a fix. `ApplicationConfigPatch.maxRetentionDays` accepts only `[0, 30, 60, 90]`, so any pinned conversation is at most a 90-day fuse, and there is no create-conversation endpoint — seeding one means an LLM completion per language per CI run.

### Changes included:

- `listAgentConversations`: drop the body from the `e2e list agent conversations` expectation, keeping `statusCode: 200`. The e2e templates gate the comparison on `{{#response}}{{#body}}`, so the test still issues the live default call and still fails on a non-2xx, but no longer asserts that a conversation exists or that `data[0]` is one specific row. This is the same shape `e2e export conversations` already uses.
- `getConversation`: drop the `e2e get conversation` entry. A 404 cannot be expressed here — the e2e templates emit an unconditional no-error assertion — and without a live conversation there is nothing to fetch. The request half is unchanged: the remaining `getConversation` entry already asserts the identical path, method and nil body, so the echo coverage this entry produced was a duplicate.

Envelope coverage stays live: `listAgentConversations with all parameters` also carries a `response`, so it runs against the real API and asserts `pagination` plus an empty `data` for `page=2&limit=10`. It has asserted absence since day one, which is why retention never touched it.

## 🧪 Test

Verified against the live CTS e2e app: the pinned conversation returns 404, both agents return `data: []` with `totalCount: 0`, and `/1/configuration` reports `maxRetentionDays: 90`.

Follow-up on the coverage this gives up is tracked in API-550, under the chained-e2e epic API-430.


[API-550]: https://algolia.atlassian.net/browse/API-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ