### PR TITLE
chore(php): cover the guzzle transport in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -427,6 +427,13 @@ jobs:
           name: clients-${{matrix.client.language }}
           path: clients-${{matrix.client.language }}.zip
 
+      # Kept last: downgrading rewrites composer.lock, which the artifact above must not carry.
+      - name: Run PHP CTS on Guzzle 7
+        if: ${{ matrix.client.language == 'php' && matrix.client.isMainVersion }}
+        run: |
+          composer update "guzzlehttp/guzzle:^7.0" --with-all-dependencies --working-dir=${{ matrix.client.path }}
+          yarn cli cts run php --no-requests --no-e2e -v
+
   kotlin_build_macos:
     timeout-minutes: 15
     runs-on: macos-14

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -431,7 +431,9 @@ jobs:
         if: ${{ matrix.client.language == 'php' && matrix.client.isMainVersion }}
         run: |
           composer update "guzzlehttp/guzzle:^7.0" --with-all-dependencies --working-dir=${{ matrix.client.path }}
-          yarn cli cts run php --no-requests --no-e2e -v
+          yarn cli cts run php --no-e2e -v
+          git checkout -- ${{ matrix.client.path }}/composer.lock
+          composer install --working-dir=${{ matrix.client.path }}
 
   kotlin_build_macos:
     timeout-minutes: 15

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -427,7 +427,6 @@ jobs:
           name: clients-${{matrix.client.language }}
           path: clients-${{matrix.client.language }}.zip
 
-      # Kept last: downgrading rewrites composer.lock, which the artifact above must not carry.
       - name: Run PHP CTS on Guzzle 7
         if: ${{ matrix.client.language == 'php' && matrix.client.isMainVersion }}
         run: |

--- a/clients/algoliasearch-client-php/composer.json
+++ b/clients/algoliasearch-client-php/composer.json
@@ -35,11 +35,6 @@
             "lib/Http/Psr7/functions.php"
         ]
     },
-    "autoload-dev": {
-        "files": [
-            "tests/bootstrap.php"
-        ]
-    },
     "suggest": {
         "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
     },

--- a/clients/algoliasearch-client-php/composer.json
+++ b/clients/algoliasearch-client-php/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91.3",
+        "guzzlehttp/guzzle": "^8.0",
         "phpunit/phpunit": "^10.0",
         "vlucas/phpdotenv": "^5.4",
         "phpstan/phpstan": "^1.12"
@@ -32,6 +33,11 @@
         "psr-4": { "Algolia\\AlgoliaSearch\\" : "lib/" },
         "files": [
             "lib/Http/Psr7/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "files": [
+            "tests/bootstrap.php"
         ]
     },
     "suggest": {

--- a/clients/algoliasearch-client-php/composer.json
+++ b/clients/algoliasearch-client-php/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91.3",
-        "guzzlehttp/guzzle": "^8.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "phpunit/phpunit": "^10.0",
         "vlucas/phpdotenv": "^5.4",
         "phpstan/phpstan": "^1.12"

--- a/clients/algoliasearch-client-php/composer.lock
+++ b/clients/algoliasearch-client-php/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28a024346052761f7dbd6dc7d266a2af",
+    "content-hash": "d57ba97500e06271ed647a3a0e136c7f",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c"
+                "reference": "a3059ba1a84c9139c4ae03cf0f45bea276c97c74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
-                "reference": "b094ded77ee97a6027ad6cf0e8c7b9f88381814c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a3059ba1a84c9139c4ae03cf0f45bea276c97c74",
+                "reference": "a3059ba1a84c9139c4ae03cf0f45bea276c97c74",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/3.0.0"
+                "source": "https://github.com/guzzle/psr7/tree/3.1.0"
             },
             "funding": [
                 {
@@ -123,7 +123,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-20T13:48:31+00:00"
+            "time": "2026-08-24T11:02:13+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1060,6 +1060,215 @@
             "time": "2024-07-20T21:45:45+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "2cdae51a4a02c3fe2c38d42e25a7bb952e27b768"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/2cdae51a4a02c3fe2c38d42e25a7bb952e27b768",
+                "reference": "2cdae51a4a02c3fe2c38d42e25a7bb952e27b768",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^3.0.2",
+                "guzzlehttp/psr7": "^3.1",
+                "php": "^7.4 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "symfony/polyfill-php80": "^1.25",
+                "symfony/polyfill-php82": "^1.27"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-curl": "*",
+                "guzzle/client-integration-tests": "4.0.1",
+                "guzzlehttp/test-server": "^1.0",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-24T11:07:02+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "42118e66a53c492effaf92bc357e931985d5c6f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/42118e66a53c492effaf92bc357e931985d5c6f9",
+                "reference": "42118e66a53c492effaf92bc357e931985d5c6f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^9.6.34"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-24T10:00:26+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.4",
             "source": {
@@ -1955,6 +2164,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "react/cache",

--- a/clients/algoliasearch-client-php/composer.lock
+++ b/clients/algoliasearch-client-php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d57ba97500e06271ed647a3a0e136c7f",
+    "content-hash": "06ad238a5e4a15442f2ee189abbc9d2f",
     "packages": [
         {
             "name": "guzzlehttp/psr7",

--- a/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
+++ b/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
@@ -5,7 +5,9 @@ namespace Algolia\AlgoliaSearch\Http;
 use Algolia\AlgoliaSearch\Exceptions\TimeoutException;
 use Algolia\AlgoliaSearch\Http\Psr7\Response;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ConnectTimeoutException;
 use GuzzleHttp\Exception\HandlerClosedException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
 use GuzzleHttp\HandlerStack;
@@ -35,7 +37,7 @@ final class GuzzleHttpClient implements HttpClientInterface
                 'decode_content' => 'gzip',
             ]);
         } catch (HandlerClosedException|NetworkExceptionInterface|ResponseTimeoutException $e) {
-            throw new TimeoutException($e->getMessage(), 0, $e);
+            throw new TimeoutException(self::isTimeout($e) ? 'Connection timed out' : $e->getMessage(), 0, $e);
         } catch (RequestException $e) {
             $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
             if (null !== $response) {
@@ -46,6 +48,18 @@ final class GuzzleHttpClient implements HttpClientInterface
         }
 
         return $response;
+    }
+
+    private static function isTimeout(\Throwable $e): bool
+    {
+        if ($e instanceof ResponseTimeoutException
+            || $e instanceof ConnectTimeoutException
+            || $e instanceof NetworkTimeoutException) {
+            return true;
+        }
+
+        return method_exists($e, 'getHandlerContext')
+            && CURLE_OPERATION_TIMEDOUT === ($e->getHandlerContext()['errno'] ?? 0);
     }
 
     private static function buildClient(array $config = [])

--- a/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
+++ b/clients/algoliasearch-client-php/lib/Http/GuzzleHttpClient.php
@@ -32,6 +32,7 @@ final class GuzzleHttpClient implements HttpClientInterface
             $response = $this->client->send($request, [
                 'timeout' => $timeout,
                 'connect_timeout' => $connectTimeout,
+                'decode_content' => 'gzip',
             ]);
         } catch (HandlerClosedException|NetworkExceptionInterface|ResponseTimeoutException $e) {
             throw new TimeoutException($e->getMessage(), 0, $e);

--- a/clients/algoliasearch-client-php/phpunit.xml.dist
+++ b/clients/algoliasearch-client-php/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="CTS">
             <directory suffix="Test.php">../../tests/output/php/src/</directory>

--- a/clients/algoliasearch-client-php/tests/bootstrap.php
+++ b/clients/algoliasearch-client-php/tests/bootstrap.php
@@ -3,4 +3,6 @@
 use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\Http\CurlHttpClient;
 
+require_once __DIR__.'/../vendor/autoload.php';
+
 Algolia::setHttpClient(new CurlHttpClient());

--- a/clients/algoliasearch-client-php/tests/bootstrap.php
+++ b/clients/algoliasearch-client-php/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+use Algolia\AlgoliaSearch\Algolia;
+use Algolia\AlgoliaSearch\Http\CurlHttpClient;
+
+/*
+ * Pins the transport the test suite runs on, so installing guzzlehttp/guzzle to exercise
+ * GuzzleHttpClient does not silently switch every other test onto the Guzzle transport.
+ */
+Algolia::setHttpClient(new CurlHttpClient());

--- a/clients/algoliasearch-client-php/tests/bootstrap.php
+++ b/clients/algoliasearch-client-php/tests/bootstrap.php
@@ -3,8 +3,4 @@
 use Algolia\AlgoliaSearch\Algolia;
 use Algolia\AlgoliaSearch\Http\CurlHttpClient;
 
-/*
- * Pins the transport the test suite runs on, so installing guzzlehttp/guzzle to exercise
- * GuzzleHttpClient does not silently switch every other test onto the Guzzle transport.
- */
 Algolia::setHttpClient(new CurlHttpClient());

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -108,7 +108,7 @@ async function runCtsOne(language: Language, suites: Record<CTSType, boolean>): 
         ...(suites.client ? [`${cwd}/src/manual/`] : []),
       ].join(' ');
       await run(
-        `php ./clients/algoliasearch-client-php/vendor/bin/phpunit --testdox --fail-on-warning ${phpTestPaths}`,
+        `php ./clients/algoliasearch-client-php/vendor/bin/phpunit --bootstrap ./clients/algoliasearch-client-php/tests/bootstrap.php --testdox --fail-on-warning ${phpTestPaths}`,
         {
           language,
         },

--- a/templates/php/composer.mustache
+++ b/templates/php/composer.mustache
@@ -35,11 +35,6 @@
             "lib/Http/Psr7/functions.php"
         ]
     },
-    "autoload-dev": {
-        "files": [
-            "tests/bootstrap.php"
-        ]
-    },
     "suggest": {
         "guzzlehttp/guzzle": "If you prefer to use Guzzle HTTP client instead of the Http Client implementation provided by the package"
     },

--- a/templates/php/composer.mustache
+++ b/templates/php/composer.mustache
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91.3",
+        "guzzlehttp/guzzle": "^8.0",
         "phpunit/phpunit": "^10.0",
         "vlucas/phpdotenv": "^5.4",
         "phpstan/phpstan": "^1.12"
@@ -32,6 +33,11 @@
         "psr-4": { "Algolia\\AlgoliaSearch\\" : "lib/" },
         "files": [
             "lib/Http/Psr7/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "files": [
+            "tests/bootstrap.php"
         ]
     },
     "suggest": {

--- a/templates/php/composer.mustache
+++ b/templates/php/composer.mustache
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.91.3",
-        "guzzlehttp/guzzle": "^8.0",
+        "guzzlehttp/guzzle": "^7.0 || ^8.0",
         "phpunit/phpunit": "^10.0",
         "vlucas/phpdotenv": "^5.4",
         "phpstan/phpstan": "^1.12"

--- a/tests/output/php/src/manual/GuzzleHttpClientTest.php
+++ b/tests/output/php/src/manual/GuzzleHttpClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Algolia\AlgoliaSearch\Tests;
+
+use Algolia\AlgoliaSearch\Exceptions\TimeoutException;
+use Algolia\AlgoliaSearch\Http\GuzzleHttpClient;
+use Algolia\AlgoliaSearch\Http\Psr7\Request;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ConnectTimeoutException;
+use GuzzleHttp\Exception\HandlerClosedException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseTimeoutException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class GuzzleHttpClientTest extends TestCase
+{
+    /**
+     * @dataProvider retriableTransferFailures
+     */
+    public function testTransferFailuresAreRaisedAsTimeouts(\Throwable $failure): void
+    {
+        $this->expectException(TimeoutException::class);
+
+        $this->transportFailingWith($failure)->sendRequest(self::request(), 5, 2);
+    }
+
+    public static function retriableTransferFailures(): iterable
+    {
+        $request = self::request();
+
+        yield 'connection refused' => [new ConnectException('connection refused', $request)];
+
+        yield 'connect timeout' => [new ConnectTimeoutException('connect timed out', $request)];
+
+        yield 'network failure before headers' => [new NetworkException('connection reset by peer', $request)];
+
+        yield 'network timeout before headers' => [new NetworkTimeoutException('operation timed out', $request)];
+
+        yield 'read timeout after headers' => [new ResponseTimeoutException('operation timed out', $request, new GuzzleResponse(200, [], '{"hits":['))];
+
+        yield 'handler closed mid-transfer' => [new HandlerClosedException('handler closed', $request)];
+    }
+
+    public function testFailuresCarryingAResponseReturnThatResponse(): void
+    {
+        $failure = new ServerException('service unavailable', self::request(), new GuzzleResponse(503, [], 'unavailable'));
+
+        $response = $this->transportFailingWith($failure)->sendRequest(self::request(), 5, 2);
+
+        $this->assertSame(503, $response->getStatusCode());
+        $this->assertSame('unavailable', (string) $response->getBody());
+    }
+
+    public function testFailuresWithoutAResponseReturnAStatusZeroResponse(): void
+    {
+        $failure = new RequestException('could not create the response', self::request());
+
+        $response = $this->transportFailingWith($failure)->sendRequest(self::request(), 5, 2);
+
+        $this->assertSame(0, $response->getStatusCode());
+        $this->assertSame('could not create the response', $response->getReasonPhrase());
+    }
+
+    private static function request(): RequestInterface
+    {
+        return new Request('GET', 'http://localhost/1/indexes/test/query');
+    }
+
+    private function transportFailingWith(\Throwable $failure): GuzzleHttpClient
+    {
+        return new GuzzleHttpClient(new GuzzleClient(['handler' => new HandlerStack(new MockHandler([$failure]))]));
+    }
+}

--- a/tests/output/php/src/manual/GuzzleHttpClientTest.php
+++ b/tests/output/php/src/manual/GuzzleHttpClientTest.php
@@ -6,6 +6,7 @@ use Algolia\AlgoliaSearch\Exceptions\TimeoutException;
 use Algolia\AlgoliaSearch\Http\GuzzleHttpClient;
 use Algolia\AlgoliaSearch\Http\Psr7\Request;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ConnectTimeoutException;
 use GuzzleHttp\Exception\HandlerClosedException;
@@ -42,6 +43,10 @@ class GuzzleHttpClientTest extends TestCase
         $request = self::request();
 
         yield 'connection refused' => [new ConnectException('connection refused', $request)];
+
+        if (8 > ClientInterface::MAJOR_VERSION) {
+            return;
+        }
 
         yield 'connect timeout' => [new ConnectTimeoutException('connect timed out', $request)];
 

--- a/tests/output/php/src/manual/GuzzleHttpClientTest.php
+++ b/tests/output/php/src/manual/GuzzleHttpClientTest.php
@@ -31,9 +31,10 @@ class GuzzleHttpClientTest extends TestCase
     /**
      * @dataProvider retriableTransferFailures
      */
-    public function testTransferFailuresAreRaisedAsTimeouts(\Throwable $failure): void
+    public function testTransferFailuresAreRaisedAsTimeouts(\Throwable $failure, string $expectedMessage): void
     {
         $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage($expectedMessage);
 
         $this->transportFailingWith($failure)->sendRequest(self::request(), 5, 2);
     }
@@ -42,21 +43,23 @@ class GuzzleHttpClientTest extends TestCase
     {
         $request = self::request();
 
-        yield 'connection refused' => [new ConnectException('connection refused', $request)];
+        yield 'connection refused' => [new ConnectException('connection refused', $request), 'connection refused'];
 
         if (8 > ClientInterface::MAJOR_VERSION) {
+            yield 'curl timeout (errno 28)' => [new ConnectException('cURL error 28: operation timed out', $request, null, ['errno' => CURLE_OPERATION_TIMEDOUT]), 'Connection timed out'];
+
             return;
         }
 
-        yield 'connect timeout' => [new ConnectTimeoutException('connect timed out', $request)];
+        yield 'connect timeout' => [new ConnectTimeoutException('connect timed out', $request), 'Connection timed out'];
 
-        yield 'network failure before headers' => [new NetworkException('connection reset by peer', $request)];
+        yield 'network failure before headers' => [new NetworkException('connection reset by peer', $request), 'connection reset by peer'];
 
-        yield 'network timeout before headers' => [new NetworkTimeoutException('operation timed out', $request)];
+        yield 'network timeout before headers' => [new NetworkTimeoutException('operation timed out', $request), 'Connection timed out'];
 
-        yield 'read timeout after headers' => [new ResponseTimeoutException('operation timed out', $request, new GuzzleResponse(200, [], '{"hits":['))];
+        yield 'read timeout after headers' => [new ResponseTimeoutException('operation timed out', $request, new GuzzleResponse(200, [], '{"hits":[')), 'Connection timed out'];
 
-        yield 'handler closed mid-transfer' => [new HandlerClosedException('handler closed', $request)];
+        yield 'handler closed mid-transfer' => [new HandlerClosedException('handler closed', $request), 'handler closed'];
     }
 
     public function testFailuresCarryingAResponseReturnThatResponse(): void

--- a/tests/output/php/src/manual/TimeoutIntegrationTest.php
+++ b/tests/output/php/src/manual/TimeoutIntegrationTest.php
@@ -64,10 +64,6 @@ class TimeoutIntegrationTest extends TestCase
     // GuzzleHttpClient connect timeout increases across failed requests: 2s -> 4s -> 6s.
     public function testGuzzleRetryCountStateful(): void
     {
-        if (!class_exists('\GuzzleHttp\Client')) {
-            $this->markTestSkipped('Guzzle is not installed. Install guzzlehttp/guzzle to run this test.');
-        }
-
         [$wrapper, $clusterHosts] = $this->createApiWrapperWithClusterHosts(
             new GuzzleHttpClient(),
             [self::NON_ROUTABLE_IP]
@@ -168,10 +164,6 @@ class TimeoutIntegrationTest extends TestCase
     // GuzzleHttpClient retry_count resets to 0 after successful request.
     public function testGuzzleRetryCountResets(): void
     {
-        if (!class_exists('\GuzzleHttp\Client')) {
-            $this->markTestSkipped('Guzzle is not installed. Install guzzlehttp/guzzle to run this test.');
-        }
-
         $badHost = self::NON_ROUTABLE_IP;
         $goodHostFull = 'http://'.getTestServerHost();
 
@@ -280,10 +272,6 @@ class TimeoutIntegrationTest extends TestCase
     // guzzle test that multiple hosts maintain independent retry counts.
     public function testGuzzleMultipleHostsIndependentRetryCount(): void
     {
-        if (!class_exists('\GuzzleHttp\Client')) {
-            $this->markTestSkipped('Guzzle is not installed. Install guzzlehttp/guzzle to run this test.');
-        }
-
         $badHost1 = self::NON_ROUTABLE_IP;
         $badHost2 = '10.255.255.2';
 
@@ -376,10 +364,6 @@ class TimeoutIntegrationTest extends TestCase
     // guzzle 1 good host and 1 bad host
     public function testGuzzleMultipleHostsMixedIndependentRetryCount(): void
     {
-        if (!class_exists('\GuzzleHttp\Client')) {
-            $this->markTestSkipped('Guzzle is not installed. Install guzzlehttp/guzzle to run this test.');
-        }
-
         $badHostFull = 'https://'.self::NON_ROUTABLE_IP.':443';
         $goodHostFull = 'http://'.getTestServerHost();
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-551]

`GuzzleHttpClient` was never exercised by CI: guzzle was only a `suggest`, so `class_exists('\GuzzleHttp\Client')` was always false and the four `testGuzzle*` cases in `TimeoutIntegrationTest` were skipped. Skips are not warnings, so `--fail-on-warning` stayed green. Installing it surfaced two divergences from `CurlHttpClient`.

### Changes included:

- Request compressed responses (`'decode_content' => 'gzip'`). Guzzle's default decodes a compressed body but never advertises for one, so guzzle users got uncompressed responses where curl users did not.
- Report `Connection timed out` for real timeouts rather than guzzle's `cURL error 28: … after 2002 milliseconds …`, which embeds elapsed time and the request URL. The guzzle exception stays chained as `$previous`.
- Add `guzzlehttp/guzzle` to `require-dev` as `^7.0 || ^8.0`; it lands in `packages-dev`, and the lock moves `psr7` 3.0.0 → 3.1.0, still inside `^2.0 || ^3.0`.
- Pin the default transport to `CurlHttpClient` from `tests/bootstrap.php`, so installing guzzle does not flip `Algolia::getHttpClient()` for the whole suite. The CTS runner passes it to phpunit with `--bootstrap` and `phpunit.xml.dist` points at it for local runs, keeping the pin scoped to phpunit rather than everything that loads the dev autoloader (the playground included).
- Add `GuzzleHttpClientTest`, which drives each guzzle failure class through a `MockHandler` and asserts the mapping directly. Guzzle-8-only classes are gated behind `ClientInterface::MAJOR_VERSION`.
- Re-run the client, requests and manual suites on guzzle 7 at the end of the PHP CTS job, which also covers the `^2.0` half of the psr7 range through the request builders. The downgrade rewrites `composer.lock`, so the step restores it and re-syncs `vendor/` afterwards.

## 🧪 Test

The four previously-skipped `testGuzzle*` cases now run: `src/manual/` is 65 tests on guzzle 8 with each `Curl`/`Guzzle` pair green side by side, and 61 on guzzle 7 where the guzzle-8-only cases are correctly not yielded and the errno-28 fallback case only is. `yarn cli cts run php --no-e2e` exits 0 on both majors. `GuzzleHttpClientTest` fails on all four reclassifications when run against the pre-guzzle-8 implementation, and both fixes are checked on the wire against real installs of guzzle 8.1.0 / psr7 3.1.0 and guzzle 7.15.5 / psr7 2.13.1.

[API-551]: https://algolia.atlassian.net/browse/API-551

