### PR TITLE
fix(swift): make the CocoaPods release step idempotent

### DIFF
--- a/clients/algoliasearch-client-swift/.github/workflows/release.yml
+++ b/clients/algoliasearch-client-swift/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Publish on CocoaPods
         run: |
           set -eo pipefail
+          version=$(sed -n "s/.*s\.version = '\(.*\)'.*/\1/p" AlgoliaSearchClient.podspec)
+          if curl -sf https://trunk.cocoapods.org/api/v1/pods/AlgoliaSearchClient | jq -e --arg v "$version" '.versions[] | select(.name == $v)' > /dev/null; then
+            echo "AlgoliaSearchClient $version is already on CocoaPods, skipping the push"
+            exit 0
+          fi
           pod trunk push --allow-warnings --verbose AlgoliaSearchClient.podspec
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: none

Retrying the swift release workflow fails with "Unable to accept duplicate entry" when a previous attempt already pushed the pod, which is exactly what happened for 9.49.0 today (attempt 1 published, attempt 2 went red). This makes the publish step idempotent: it queries the CocoaPods trunk API for the podspec version and skips the push when it is already live.

### Changes included:

- `clients/algoliasearch-client-swift/.github/workflows/release.yml`: extract the version from `AlgoliaSearchClient.podspec` and exit early if `https://trunk.cocoapods.org/api/v1/pods/AlgoliaSearchClient` already lists it.

## 🧪 Test

- YAML parses (validated locally with ruby YAML.load_file).
- Skip logic tested against the live trunk API: version 9.49.0 (published) matches and would skip, a fake 9.99.99 does not match and would push.
- The failed run for reference: https://github.com/algolia/algoliasearch-client-swift/actions/runs/34370089262
