### PR TITLE
fix(specs): flag analytics patterns endpoints with x-beta

### DIFF
--- a/specs/analytics/common/schemas/patterns.yml
+++ b/specs/analytics/common/schemas/patterns.yml
@@ -1,4 +1,4 @@
-# Schemas for the Beta semantic patterns query framework (/3/patterns/*).
+# Schemas for the semantic patterns query framework (/3/patterns/*).
 
 FieldReference:
   type: object

--- a/specs/analytics/paths/patterns/getPatternsFields.yml
+++ b/specs/analytics/paths/patterns/getPatternsFields.yml
@@ -2,12 +2,11 @@ get:
   tags:
     - pattern
   operationId: getPatternsFields
+  x-beta: true
   x-acl: []
   security: []
-  summary: (Beta) Retrieve the field catalog
+  summary: Retrieve the field catalog
   description: |
-    **Beta**: this endpoint is under active development and may change without notice.
-
     Returns the static catalog of analytics fields, grouped by domain and usage (metrics, filters,
     groups, distributions). No authentication is required. Use it to discover valid `(domain, kind)`
     pairs before building the other `/3/patterns/*` queries; two fields are combinable in one query

--- a/specs/analytics/paths/patterns/queryPatternsDistribution.yml
+++ b/specs/analytics/paths/patterns/queryPatternsDistribution.yml
@@ -2,12 +2,11 @@ post:
   tags:
     - pattern
   operationId: queryPatternsDistribution
+  x-beta: true
   x-acl:
     - analytics
-  summary: (Beta) Query a numeric distribution
+  summary: Query a numeric distribution
   description: |
-    **Beta**: this endpoint is under active development and may change without notice.
-
     Buckets one or more numeric fields into histograms and returns an object keyed by `histogram<Field>`,
     each mapping a bin label to a count. `distributions` and `parameters` are required; `filters` is
     optional. Discover valid field kinds per domain with `/3/patterns/fields`.

--- a/specs/analytics/paths/patterns/queryPatternsScalar.yml
+++ b/specs/analytics/paths/patterns/queryPatternsScalar.yml
@@ -2,12 +2,11 @@ post:
   tags:
     - pattern
   operationId: queryPatternsScalar
+  x-beta: true
   x-acl:
     - analytics
-  summary: (Beta) Query single-row aggregates
+  summary: Query single-row aggregates
   description: |
-    **Beta**: this endpoint is under active development and may change without notice.
-
     Aggregates the requested `metrics` over the whole period and returns a single object keyed by metric
     kind. `metrics` and `parameters` are required; `filters` is optional. Discover valid field kinds per
     domain with `/3/patterns/fields`.

--- a/specs/analytics/paths/patterns/queryPatternsTable.yml
+++ b/specs/analytics/paths/patterns/queryPatternsTable.yml
@@ -2,12 +2,11 @@ post:
   tags:
     - pattern
   operationId: queryPatternsTable
+  x-beta: true
   x-acl:
     - analytics
-  summary: (Beta) Query a grouped table
+  summary: Query a grouped table
   description: |
-    **Beta**: this endpoint is under active development and may change without notice.
-
     Returns `rows`, each a flat object of the requested fields. `metrics` and `parameters` are required;
     `groupBy`, `filters`, and `orderBy` are optional, though `orderBy` is required when `groupBy` is set.
     Discover valid field kinds per domain with `/3/patterns/fields`.

--- a/specs/analytics/paths/patterns/queryPatternsTimeseries.yml
+++ b/specs/analytics/paths/patterns/queryPatternsTimeseries.yml
@@ -2,12 +2,11 @@ post:
   tags:
     - pattern
   operationId: queryPatternsTimeseries
+  x-beta: true
   x-acl:
     - analytics
-  summary: (Beta) Query a metrics time series
+  summary: Query a metrics time series
   description: |
-    **Beta**: this endpoint is under active development and may change without notice.
-
     Returns one time series per `groupBy` combination, each with period `totals` and a per-day metric
     breakdown. `metrics` and `parameters` are required; `groupBy` and `filters` are optional. Discover
     valid field kinds per domain with `/3/patterns/fields`.

--- a/specs/analytics/spec.yml
+++ b/specs/analytics/spec.yml
@@ -56,8 +56,8 @@ info:
 
     The current version of the Analytics API is version 2, indicated by the `/2/` in each endpoint's URL.
 
-    A Beta semantic patterns framework is also available under `/3/patterns/*` for building custom
-    analytics queries. These endpoints are under active development and may change without notice.
+    A semantic patterns framework is also available under `/3/patterns/*` for building custom
+    analytics queries.
 
     ## Query aggregation
 
@@ -99,11 +99,10 @@ tags:
     description: |
       Metrics related to filters.
   - name: pattern
-    x-displayName: Patterns (Beta)
+    x-displayName: Patterns
     description: |
-      Beta — the semantic patterns query framework (`/3/patterns/*`).
+      The semantic patterns query framework (`/3/patterns/*`).
       Build custom analytics queries from metrics, groupBy, filters, and parameters.
-      These endpoints are under active development and may change without notice.
   - name: revenue
     x-displayName: Revenue
     description: |
@@ -190,9 +189,9 @@ paths:
   /2/status:
     $ref: 'paths/status/getStatus.yml'
 
-  # ##############################
-  # ### Patterns (Beta) — /3/ ####
-  # ##############################
+  # ######################
+  # ### Patterns — /3/ ###
+  # ######################
   /3/patterns/fields:
     $ref: 'paths/patterns/getPatternsFields.yml'
   /3/patterns/timeseries:


### PR DESCRIPTION
## 🧭 What and Why

The `/3/patterns/*` endpoints announced their beta status in prose: a `(Beta)` prefix on every operation summary, a `**Beta**: ...` line in every description, and `Patterns (Beta)` as the tag display name. 

ref: [Slack thread](https://algolia.slack.com/archives/CSP64JJ3T/p1787745060578209?thread_ts=1787137040.246209&cid=CSP64JJ3T)

### Changes included:

- `specs/analytics/paths/patterns/*.yml`: add `x-beta: true` to all 5 operations, drop the `(Beta)` summary prefix and the `**Beta**: this endpoint is under active development and may change without notice.` description line
- `specs/analytics/spec.yml`: rename the tag display name to `Patterns`, drop the beta sentences from the tag description and the `## Version` prose

## 🧪 Test

- Green CI
