### PR TITLE
chore(ci): hardening nits from the API-479 review

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,7 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.number }}
     # no GITHUB_TOKEN permissions: the sticky comment is posted with the app token
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
+      # no checkout: no step in this job reads the workspace
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -53,11 +52,6 @@ jobs:
     env:
       CACHE_VERSION: 1.13 # bump this to run all clients on the CI.
     steps:
-      - name: debugging - dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -101,6 +95,9 @@ jobs:
 
       - name: Lint GitHub actions
         run: yarn github-actions:lint
+
+      - name: Check that the issue sync workflow matches its template
+        run: diff .github/workflows/issue.yml templates/issue.yml
 
       - name: Lint generators
         run: |
@@ -659,7 +656,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: 'Deploy from GitHub Actions'
           enable-pull-request-comment: true
-          enable-commit-comment: true
+          # commit comments need contents: write which this job does not have, the flag never produced a comment
+          enable-commit-comment: false
           overwrites-pull-request-comment: true
           netlify-config-path: ./netlify.toml
         env:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,4 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - run: git push -d origin "generated/${{ github.head_ref }}" || true
+      - run: git push -d origin "generated/$HEAD_REF" || true
+        env:
+          # env indirection so the branch name is never interpolated into the shell script
+          HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Create ticket
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # env indirection so the secret is never materialized into the composed script
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         with:
           script: |
             const action = context.payload.action;
@@ -26,7 +29,7 @@ jobs:
               headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'Authorization': `Basic ${{ secrets.JIRA_TOKEN }}`
+                'Authorization': `Basic ${process.env.JIRA_TOKEN}`
               },
               body: JSON.stringify({
                 fields: {

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,13 +10,8 @@ jobs:
   setup:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
+      # no checkout: the action reads the title from the event payload
       - name: Pull Request title rules
         uses: Slashgear/action-check-pr-title@161cede0311ec624ae3ee76a2c27522f7b6fa2d8 # v5.0.1
         with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,5 +13,9 @@ specs/composition @algolia/composition
 tests/CTS/**/composition @algolia/composition @algolia/api-clients-automation
 
 # keep these rules last: CODEOWNERS is last-match-wins, so a broader rule added above cannot silently take over the CI surface
+# these assign the same team as the catch-all above, they only guard the CI surface without changing any approver
 /.github/workflows/ @algolia/api-clients-automation
 /.github/actions/ @algolia/api-clients-automation
+/scripts/ci/ @algolia/api-clients-automation
+/scripts/release/ @algolia/api-clients-automation
+/templates/**/*.yml @algolia/api-clients-automation

--- a/scripts/ci/githubActions/utils.ts
+++ b/scripts/ci/githubActions/utils.ts
@@ -46,6 +46,7 @@ export const DEPENDENCIES = {
         `templates/${lang}`,
         'templates/Bug_report.yml',
         'templates/issue.yml',
+        'templates/do-not-edit-this-repository.yml',
         'templates/LICENSE',
         // language related files
         langFolder,

--- a/templates/issue.yml
+++ b/templates/issue.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Create ticket
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # env indirection so the secret is never materialized into the composed script
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         with:
           script: |
             const action = context.payload.action;
@@ -26,7 +29,7 @@ jobs:
               headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'Authorization': `Basic ${{ secrets.JIRA_TOKEN }}`
+                'Authorization': `Basic ${process.env.JIRA_TOKEN}`
               },
               body: JSON.stringify({
                 fields: {


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-479](https://algolia.atlassian.net/browse/API-479)

Follow up to #6918, split out so the permissions PR stays on the ticket scope. Based on that branch, GitHub will retarget to main when it merges.

### Changes included:

- Env indirect the Jira token in the issue sync script, in both the root workflow and `templates/issue.yml` (all `templates/*/issue.yml` are symlinks to it), plus a `diff` step in setup so the two copies cannot drift. The permission drop itself moved to #6918 so main never carries a divergence between the two copies.
- Remove the vestigial checkouts from the pr-title job (the action only reads the event payload, and the full history clone goes with it) and from the notification job (no step there reads the workspace); both jobs now run with no permissions at all.
- Shell hardening: env indirection for the branch name in `cleanup.yml`, the netlify `enable-commit-comment` flag turned off since commit comments need `contents: write` and none was ever posted (checked recent main commits), and the setup job's debugging step that dumped the full GitHub context on every run is removed.
- Add `templates/do-not-edit-this-repository.yml` to the per language regeneration dependencies so the deferred `pull_request_target` fix will trigger client regeneration when it lands.
- Broaden the CODEOWNERS CI guard to `/scripts/ci/`, `/scripts/release/` and `/templates/**/*.yml`. Same team as the catch-all, so no approver changes anywhere.

## 🧪 Test

- actionlint and `yarn github-actions:lint` are clean on the changed workflows.
- The template drift `diff` passes (root workflow and template are byte identical).
- `DEPENDENCIES` change verified by loading the module and checking the new entry is present.

[API-479]: https://algolia.atlassian.net/browse/API-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

