### PR TITLE
fix(specs): decode paginationLimitedTo as int64

### DIFF
--- a/specs/common/schemas/IndexSettings.yml
+++ b/specs/common/schemas/IndexSettings.yml
@@ -65,6 +65,7 @@ baseIndexSettings:
         - Ranking
     paginationLimitedTo:
       type: integer
+      format: int64
       example: 100
       description: |
         Maximum number of search results that can be obtained through pagination.


### PR DESCRIPTION
## 🧭 What and Why

GetSettings (and index-existence checks that call it) cannot decode some live `paginationLimitedTo` values because generated clients treat the field as int32. This sets `format: int64` so those responses unmarshal. The documented product cap remains 20,000.

This is a source break on typed clients once CI regenerates: Go `int32`→`int64`, Java `Integer`→`Long`, C# `int?`→`long?`, Kotlin/Scala `Int`→`Long`, Swift `Int`→`Int64`.

## 🧪 Test

CI regenerates clients and runs CTS.
