### PR TITLE
feat(python): wait and retry on 429 with Retry-After

### DIFF
--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -35,9 +35,7 @@ class BaseConfig:
 
         self.request_id_enabled: bool = False
 
-        # How many times to wait and retry on the same host after HTTP 429.
-        # 0 fails on the first 429. The wait is `Retry-After` in whole seconds,
-        # or 1 second when the header is missing or invalid.
+        # Same-host retries after HTTP 429; 0 fails on the first 429.
         self.max_rate_limit_retries: int = 3
 
     def set_client_api_key(self, api_key: str) -> None:

--- a/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/base_config.py
@@ -35,6 +35,11 @@ class BaseConfig:
 
         self.request_id_enabled: bool = False
 
+        # How many times to wait and retry on the same host after HTTP 429.
+        # 0 fails on the first 429. The wait is `Retry-After` in whole seconds,
+        # or 1 second when the header is missing or invalid.
+        self.max_rate_limit_retries: int = 3
+
     def set_client_api_key(self, api_key: str) -> None:
         """Sets a new API key to authenticate requests."""
         self.api_key = api_key

--- a/clients/algoliasearch-client-python/algoliasearch/http/retry.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/retry.py
@@ -1,8 +1,31 @@
 import time
-from typing import List
+from re import fullmatch
+from typing import List, Mapping, Optional
 
 from algoliasearch.http.api_response import ApiResponse
 from algoliasearch.http.hosts import Host
+
+RATE_LIMIT_STATUS_CODE = 429
+DEFAULT_RATE_LIMIT_WAIT_SECONDS = 1.0
+
+
+def parse_retry_after_seconds(headers: Optional[Mapping[str, str]]) -> float:
+    """`Retry-After` as a wait in seconds.
+
+    Only a positive whole number of seconds is honored; a missing, empty, zero,
+    negative, HTTP-date or otherwise unparseable value waits 1 second.
+    """
+    raw = (headers.get("retry-after") or "").strip() if headers else ""
+
+    if fullmatch(r"\d+", raw) is None:
+        return DEFAULT_RATE_LIMIT_WAIT_SECONDS
+
+    seconds = int(raw)
+
+    if seconds <= 0:
+        return DEFAULT_RATE_LIMIT_WAIT_SECONDS
+
+    return float(seconds)
 
 
 class RetryOutcome:
@@ -38,6 +61,12 @@ class RetryStrategy:
             return RetryOutcome.SUCCESS
 
         return RetryOutcome.FAIL
+
+    def is_rate_limited(self, response: ApiResponse) -> bool:
+        return response.status_code == RATE_LIMIT_STATUS_CODE
+
+    def rate_limit_wait_seconds(self, response: ApiResponse) -> float:
+        return parse_retry_after_seconds(response.headers)
 
     def _is_success(self, response: ApiResponse) -> bool:
         return response.status_code is not None and (response.status_code // 100) == 2

--- a/clients/algoliasearch-client-python/algoliasearch/http/retry.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/retry.py
@@ -62,12 +62,6 @@ class RetryStrategy:
 
         return RetryOutcome.FAIL
 
-    def is_rate_limited(self, response: ApiResponse) -> bool:
-        return response.status_code == RATE_LIMIT_STATUS_CODE
-
-    def rate_limit_wait_seconds(self, response: ApiResponse) -> float:
-        return parse_retry_after_seconds(response.headers)
-
     def _is_success(self, response: ApiResponse) -> bool:
         return response.status_code is not None and (response.status_code // 100) == 2
 

--- a/clients/algoliasearch-client-python/algoliasearch/http/retry.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/retry.py
@@ -17,7 +17,7 @@ def parse_retry_after_seconds(headers: Optional[Mapping[str, str]]) -> float:
     """
     raw = (headers.get("retry-after") or "").strip() if headers else ""
 
-    if fullmatch(r"\d+", raw) is None:
+    if fullmatch(r"[0-9]+", raw) is None:
         return DEFAULT_RATE_LIMIT_WAIT_SECONDS
 
     seconds = int(raw)

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
@@ -1,4 +1,4 @@
-from asyncio import TimeoutError
+from asyncio import TimeoutError, sleep
 from gzip import compress as gzip_compress
 from json import dumps, loads
 from typing import AsyncIterator, List, Optional
@@ -15,7 +15,12 @@ from algoliasearch.http.exceptions import (
 from algoliasearch.http.hosts import Host
 from algoliasearch.http.request_id import get_correlation_id, with_request_id
 from algoliasearch.http.request_options import RequestOptions
-from algoliasearch.http.retry import RetryOutcome, RetryStrategy
+from algoliasearch.http.retry import (
+    RATE_LIMIT_STATUS_CODE,
+    RetryOutcome,
+    RetryStrategy,
+    parse_retry_after_seconds,
+)
 from algoliasearch.http.sse import ServerSentEvent, aiter_sse_events
 from algoliasearch.http.verb import Verb
 
@@ -63,55 +68,67 @@ class Transporter(BaseTransporter):
             request_options.headers["content-encoding"] = "gzip"
 
         last_correlation_id = None
+        rate_limit_retries_left = self._config.max_rate_limit_retries
 
         for host in self._retry_strategy.valid_hosts(self._hosts):
             url = self.build_url(host, path)
             proxy = self.get_proxy(url)
 
-            try:
-                connect_timeout = (
-                    request_options.timeouts["connect"] * (host.retry_count + 1)
-                ) / 1000
-                request_timeout = self._timeout / 1000
+            while True:
+                try:
+                    connect_timeout = (
+                        request_options.timeouts["connect"] * (host.retry_count + 1)
+                    ) / 1000
+                    request_timeout = self._timeout / 1000
 
-                timeout_config = ClientTimeout(
-                    connect=connect_timeout, sock_read=request_timeout
-                )
+                    timeout_config = ClientTimeout(
+                        connect=connect_timeout, sock_read=request_timeout
+                    )
 
-                async with self._session.request(
-                    method=verb,
-                    url=url,
-                    headers=request_options.headers,
-                    data=request_options.data,
-                    proxy=proxy,
-                    timeout=timeout_config,
-                ) as resp:
-                    _raw_data = await resp.text()
+                    async with self._session.request(
+                        method=verb,
+                        url=url,
+                        headers=request_options.headers,
+                        data=request_options.data,
+                        proxy=proxy,
+                        timeout=timeout_config,
+                    ) as resp:
+                        _raw_data = await resp.text()
 
+                        response = ApiResponse(
+                            verb=verb,
+                            path=path,
+                            url=url,
+                            host=host.url,
+                            status_code=resp.status,
+                            headers=resp.headers,  # pyright: ignore # insensitive dict is still a dict
+                            data=_raw_data,
+                            raw_data=_raw_data,
+                            error_message=str(resp.reason),
+                        )
+
+                except TimeoutError as e:
                     response = ApiResponse(
                         verb=verb,
                         path=path,
                         url=url,
                         host=host.url,
-                        status_code=resp.status,
-                        headers=resp.headers,  # pyright: ignore # insensitive dict is still a dict
-                        data=_raw_data,
-                        raw_data=_raw_data,
-                        error_message=str(resp.reason),
+                        error_message=str(e),
+                        is_timed_out_error=True,
                     )
 
-            except TimeoutError as e:
-                response = ApiResponse(
-                    verb=verb,
-                    path=path,
-                    url=url,
-                    host=host.url,
-                    error_message=str(e),
-                    is_timed_out_error=True,
-                )
+                correlation_id = get_correlation_id(response.headers)
+                last_correlation_id = correlation_id or last_correlation_id
 
-            correlation_id = get_correlation_id(response.headers)
-            last_correlation_id = correlation_id or last_correlation_id
+                if (
+                    self._retry_strategy.is_rate_limited(response)
+                    and rate_limit_retries_left > 0
+                ):
+                    rate_limit_retries_left -= 1
+                    await sleep(self._retry_strategy.rate_limit_wait_seconds(response))
+                    continue
+
+                break
 
             decision = self._retry_strategy.decide(host, response)
 
@@ -166,14 +183,26 @@ class Transporter(BaseTransporter):
             connect=connect_timeout, sock_read=request_timeout
         )
 
-        resp = await self._session.request(
-            method=verb,
-            url=url,
-            headers=request_options.headers,
-            data=request_options.data,
-            proxy=proxy,
-            timeout=timeout_config,
-        )
+        rate_limit_retries_left = self._config.max_rate_limit_retries
+
+        while True:
+            resp = await self._session.request(
+                method=verb,
+                url=url,
+                headers=request_options.headers,
+                data=request_options.data,
+                proxy=proxy,
+                timeout=timeout_config,
+            )
+
+            if resp.status == RATE_LIMIT_STATUS_CODE and rate_limit_retries_left > 0:
+                rate_limit_retries_left -= 1
+                wait_seconds = parse_retry_after_seconds(resp.headers)
+                resp.release()
+                await sleep(wait_seconds)
+                continue
+
+            break
 
         try:
             if resp.status >= 400:

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter.py
@@ -121,11 +121,11 @@ class Transporter(BaseTransporter):
                 last_correlation_id = correlation_id or last_correlation_id
 
                 if (
-                    self._retry_strategy.is_rate_limited(response)
+                    response.status_code == RATE_LIMIT_STATUS_CODE
                     and rate_limit_retries_left > 0
                 ):
                     rate_limit_retries_left -= 1
-                    await sleep(self._retry_strategy.rate_limit_wait_seconds(response))
+                    await sleep(parse_retry_after_seconds(response.headers))
                     continue
 
                 break

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
@@ -1,6 +1,7 @@
 from gzip import compress as gzip_compress
 from json import dumps, loads
 from sys import version_info
+from time import sleep
 from typing import Iterator, Optional
 
 from requests import Request, Session, Timeout
@@ -23,7 +24,12 @@ from algoliasearch.http.exceptions import (
 from algoliasearch.http.hosts import Host
 from algoliasearch.http.request_id import get_correlation_id, with_request_id
 from algoliasearch.http.request_options import RequestOptions
-from algoliasearch.http.retry import RetryOutcome, RetryStrategy
+from algoliasearch.http.retry import (
+    RATE_LIMIT_STATUS_CODE,
+    RetryOutcome,
+    RetryStrategy,
+    parse_retry_after_seconds,
+)
 from algoliasearch.http.sse import ServerSentEvent, iter_sse_events
 from algoliasearch.http.verb import Verb
 
@@ -76,6 +82,7 @@ class TransporterSync(BaseTransporter):
             request_options.headers["content-encoding"] = "gzip"
 
         last_correlation_id = None
+        rate_limit_retries_left = self._config.max_rate_limit_retries
 
         for host in self._retry_strategy.valid_hosts(self._hosts):
             url = self.build_url(host, path)
@@ -90,41 +97,52 @@ class TransporterSync(BaseTransporter):
                 )
             )
 
-            try:
-                connect_timeout = (
-                    request_options.timeouts["connect"] * (host.retry_count + 1)
-                ) / 1000
-                read_timeout = self._timeout / 1000
+            while True:
+                try:
+                    connect_timeout = (
+                        request_options.timeouts["connect"] * (host.retry_count + 1)
+                    ) / 1000
+                    read_timeout = self._timeout / 1000
 
-                resp = self._session.send(
-                    req,
-                    timeout=(connect_timeout, read_timeout),
-                    proxies=proxies,
-                )
+                    resp = self._session.send(
+                        req,
+                        timeout=(connect_timeout, read_timeout),
+                        proxies=proxies,
+                    )
 
-                response = ApiResponse(
-                    verb=verb,
-                    path=path,
-                    url=url,
-                    host=host.url,
-                    status_code=resp.status_code,
-                    headers=resp.headers,  # type: ignore # insensitive dict is still a dict
-                    data=resp.text,
-                    raw_data=resp.text,
-                    error_message=str(resp.reason),
-                )
-            except Timeout as e:
-                response = ApiResponse(
-                    verb=verb,
-                    path=path,
-                    url=url,
-                    host=host.url,
-                    error_message=str(e),
-                    is_timed_out_error=True,
-                )
+                    response = ApiResponse(
+                        verb=verb,
+                        path=path,
+                        url=url,
+                        host=host.url,
+                        status_code=resp.status_code,
+                        headers=resp.headers,  # type: ignore # insensitive dict is still a dict
+                        data=resp.text,
+                        raw_data=resp.text,
+                        error_message=str(resp.reason),
+                    )
+                except Timeout as e:
+                    response = ApiResponse(
+                        verb=verb,
+                        path=path,
+                        url=url,
+                        host=host.url,
+                        error_message=str(e),
+                        is_timed_out_error=True,
+                    )
 
-            correlation_id = get_correlation_id(response.headers)
-            last_correlation_id = correlation_id or last_correlation_id
+                correlation_id = get_correlation_id(response.headers)
+                last_correlation_id = correlation_id or last_correlation_id
+
+                if (
+                    self._retry_strategy.is_rate_limited(response)
+                    and rate_limit_retries_left > 0
+                ):
+                    rate_limit_retries_left -= 1
+                    sleep(self._retry_strategy.rate_limit_wait_seconds(response))
+                    continue
+
+                break
 
             decision = self._retry_strategy.decide(host, response)
 
@@ -183,12 +201,27 @@ class TransporterSync(BaseTransporter):
         connect_timeout = request_options.timeouts["connect"] / 1000
         read_timeout = self._timeout / 1000
 
-        resp = self._session.send(
-            req,
-            timeout=(connect_timeout, read_timeout),
-            proxies=proxies,
-            stream=True,
-        )
+        rate_limit_retries_left = self._config.max_rate_limit_retries
+
+        while True:
+            resp = self._session.send(
+                req,
+                timeout=(connect_timeout, read_timeout),
+                proxies=proxies,
+                stream=True,
+            )
+
+            if (
+                resp.status_code == RATE_LIMIT_STATUS_CODE
+                and rate_limit_retries_left > 0
+            ):
+                rate_limit_retries_left -= 1
+                wait_seconds = parse_retry_after_seconds(resp.headers)
+                resp.close()
+                sleep(wait_seconds)
+                continue
+
+            break
 
         try:
             if resp.status_code >= 400:

--- a/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
+++ b/clients/algoliasearch-client-python/algoliasearch/http/transporter_sync.py
@@ -135,11 +135,11 @@ class TransporterSync(BaseTransporter):
                 last_correlation_id = correlation_id or last_correlation_id
 
                 if (
-                    self._retry_strategy.is_rate_limited(response)
+                    response.status_code == RATE_LIMIT_STATUS_CODE
                     and rate_limit_retries_left > 0
                 ):
                     rate_limit_retries_left -= 1
-                    sleep(self._retry_strategy.rate_limit_wait_seconds(response))
+                    sleep(parse_retry_after_seconds(response.headers))
                     continue
 
                 break

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -12,7 +12,7 @@ import { assertChunkWrapperValid } from './testServer/chunkWrapper.ts';
 import { assertNeverCalledServerWasNotCalled, assertValidErrors } from './testServer/error.ts';
 import { startTestServer } from './testServer/index.ts';
 import { assertPushMockValid } from './testServer/pushMock.ts';
-import { assertValidRateLimitRetries } from './testServer/rateLimit.ts';
+import { assertValidRateLimitRetries, rateLimitRuns } from './testServer/rateLimit.ts';
 import { assertValidReplaceAllObjects } from './testServer/replaceAllObjects.ts';
 import { assertValidReplaceAllObjectsFailed } from './testServer/replaceAllObjectsFailed.ts';
 import { assertValidReplaceAllObjectsScopes } from './testServer/replaceAllObjectsScopes.ts';
@@ -206,7 +206,7 @@ export async function runCts(
     assertValidWaitForApiKey(languages.length - skip('dart'));
     assertPushMockValid(languages.length);
     assertValidChunkedPushWait(languages.length);
-    assertValidRateLimitRetries(languages.includes('javascript'));
+    assertValidRateLimitRetries(rateLimitRuns(languages));
   }
   if (withBenchmarkServer) {
     printBenchmarkReport();

--- a/scripts/cts/testServer/rateLimit.ts
+++ b/scripts/cts/testServer/rateLimit.ts
@@ -33,25 +33,44 @@ function langState(lang: string): LangState {
 
 function assertDelay(timestamps: number[], expectedMs: number): void {
   expect(timestamps.length).to.be.at.least(2);
-  expect(timestamps[1] - timestamps[0]).to.be.closeTo(expectedMs, 400);
+
+  for (let i = 0; i + 1 < timestamps.length; i += 2) {
+    expect(timestamps[i + 1] - timestamps[i]).to.be.closeTo(expectedMs, 400);
+  }
 }
 
-export function assertValidRateLimitRetries(javascriptRan: boolean): void {
-  // Only JavaScript implements 429 retries so far, but any language that hit the mock is validated.
-  if (javascriptRan) {
+// Languages that implement 429 wait-and-retry. Append yours when the port lands.
+const RATE_LIMIT_LANGUAGES = ['javascript', 'python'];
+
+// Languages whose client CTS suite is emitted more than once, so every mock
+// route is hit once per mode (python: async + sync, see TestsClient.java:25).
+const DOUBLE_RUN_LANGUAGES = ['python'];
+
+export function rateLimitRuns(languages: string[]): Record<string, number> {
+  return Object.fromEntries(
+    languages
+      .filter((lang) => RATE_LIMIT_LANGUAGES.includes(lang))
+      .map((lang) => [lang, DOUBLE_RUN_LANGUAGES.includes(lang) ? 2 : 1]),
+  );
+}
+
+export function assertValidRateLimitRetries(runs: Record<string, number>): void {
+  if (Object.keys(runs).length > 0) {
     expect(Object.keys(state).length, 'rate-limit mock was never hit').to.be.at.least(1);
   }
 
   for (const [lang, langState] of Object.entries(state)) {
+    const runCount = runs[lang] ?? 1;
+
     // 2s proves Retry-After was parsed: the fallback wait for a missing header is 1s.
-    expect(langState.retryAfterCalls, `${lang} retry-after calls`).to.equal(2);
+    expect(langState.retryAfterCalls, `${lang} retry-after calls`).to.equal(2 * runCount);
     assertDelay(langState.retryAfterTimestamps, 2000);
 
-    expect(langState.missingHeaderCalls, `${lang} missing-header calls`).to.equal(2);
+    expect(langState.missingHeaderCalls, `${lang} missing-header calls`).to.equal(2 * runCount);
     assertDelay(langState.missingHeaderTimestamps, 1000);
 
-    expect(langState.exhaustedCalls, `${lang} exhausted calls`).to.equal(4);
-    expect(langState.zeroRetriesCalls, `${lang} zero-retries calls`).to.equal(1);
+    expect(langState.exhaustedCalls, `${lang} exhausted calls`).to.equal(4 * runCount);
+    expect(langState.zeroRetriesCalls, `${lang} zero-retries calls`).to.equal(1 * runCount);
   }
 
   for (const [lang, callCount] of Object.entries(neverCalledState)) {
@@ -65,7 +84,7 @@ function addRoutes(app: express.Express): void {
     current.retryAfterCalls++;
     current.retryAfterTimestamps.push(Date.now());
 
-    if (current.retryAfterCalls === 1) {
+    if (current.retryAfterCalls % 2 === 1) {
       res.setHeader('Retry-After', '2');
       res.status(429).json({ message: 'Too many requests' });
       return;
@@ -79,7 +98,7 @@ function addRoutes(app: express.Express): void {
     current.missingHeaderCalls++;
     current.missingHeaderTimestamps.push(Date.now());
 
-    if (current.missingHeaderCalls === 1) {
+    if (current.missingHeaderCalls % 2 === 1) {
       res.status(429).json({ message: 'Too many requests' });
       return;
     }

--- a/scripts/cts/testServer/rateLimit.ts
+++ b/scripts/cts/testServer/rateLimit.ts
@@ -39,11 +39,10 @@ function assertDelay(timestamps: number[], expectedMs: number): void {
   }
 }
 
-// Languages that implement 429 wait-and-retry. Append yours when the port lands.
+// Languages that implement 429 wait-and-retry.
 const RATE_LIMIT_LANGUAGES = ['javascript', 'python'];
 
-// Languages whose client CTS suite is emitted more than once, so every mock
-// route is hit once per mode (python: async + sync, see TestsClient.java:25).
+// Languages whose client CTS suite runs once per mode (python: async + sync, see TestsClient.java:25).
 const DOUBLE_RUN_LANGUAGES = ['python'];
 
 export function rateLimitRuns(languages: string[]): Record<string, number> {

--- a/scripts/cts/testServer/rateLimit.ts
+++ b/scripts/cts/testServer/rateLimit.ts
@@ -42,7 +42,7 @@ function assertDelay(timestamps: number[], expectedMs: number): void {
 // Languages that implement 429 wait-and-retry.
 const RATE_LIMIT_LANGUAGES = ['javascript', 'python'];
 
-// Languages whose client CTS suite runs once per mode (python: async + sync, see TestsClient.java:25).
+// Languages whose client CTS suite runs once per mode (python: async + sync, see withSyncTests in TestsClient.java).
 const DOUBLE_RUN_LANGUAGES = ['python'];
 
 export function rateLimitRuns(languages: string[]): Record<string, number> {
@@ -78,6 +78,8 @@ export function assertValidRateLimitRetries(runs: Record<string, number>): void 
 }
 
 function addRoutes(app: express.Express): void {
+  // The % 2 alternation assumes each language's runs are sequential (a single test file per
+  // mode), so a 429→200 pair never interleaves with another run's calls in assertDelay.
   app.get('/1/test/rate-limit/retry-after/:lang', (req, res) => {
     const current = langState(req.params.lang);
     current.retryAfterCalls++;

--- a/templates/python/tests/client/createClient.mustache
+++ b/templates/python/tests/client/createClient.mustache
@@ -11,4 +11,7 @@ _config = {{#lambda.pascalcase}}{{clientPrefix}}Config{{/lambda.pascalcase}}("{{
         {{#gzipEncoding}}
         {{#isError}}    {{/isError}}_config.compression_type = "gzip"
         {{/gzipEncoding}}
+        {{#hasMaxRateLimitRetries}}
+        {{#isError}}    {{/isError}}_config.max_rate_limit_retries = {{maxRateLimitRetries}}
+        {{/hasMaxRateLimitRetries}}
         {{#isError}}    {{/isError}}_client = {{#lambda.pascalcase}}{{{client}}}{{/lambda.pascalcase}}{{#isSyncClient}}Sync{{/isSyncClient}}.create_with_config(config=_config{{#useEchoRequester}}, transporter=EchoTransporter{{#isSyncClient}}Sync{{/isSyncClient}}(_config){{/useEchoRequester}})

--- a/tests/CTS/client/ingestion/api.json
+++ b/tests/CTS/client/ingestion/api.json
@@ -1,7 +1,7 @@
 [
   {
     "testName": "can handle HTML error",
-    "skipLanguages": ["javascript"],
+    "skipLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -30,7 +30,6 @@
             "java": "Status Code: 429 - Too Many Requests",
             "kotlin": "Client request\\\\(GET http://%localhost%:6676/1/html-error\\\\) invalid: 429 Too Many Requests. Text: \\\"<html><body>429 Too Many Requests</body></html>\\\"",
             "php": "429: Too Many Requests",
-            "python": "Too Many Requests",
             "ruby": "429: Too Many Requests",
             "scala": "<html><body>429 Too Many Requests</body></html>",
             "swift": "HTTP error: Status code: 429 Message: No message",
@@ -42,7 +41,7 @@
   },
   {
     "testName": "can handle HTML error when rate-limit retries are disabled",
-    "onlyLanguages": ["javascript"],
+    "onlyLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -67,7 +66,8 @@
         },
         "expected": {
           "error": {
-            "javascript": "Too Many Requests"
+            "javascript": "Too Many Requests",
+            "python": "Too Many Requests"
           }
         }
       }

--- a/tests/CTS/client/search/api.json
+++ b/tests/CTS/client/search/api.json
@@ -418,7 +418,7 @@
   },
   {
     "testName": "retries 429 on the same host using Retry-After",
-    "onlyLanguages": ["javascript"],
+    "onlyLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -453,7 +453,7 @@
   },
   {
     "testName": "retries 429 with a 1s wait when Retry-After is missing",
-    "onlyLanguages": ["javascript"],
+    "onlyLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -485,7 +485,7 @@
   },
   {
     "testName": "returns 429 after maxRateLimitRetries is used up",
-    "onlyLanguages": ["javascript"],
+    "onlyLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -508,7 +508,8 @@
         },
         "expected": {
           "error": {
-            "javascript": "Too many requests"
+            "javascript": "Too many requests",
+            "python": "Too many requests"
           }
         }
       }
@@ -516,7 +517,7 @@
   },
   {
     "testName": "fails on the first 429 when maxRateLimitRetries is 0",
-    "onlyLanguages": ["javascript"],
+    "onlyLanguages": ["javascript", "python"],
     "autoCreateClient": false,
     "steps": [
       {
@@ -540,7 +541,8 @@
         },
         "expected": {
           "error": {
-            "javascript": "Too many requests"
+            "javascript": "Too many requests",
+            "python": "Too many requests"
           }
         }
       }

--- a/tests/output/python/tests/manual/test_rate_limit_retry.py
+++ b/tests/output/python/tests/manual/test_rate_limit_retry.py
@@ -1,0 +1,536 @@
+from contextlib import contextmanager
+from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple
+
+from multidict import CIMultiDict
+from requests import PreparedRequest, Response, Session
+from requests.structures import CaseInsensitiveDict
+
+from algoliasearch.http import transporter as async_transporter
+from algoliasearch.http import transporter_sync as sync_transporter
+from algoliasearch.http.base_config import BaseConfig
+from algoliasearch.http.exceptions import RequestException
+from algoliasearch.http.hosts import CallType, Host, HostsCollection
+from algoliasearch.http.request_options import RequestOptions
+from algoliasearch.http.retry import (
+    DEFAULT_RATE_LIMIT_WAIT_SECONDS,
+    parse_retry_after_seconds,
+)
+from algoliasearch.http.transporter import Transporter
+from algoliasearch.http.transporter_sync import TransporterSync
+from algoliasearch.http.verb import Verb
+
+RATE_LIMITED_BODY = '{"message":"Too many requests"}'
+SUCCESS_BODY = '{"message":"ok rate limit retry"}'
+SSE_BODY = "data: hello\n\n"
+
+
+def create_config(
+    hosts: int = 1, max_rate_limit_retries: Optional[int] = None
+) -> BaseConfig:
+    config = BaseConfig("test-app", "test-key")
+    if max_rate_limit_retries is not None:
+        config.max_rate_limit_retries = max_rate_limit_retries
+    config.hosts = HostsCollection(
+        [
+            Host("localhost{}".format(index), accept=CallType.READ | CallType.WRITE)
+            for index in range(hosts)
+        ]
+    )
+    return config
+
+
+class FakeSyncResponse(Response):
+    def __init__(
+        self,
+        status_code: int,
+        retry_after: Optional[str] = None,
+        body: str = SUCCESS_BODY,
+    ) -> None:
+        super().__init__()
+        self.status_code = status_code
+        self.headers = CaseInsensitiveDict()
+        if retry_after is not None:
+            self.headers["Retry-After"] = retry_after
+        self.reason = "Too Many Requests" if status_code == 429 else "OK"
+        self.closes = 0
+        self._body = body
+
+    @property
+    def text(self) -> str:
+        return self._body
+
+    def iter_content(  # type: ignore[override]
+        self, chunk_size: Optional[int] = 1, decode_unicode: bool = False
+    ) -> Iterator[bytes]:
+        _ = chunk_size
+        _ = decode_unicode
+        yield self._body.encode("utf-8")
+
+    def close(self) -> None:
+        self.closes += 1
+
+
+class RecordingSyncSession(Session):
+    def __init__(self, responses: List[FakeSyncResponse]) -> None:
+        super().__init__()
+        self._responses = list(responses)
+        self.sent_urls: List[str] = []
+
+    def send(self, request: PreparedRequest, **kwargs: Any) -> Response:  # type: ignore # the tests only need the recorded request
+        _ = kwargs
+        self.sent_urls.append(request.url or "")
+        return self._responses.pop(0)
+
+
+class AsyncByteStream:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def _iter(self) -> AsyncIterator[bytes]:
+        yield self._payload
+
+    def iter_any(self) -> AsyncIterator[bytes]:
+        return self._iter()
+
+
+class FakeAsyncResponse:
+    def __init__(
+        self,
+        status: int,
+        retry_after: Optional[str] = None,
+        body: str = SUCCESS_BODY,
+    ) -> None:
+        self.status = status
+        self.headers: CIMultiDict[str] = CIMultiDict()
+        if retry_after is not None:
+            self.headers["Retry-After"] = retry_after
+        self.reason = "Too Many Requests" if status == 429 else "OK"
+        self.releases = 0
+        self.content = AsyncByteStream(body.encode("utf-8"))
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+    def release(self) -> None:
+        self.releases += 1
+
+
+class FakeRequestContext:
+    def __init__(self, response: FakeAsyncResponse) -> None:
+        self._response = response
+
+    async def _resolve(self) -> FakeAsyncResponse:
+        return self._response
+
+    def __await__(self) -> Any:
+        return self._resolve().__await__()
+
+    async def __aenter__(self) -> FakeAsyncResponse:
+        return self._response
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class RecordingAsyncSession:
+    def __init__(self, responses: List[FakeAsyncResponse]) -> None:
+        self._responses = list(responses)
+        self.sent_urls: List[str] = []
+
+    def request(self, **kwargs: Any) -> FakeRequestContext:
+        self.sent_urls.append(str(kwargs.get("url", "")))
+        return FakeRequestContext(self._responses.pop(0))
+
+
+@contextmanager
+def recorded_sync_sleep() -> Iterator[List[float]]:
+    waits: List[float] = []
+    original = sync_transporter.sleep
+
+    def fake_sleep(seconds: float) -> None:
+        waits.append(seconds)
+
+    sync_transporter.sleep = fake_sleep  # type: ignore[assignment]
+    try:
+        yield waits
+    finally:
+        sync_transporter.sleep = original  # type: ignore[assignment]
+
+
+@contextmanager
+def recorded_async_sleep() -> Iterator[List[float]]:
+    waits: List[float] = []
+    original = async_transporter.sleep
+
+    async def fake_sleep(seconds: float) -> None:
+        waits.append(seconds)
+
+    async_transporter.sleep = fake_sleep  # type: ignore[assignment]
+    try:
+        yield waits
+    finally:
+        async_transporter.sleep = original  # type: ignore[assignment]
+
+
+def build_sync_transporter(
+    config: BaseConfig, responses: List[FakeSyncResponse]
+) -> Tuple[TransporterSync, RecordingSyncSession]:
+    transporter = TransporterSync(config)
+    session = RecordingSyncSession(responses)
+    transporter._session = session
+    return transporter, session
+
+
+def build_async_transporter(
+    config: BaseConfig, responses: List[FakeAsyncResponse]
+) -> Tuple[Transporter, RecordingAsyncSession]:
+    transporter = Transporter(config)
+    session = RecordingAsyncSession(responses)
+    transporter._session = session  # type: ignore[assignment]
+    return transporter, session
+
+
+def test_the_default_budget_is_three_retries() -> None:
+    assert BaseConfig("test-app", "test-key").max_rate_limit_retries == 3
+
+
+def test_retry_after_honors_only_positive_whole_seconds() -> None:
+    assert parse_retry_after_seconds({"retry-after": "2"}) == 2.0
+    assert parse_retry_after_seconds({"retry-after": " 3 "}) == 3.0
+    assert parse_retry_after_seconds({"retry-after": "86400"}) == 86400.0
+
+    assert parse_retry_after_seconds(None) == DEFAULT_RATE_LIMIT_WAIT_SECONDS
+    assert parse_retry_after_seconds({}) == DEFAULT_RATE_LIMIT_WAIT_SECONDS
+
+    for value in [
+        "",
+        "   ",
+        "0",
+        "-1",
+        "1.5",
+        "+2",
+        "120abc",
+        "Wed, 21 Oct 2015 07:28:00 GMT",
+    ]:
+        assert (
+            parse_retry_after_seconds({"retry-after": value})
+            == DEFAULT_RATE_LIMIT_WAIT_SECONDS
+        ), value
+
+
+def test_retry_after_is_read_whatever_the_header_casing() -> None:
+    assert parse_retry_after_seconds(CaseInsensitiveDict({"Retry-After": "5"})) == 5.0
+    assert parse_retry_after_seconds(CIMultiDict({"RETRY-AFTER": "5"})) == 5.0
+
+
+def test_sync_waits_and_retries_the_same_host_on_429() -> None:
+    config = create_config(hosts=2)
+    transporter, session = build_sync_transporter(
+        config,
+        [
+            FakeSyncResponse(429, retry_after="2", body=RATE_LIMITED_BODY),
+            FakeSyncResponse(200),
+        ],
+    )
+
+    with recorded_sync_sleep() as waits:
+        response = transporter.request(
+            verb=Verb.GET,
+            path="/test",
+            request_options=RequestOptions(config).merge(),
+            use_read_transporter=True,
+        )
+
+    assert response.status_code == 200
+    assert waits == [2.0]
+    assert session.sent_urls == ["https://localhost0/test"] * 2
+
+    host = transporter._hosts[0]
+    assert host.up is True
+    assert host.retry_count == 0
+
+
+def test_sync_falls_back_to_one_second_without_the_header() -> None:
+    config = create_config()
+    transporter, session = build_sync_transporter(
+        config,
+        [FakeSyncResponse(429, body=RATE_LIMITED_BODY), FakeSyncResponse(200)],
+    )
+
+    with recorded_sync_sleep() as waits:
+        transporter.request(
+            verb=Verb.GET,
+            path="/test",
+            request_options=RequestOptions(config).merge(),
+            use_read_transporter=True,
+        )
+
+    assert waits == [1.0]
+    assert len(session.sent_urls) == 2
+
+
+def test_sync_raises_once_the_budget_is_spent() -> None:
+    config = create_config()
+    transporter, session = build_sync_transporter(
+        config,
+        [FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)] * 4,
+    )
+
+    with recorded_sync_sleep() as waits:
+        try:
+            transporter.request(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert str(exception) == "Too many requests"
+            assert exception.status_code == 429
+
+    assert waits == [1.0, 1.0, 1.0]
+    assert len(session.sent_urls) == 4
+    assert transporter._hosts[0].up is True
+    assert transporter._hosts[0].retry_count == 0
+
+
+def test_sync_fails_on_the_first_429_when_retries_are_disabled() -> None:
+    config = create_config(max_rate_limit_retries=0)
+    transporter, session = build_sync_transporter(
+        config, [FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)]
+    )
+
+    with recorded_sync_sleep() as waits:
+        try:
+            transporter.request(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert exception.status_code == 429
+
+    assert waits == []
+    assert len(session.sent_urls) == 1
+
+
+def test_sync_does_not_fail_over_to_another_host_on_429() -> None:
+    config = create_config(hosts=2)
+    transporter, session = build_sync_transporter(
+        config,
+        [
+            FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY),
+            FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY),
+            FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY),
+            FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY),
+        ],
+    )
+
+    with recorded_sync_sleep() as waits:
+        try:
+            transporter.request(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException:
+            pass
+
+    assert waits == [1.0, 1.0, 1.0]
+    assert session.sent_urls == ["https://localhost0/test"] * 4
+
+
+def test_sync_request_stream_waits_and_retries_on_429() -> None:
+    config = create_config()
+    rate_limited = FakeSyncResponse(429, retry_after="2", body=RATE_LIMITED_BODY)
+    transporter, session = build_sync_transporter(
+        config, [rate_limited, FakeSyncResponse(200, body=SSE_BODY)]
+    )
+
+    with recorded_sync_sleep() as waits:
+        events = list(
+            transporter.request_stream(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+        )
+
+    assert [event.data for event in events] == ["hello"]
+    assert waits == [2.0]
+    assert len(session.sent_urls) == 2
+    assert rate_limited.closes == 1
+
+
+def test_sync_request_stream_raises_once_the_budget_is_spent() -> None:
+    config = create_config(max_rate_limit_retries=1)
+    transporter, session = build_sync_transporter(
+        config,
+        [FakeSyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)] * 2,
+    )
+
+    with recorded_sync_sleep() as waits:
+        try:
+            list(
+                transporter.request_stream(
+                    verb=Verb.GET,
+                    path="/test",
+                    request_options=RequestOptions(config).merge(),
+                    use_read_transporter=True,
+                )
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert exception.status_code == 429
+
+    assert waits == [1.0]
+    assert len(session.sent_urls) == 2
+
+
+async def test_async_waits_and_retries_the_same_host_on_429() -> None:
+    config = create_config(hosts=2)
+    transporter, session = build_async_transporter(
+        config,
+        [
+            FakeAsyncResponse(429, retry_after="2", body=RATE_LIMITED_BODY),
+            FakeAsyncResponse(200),
+        ],
+    )
+
+    with recorded_async_sleep() as waits:
+        response = await transporter.request(
+            verb=Verb.GET,
+            path="/test",
+            request_options=RequestOptions(config).merge(),
+            use_read_transporter=True,
+        )
+
+    assert response.status_code == 200
+    assert waits == [2.0]
+    assert session.sent_urls == ["https://localhost0/test"] * 2
+
+    host = transporter._hosts[0]
+    assert host.up is True
+    assert host.retry_count == 0
+
+
+async def test_async_falls_back_to_one_second_without_the_header() -> None:
+    config = create_config()
+    transporter, session = build_async_transporter(
+        config,
+        [FakeAsyncResponse(429, body=RATE_LIMITED_BODY), FakeAsyncResponse(200)],
+    )
+
+    with recorded_async_sleep() as waits:
+        await transporter.request(
+            verb=Verb.GET,
+            path="/test",
+            request_options=RequestOptions(config).merge(),
+            use_read_transporter=True,
+        )
+
+    assert waits == [1.0]
+    assert len(session.sent_urls) == 2
+
+
+async def test_async_raises_once_the_budget_is_spent() -> None:
+    config = create_config()
+    transporter, session = build_async_transporter(
+        config,
+        [FakeAsyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)] * 4,
+    )
+
+    with recorded_async_sleep() as waits:
+        try:
+            await transporter.request(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert str(exception) == "Too many requests"
+            assert exception.status_code == 429
+
+    assert waits == [1.0, 1.0, 1.0]
+    assert len(session.sent_urls) == 4
+    assert transporter._hosts[0].up is True
+    assert transporter._hosts[0].retry_count == 0
+
+
+async def test_async_fails_on_the_first_429_when_retries_are_disabled() -> None:
+    config = create_config(max_rate_limit_retries=0)
+    transporter, session = build_async_transporter(
+        config, [FakeAsyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)]
+    )
+
+    with recorded_async_sleep() as waits:
+        try:
+            await transporter.request(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert exception.status_code == 429
+
+    assert waits == []
+    assert len(session.sent_urls) == 1
+
+
+async def test_async_request_stream_waits_and_retries_on_429() -> None:
+    config = create_config()
+    rate_limited = FakeAsyncResponse(429, retry_after="2", body=RATE_LIMITED_BODY)
+    transporter, session = build_async_transporter(
+        config, [rate_limited, FakeAsyncResponse(200, body=SSE_BODY)]
+    )
+
+    with recorded_async_sleep() as waits:
+        events = [
+            event
+            async for event in transporter.request_stream(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            )
+        ]
+
+    assert [event.data for event in events] == ["hello"]
+    assert waits == [2.0]
+    assert len(session.sent_urls) == 2
+    assert rate_limited.releases == 1
+
+
+async def test_async_request_stream_raises_once_the_budget_is_spent() -> None:
+    config = create_config(max_rate_limit_retries=1)
+    transporter, session = build_async_transporter(
+        config,
+        [FakeAsyncResponse(429, retry_after="1", body=RATE_LIMITED_BODY)] * 2,
+    )
+
+    with recorded_async_sleep() as waits:
+        try:
+            async for _ in transporter.request_stream(
+                verb=Verb.GET,
+                path="/test",
+                request_options=RequestOptions(config).merge(),
+                use_read_transporter=True,
+            ):
+                pass
+            raise AssertionError("expected a RequestException")
+        except RequestException as exception:
+            assert exception.status_code == 429
+
+    assert waits == [1.0]
+    assert len(session.sent_urls) == 2

--- a/tests/output/python/tests/manual/test_rate_limit_retry.py
+++ b/tests/output/python/tests/manual/test_rate_limit_retry.py
@@ -211,6 +211,7 @@ def test_retry_after_honors_only_positive_whole_seconds() -> None:
         "1.5",
         "+2",
         "120abc",
+        "٦٠",
         "Wed, 21 Oct 2015 07:28:00 GMT",
     ]:
         assert (

--- a/website/docs/add-a-new-language.md
+++ b/website/docs/add-a-new-language.md
@@ -60,9 +60,10 @@ The constructor of the client can be edited (from the `.mustache` files) to acce
 
 The retry strategy cannot be generated and needs to be implemented outside of the generated client folder. You can achieve this by creating a `utils` (_or any naming that you find relevant_) folder and add a transporter and retry strategy logic to it.
 
-HTTP 429 is not a host-failover case. The JavaScript transporter waits on the **same host** (`Retry-After` in whole seconds, or 1 second if the header is missing or invalid) up to `maxRateLimitRetries` (default 3; `0` fails on the first 429). Other languages still treat 429 as a non-retryable 4xx until that behavior is ported. 5xx, timeouts, and network errors still try other hosts.
+HTTP 429 is not a host-failover case. The JavaScript and Python transporters wait on the **same host** (`Retry-After` in whole seconds, or 1 second if the header is missing or invalid) up to `maxRateLimitRetries` / `max_rate_limit_retries` (default 3; `0` fails on the first 429). Other languages still treat 429 as a non-retryable 4xx until that behavior is ported. 5xx, timeouts, and network errors still try other hosts.
 
 - [429 wait/retry on the JavaScript transporter](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-javascript/packages/client-common/src/transporter/createTransporter.ts)
+- [429 wait/retry on the Python transporter](https://github.com/algolia/api-clients-automation/blob/main/clients/algoliasearch-client-python/algoliasearch/http/transporter.py)
 - [Host failover on the PHP client](https://github.com/algolia/api-clients-automation/tree/main/clients/algoliasearch-client-php/lib/RetryStrategy)
 
 ### Different client hosts


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [API-548](https://algolia.atlassian.net/browse/API-548)

Mirrors #6965 for the Python client: a 429 is no longer a plain non-retryable 4xx that fails on the spot. Both transporters — `Transporter` (aiohttp) and `TransporterSync` (requests) — now wait for the duration the server asks for in `Retry-After` and reissue against the **same** host, up to `config.max_rate_limit_retries` times (default `3`), before the 429 surfaces as the usual `RequestException`. The host is never marked down and `retry_count` is never bumped, so a throttled app no longer looks like an outage and no longer pushes its load onto sibling hosts that share the same quota.

### Changes included:

- `algoliasearch/http/retry.py`: `RATE_LIMIT_STATUS_CODE`, `DEFAULT_RATE_LIMIT_WAIT_SECONDS`, and a `parse_retry_after_seconds(headers)` helper the transporters call directly. `Retry-After` is honored only as a positive whole number of seconds; missing, empty, `0`, negative, HTTP-date and junk values all wait 1 second. There is no upper clamp — the server's own value is the source of truth. `retry.py` stays sleep-free and returns a duration; the transporters own the sleep primitive.
- `algoliasearch/http/transporter.py` and `transporter_sync.py`: an inner same-host loop around the send in `request`, and around `sendStream`'s equivalent in `request_stream`. The rate-limit check sits *before* `RetryStrategy.decide`, so it never touches the host-state and connect-timeout escalation machinery that the 5xx path drives. The budget is initialized once per outer call and shared across every wait within it. The async path awaits `asyncio.sleep`; the sync path uses `time.sleep`.
- `algoliasearch/http/base_config.py`: `max_rate_limit_retries: int = 3` on `BaseConfig`, so every generated per-client config inherits it through `super().__init__`.
- `templates/python/tests/client/createClient.mustache`: renders `_config.max_rate_limit_retries = N` so the CTS can build a client with the budget disabled.
- Opted Python into the four shared rate-limit CTS tests in `tests/CTS/client/search/api.json`, and moved it onto the `maxRateLimitRetries: 0` clone of the ingestion HTML-error test — with retries on, that 429 now costs four requests and ~3s, so the original timing no longer holds.
- Reworked the shared rate-limit mock (`scripts/cts/testServer/rateLimit.ts`). Python is the one language whose client CTS is emitted twice — `TestSearchClient` and `TestSearchClientSync` from the same `{{#modes}}` template — and the mock keys its state only by language, so the previous one-shot routes handed the second run a `200` on its first call (never exercising the retry) and the exact call-count assertions could not hold. The two stateful routes now alternate 429→200 on every pair of calls, `assertDelay` checks each pair rather than only the first, and `assertValidRateLimitRetries` takes a per-language runs map (`rateLimitRuns`) and multiplies its four expectations. Both Python modes genuinely exercise the wait, with no coverage hole.

### Usage

```python
# async
config = SearchConfig(app_id, api_key)
config.max_rate_limit_retries = 5
async with SearchClient.create_with_config(config) as client:
    await client.search_single_index("my-index", {"query": "shoes"})

# sync — no waiting, fail on the first 429
config = SearchConfig(app_id, api_key)
config.max_rate_limit_retries = 0
with SearchClientSync.create_with_config(config) as client:
    client.search_single_index("my-index", {"query": "shoes"})
```

No API surface changes, but callers do see a behavior change worth noticing: a call that hits a 429 used to raise `RequestException` immediately and now waits up to three times first (1s each by default, or whatever `Retry-After` says, uncapped), costing up to four requests instead of one. On the sync client that wait blocks the calling thread. Anything that relied on a fast 429 failure and does its own backoff — Celery/RQ workers, request-scoped WSGI handlers, one-shot scripts — should set `config.max_rate_limit_retries = 0`.

## 🧪 Test

- `tests/output/python/tests/manual/test_rate_limit_retry.py` (new, 16 tests) covers what the CTS cannot reach: the full `Retry-After` parse table including the malformed values, and both transporters — `request` and `request_stream` — driven through hand-rolled aiohttp and requests session fakes with the sleep primitive stubbed, so the suite pays no real seconds. It asserts the wait duration, that every retry goes to the same host with a second host available, that `host.up` stays `True` and `host.retry_count` stays `0` across a 429 round, that the 429 raises once the budget is spent, and that `max_rate_limit_retries = 0` fails on the first response.
- The four shared CTS tests (valid `Retry-After`, missing header, budget exhausted, budget disabled) plus the never-called-host guard now run for Python. Because the client suite runs twice, Python pays the mock's waits twice — roughly 12s added to the client CTS wall clock.


[API-548]: https://algolia.atlassian.net/browse/API-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
