### PR TITLE
fix(specs): remove plan restriction from Analytics API description

### DIFF
--- a/specs/analytics/spec.yml
+++ b/specs/analytics/spec.yml
@@ -20,8 +20,6 @@ info:
 
     ## Availability and authentication
 
-    Access to the Analytics API is available as part of the [Premium or Elevate plans](https://www.algolia.com/pricing).
-
     Add these headers to authenticate requests:
 
     - `x-algolia-application-id`. Your Algolia application ID.


### PR DESCRIPTION
The Analytics API description said access requires a Premium or Elevate plan. That's no longer true — the API is available on all plans — so the sentence is removed from the `## Availability and authentication` section.

Reported in #help-documentation by Louise Stone, who found the docs page contradicting internal threads confirming all-plan availability.

https://algolia.slack.com/archives/C0D3A9E82/p1787755269478269