### PR TITLE
docs(specs): declare the Correlation-ID response header

### DIFF
--- a/specs/common/responses/CreatedAt.yml
+++ b/specs/common/responses/CreatedAt.yml
@@ -1,4 +1,8 @@
+# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
 description: OK
+headers:
+  Correlation-ID:
+    $ref: 'correlationId.yml#/Correlation-ID'
 content:
   application/json:
     schema:

--- a/specs/common/responses/CreatedAt.yml
+++ b/specs/common/responses/CreatedAt.yml
@@ -1,4 +1,4 @@
-# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
+# Only APIs on {appId}.algolia.net send Correlation-ID. Drop the header below if another API reuses this response.
 description: OK
 headers:
   Correlation-ID:

--- a/specs/common/responses/DeletedAt.yml
+++ b/specs/common/responses/DeletedAt.yml
@@ -1,4 +1,8 @@
+# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
 description: OK
+headers:
+  Correlation-ID:
+    $ref: 'correlationId.yml#/Correlation-ID'
 content:
   application/json:
     schema:

--- a/specs/common/responses/DeletedAt.yml
+++ b/specs/common/responses/DeletedAt.yml
@@ -1,4 +1,4 @@
-# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
+# Only APIs on {appId}.algolia.net send Correlation-ID. Drop the header below if another API reuses this response.
 description: OK
 headers:
   Correlation-ID:

--- a/specs/common/responses/UpdatedAt.yml
+++ b/specs/common/responses/UpdatedAt.yml
@@ -1,4 +1,8 @@
+# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
 description: OK
+headers:
+  Correlation-ID:
+    $ref: 'correlationId.yml#/Correlation-ID'
 content:
   application/json:
     schema:

--- a/specs/common/responses/UpdatedAt.yml
+++ b/specs/common/responses/UpdatedAt.yml
@@ -1,4 +1,4 @@
-# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
+# Only APIs on {appId}.algolia.net send Correlation-ID. Drop the header below if another API reuses this response.
 description: OK
 headers:
   Correlation-ID:

--- a/specs/common/responses/UpdatedAtWithObjectId.yml
+++ b/specs/common/responses/UpdatedAtWithObjectId.yml
@@ -1,4 +1,8 @@
+# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
 description: OK
+headers:
+  Correlation-ID:
+    $ref: 'correlationId.yml#/Correlation-ID'
 content:
   application/json:
     schema:

--- a/specs/common/responses/UpdatedAtWithObjectId.yml
+++ b/specs/common/responses/UpdatedAtWithObjectId.yml
@@ -1,4 +1,4 @@
-# Reused by Search and Recommend only. Drop the Correlation-ID header below before reusing this response for an API that does not send it.
+# Only APIs on {appId}.algolia.net send Correlation-ID. Drop the header below if another API reuses this response.
 description: OK
 headers:
   Correlation-ID:

--- a/specs/common/responses/correlationId.yml
+++ b/specs/common/responses/correlationId.yml
@@ -1,0 +1,8 @@
+Correlation-ID:
+  description: |
+    Identifies the request in Algolia's logs, where it's the `cid` property of a log entry.
+    Include it when you contact the Algolia support team about a specific request.
+    Retried requests can share an identifier, so don't use it as a unique key.
+  example: MyAppl-1tMcE-a7BqLm2Pd0Z
+  schema:
+    type: string

--- a/specs/composition/common/responses/correlationId.yml
+++ b/specs/composition/common/responses/correlationId.yml
@@ -1,0 +1,3 @@
+# Composition reaches the shared header through here, so a Composition-only change stays in one file.
+Correlation-ID:
+  $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'

--- a/specs/composition/paths/advanced/getTask.yml
+++ b/specs/composition/paths/advanced/getTask.yml
@@ -24,6 +24,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/advanced/getTask.yml
+++ b/specs/composition/paths/advanced/getTask.yml
@@ -26,7 +26,7 @@ get:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/batch.yml
+++ b/specs/composition/paths/compositions/batch.yml
@@ -36,6 +36,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/batch.yml
+++ b/specs/composition/paths/compositions/batch.yml
@@ -38,7 +38,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/composition.yml
+++ b/specs/composition/paths/compositions/composition.yml
@@ -13,6 +13,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -46,6 +49,9 @@ put:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -80,6 +86,9 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/composition.yml
+++ b/specs/composition/paths/compositions/composition.yml
@@ -15,7 +15,7 @@ get:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -51,7 +51,7 @@ put:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -88,7 +88,7 @@ delete:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/list.yml
+++ b/specs/composition/paths/compositions/list.yml
@@ -14,6 +14,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/list.yml
+++ b/specs/composition/paths/compositions/list.yml
@@ -16,7 +16,7 @@ get:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/updateSortingStrategy.yml
+++ b/specs/composition/paths/compositions/updateSortingStrategy.yml
@@ -27,7 +27,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/compositions/updateSortingStrategy.yml
+++ b/specs/composition/paths/compositions/updateSortingStrategy.yml
@@ -25,6 +25,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/rule.yml
+++ b/specs/composition/paths/rules/rule.yml
@@ -16,6 +16,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -51,6 +54,9 @@ put:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -88,6 +94,9 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/rule.yml
+++ b/specs/composition/paths/rules/rule.yml
@@ -18,7 +18,7 @@ get:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -56,7 +56,7 @@ put:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -96,7 +96,7 @@ delete:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/saveRules.yml
+++ b/specs/composition/paths/rules/saveRules.yml
@@ -39,7 +39,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/saveRules.yml
+++ b/specs/composition/paths/rules/saveRules.yml
@@ -37,6 +37,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/searchRules.yml
+++ b/specs/composition/paths/rules/searchRules.yml
@@ -43,7 +43,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/rules/searchRules.yml
+++ b/specs/composition/paths/rules/searchRules.yml
@@ -41,6 +41,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/search/search.yml
+++ b/specs/composition/paths/search/search.yml
@@ -28,7 +28,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/search/search.yml
+++ b/specs/composition/paths/search/search.yml
@@ -26,6 +26,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/search/searchForFacetValues.yml
+++ b/specs/composition/paths/search/searchForFacetValues.yml
@@ -47,7 +47,7 @@ post:
       description: OK
       headers:
         Correlation-ID:
-          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/composition/paths/search/searchForFacetValues.yml
+++ b/specs/composition/paths/search/searchForFacetValues.yml
@@ -45,6 +45,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/recommend/common/responses/RecommendUpdatedAt.yml
+++ b/specs/recommend/common/responses/RecommendUpdatedAt.yml
@@ -1,4 +1,7 @@
 description: OK
+headers:
+  Correlation-ID:
+    $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
 content:
   application/json:
     schema:

--- a/specs/recommend/common/responses/RecommendUpdatedAt.yml
+++ b/specs/recommend/common/responses/RecommendUpdatedAt.yml
@@ -1,3 +1,4 @@
+# Only APIs on {appId}.algolia.net send Correlation-ID. Drop the header below if another API reuses this response.
 description: OK
 headers:
   Correlation-ID:

--- a/specs/recommend/paths/getRecommendStatus.yml
+++ b/specs/recommend/paths/getRecommendStatus.yml
@@ -23,6 +23,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/recommend/paths/getRecommendations.yml
+++ b/specs/recommend/paths/getRecommendations.yml
@@ -30,6 +30,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/recommend/paths/recommendRule.yml
+++ b/specs/recommend/paths/recommendRule.yml
@@ -13,6 +13,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/recommend/paths/searchRecommendRules.yml
+++ b/specs/recommend/paths/searchRecommendRules.yml
@@ -58,6 +58,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/advanced/getAppTask.yml
+++ b/specs/search/paths/advanced/getAppTask.yml
@@ -19,6 +19,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/advanced/getLogs.yml
+++ b/specs/search/paths/advanced/getLogs.yml
@@ -45,6 +45,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/advanced/getTask.yml
+++ b/specs/search/paths/advanced/getTask.yml
@@ -26,6 +26,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/dictionaries/dictionarySettings.yml
+++ b/specs/search/paths/dictionaries/dictionarySettings.yml
@@ -9,6 +9,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/dictionaries/getDictionaryLanguages.yml
+++ b/specs/search/paths/dictionaries/getDictionaryLanguages.yml
@@ -13,6 +13,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/dictionaries/searchDictionaryEntries.yml
+++ b/specs/search/paths/dictionaries/searchDictionaryEntries.yml
@@ -33,6 +33,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/keys/key.yml
+++ b/specs/search/paths/keys/key.yml
@@ -16,6 +16,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -51,6 +54,9 @@ put:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -87,6 +93,9 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/keys/keys.yml
+++ b/specs/search/paths/keys/keys.yml
@@ -9,6 +9,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -49,6 +52,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/keys/restoreApiKey.yml
+++ b/specs/search/paths/keys/restoreApiKey.yml
@@ -17,6 +17,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/manage_indices/listIndices.yml
+++ b/specs/search/paths/manage_indices/listIndices.yml
@@ -16,6 +16,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/getTopUserIds.yml
+++ b/specs/search/paths/multiclusters/getTopUserIds.yml
@@ -14,6 +14,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/hasPendingMappings.yml
+++ b/specs/search/paths/multiclusters/hasPendingMappings.yml
@@ -17,6 +17,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/listClusters.yml
+++ b/specs/search/paths/multiclusters/listClusters.yml
@@ -10,6 +10,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/searchUserIds.yml
+++ b/specs/search/paths/multiclusters/searchUserIds.yml
@@ -36,6 +36,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/userId.yml
+++ b/specs/search/paths/multiclusters/userId.yml
@@ -16,6 +16,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -43,6 +46,9 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/multiclusters/userIds.yml
+++ b/specs/search/paths/multiclusters/userIds.yml
@@ -57,6 +57,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/objects/batch.yml
+++ b/specs/search/paths/objects/batch.yml
@@ -27,6 +27,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/objects/getObjects.yml
+++ b/specs/search/paths/objects/getObjects.yml
@@ -54,6 +54,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/objects/multipleBatch.yml
+++ b/specs/search/paths/objects/multipleBatch.yml
@@ -62,6 +62,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/objects/object.yml
+++ b/specs/search/paths/objects/object.yml
@@ -30,6 +30,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/objects/objects.yml
+++ b/specs/search/paths/objects/objects.yml
@@ -35,6 +35,9 @@ post:
   responses:
     '201':
       description: Created
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/rules/rule.yml
+++ b/specs/search/paths/rules/rule.yml
@@ -15,6 +15,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/rules/searchRules.yml
+++ b/specs/search/paths/rules/searchRules.yml
@@ -44,6 +44,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/search/browse.yml
+++ b/specs/search/paths/search/browse.yml
@@ -42,6 +42,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/search/search.yml
+++ b/specs/search/paths/search/search.yml
@@ -38,6 +38,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/search/searchForFacetValues.yml
+++ b/specs/search/paths/search/searchForFacetValues.yml
@@ -41,6 +41,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/search/searchSingleIndex.yml
+++ b/specs/search/paths/search/searchSingleIndex.yml
@@ -23,6 +23,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/settings/settings.yml
+++ b/specs/search/paths/settings/settings.yml
@@ -13,6 +13,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/synonyms/searchSynonyms.yml
+++ b/specs/search/paths/synonyms/searchSynonyms.yml
@@ -31,6 +31,9 @@ post:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/synonyms/synonym.yml
+++ b/specs/search/paths/synonyms/synonym.yml
@@ -15,6 +15,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -52,6 +55,9 @@ put:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/vault/deleteSource.yml
+++ b/specs/search/paths/vault/deleteSource.yml
@@ -17,6 +17,9 @@ delete:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:

--- a/specs/search/paths/vault/vaultSources.yml
+++ b/specs/search/paths/vault/vaultSources.yml
@@ -9,6 +9,9 @@ get:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:
@@ -40,6 +43,9 @@ put:
   responses:
     '200':
       description: OK
+      headers:
+        Correlation-ID:
+          $ref: '../../../common/responses/correlationId.yml#/Correlation-ID'
       content:
         application/json:
           schema:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: n/a

Search, Recommend and Composition return a `Correlation-ID` header on every response the engine handles, and no spec declared it, so the REST API reference omits it. #6820 added the `cid` log field, which points at that header, and @Fluf22 asked for the declaration there.

`specs/common/responses/correlationId.yml` holds the definition and copies the shape of `rateLimit.yml`. 56 responses reference it directly, and five shared response files carry it for another 22.

## Scope

Only these three APIs answer on `{appId}.algolia.net`, so my "every API" claim on #6820 was too broad. Left out:

- Error responses, because the engine sends no header when it refuses a request before a handler runs. AlgoliaSaaS #14953 fixes that.
- Client helpers, because one helper call spans several requests.
- `customRequest.yml`, because all 13 APIs share it.
- Agent Studio, because it answers on the same host but returned nothing I could check.

## How

No lint rule checks that a new engine operation declares the header, so that is worth a follow-up.

No test can assert the header today. The CTS `correlationIdSuffix` key asserts that the response repeats the `Request-ID` the client sent, and Search clusters do not repeat it. Codegen produces no client changes.
