### PR TITLE
docs: document handling of beta endpoints and APIs

### DIFF
--- a/website/docs/add-a-new-api/api-documentation-guidelines.md
+++ b/website/docs/add-a-new-api/api-documentation-guidelines.md
@@ -164,6 +164,14 @@ Explain the response format, status codes, and error messages.
 
 State the current version of the API and how to determine it.
 
+## Beta APIs and endpoints
+
+Don't announce beta status in prose, in the API `description`, or in operation summaries and descriptions.
+Instead, set `x-beta: true` on the whole API or on a single operation.
+The documentation then displays a beta banner for that API or endpoint.
+
+For details, see [Beta APIs](./write-a-specification.md#beta-apis) and [Beta endpoints](./write-a-specification.md#beta-endpoints).
+
 ## Operation summaries
 
 Operations are endpoints combined with an HTTP verb.

--- a/website/docs/add-a-new-api/write-a-specification.md
+++ b/website/docs/add-a-new-api/write-a-specification.md
@@ -34,6 +34,17 @@ Each API must be contained in its own directory, for example: [the Search API](h
 
 This file is the main entrypoint of your specification and should describe your API, including the `servers`, `securitySchemes` and `paths` properties.
 
+#### Beta APIs
+
+To mark a whole API as beta, add `x-beta: true` at the root level of `spec.yml`:
+
+```yaml
+x-beta: true
+```
+
+This property only affects [the Algolia public documentation](https://www.algolia.com/doc/api-reference/rest-api/), which displays a banner informing users that the API is in beta.
+It has no effect on the generated API clients, tests, or code snippets.
+
 ### `specs/<apiName>/common/`
 
 This directory contains schemas and parameters that are common to **your API**.
@@ -69,6 +80,17 @@ to document the ACL required to make the request.
 
 The `x-acl` property is an array of strings, the allowed values are: `search`, `browse`, `addObject`, `deleteObject`, `listIndexes`, `deleteIndex`, `settings`, `editSettings`, `analytics`, `recommendation`, `usage`, `logs`, `setUnretrievableAttributes`, `admin`.
 For operations that require the admin API key, use `admin`
+
+##### Beta endpoints
+
+To mark a single endpoint as beta, add `x-beta: true` to the root of the operation:
+
+```yaml
+post:
+  x-beta: true
+```
+
+As for whole APIs, this only adds a beta banner to the documentation and doesn't change the generated code.
 
 ##### Complex objects
 


### PR DESCRIPTION
## 🧭 What and Why

Document the handling of beta endpoints and APIs.
This is only relevant for docs and doesn't affect the generated clients.

Adding `x-beta` to and endpoint or the whole API generates a banner on the docs page that tells people that this is a beta API. 

🎟 JIRA Ticket:

### Changes included:

- Update the API documentation and the Write a specification guidelines

## 🧪 Test

N/A