### PR TITLE
feat(kotlin): restore optional Kotlin DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ swiftformat
 
 foo
 
+# Local planning artifacts. Tracked skills stay under .agents/skills/.
+.agents/plans/
+
 # reports saved by the api-clients-review skill
 .agents/reviews/

--- a/clients/algoliasearch-client-kotlin/README.md
+++ b/clients/algoliasearch-client-kotlin/README.md
@@ -49,6 +49,56 @@ Alternatively, you can use [algoliasearch-client-kotlin-bom](/client-bom).
 
 For full documentation, visit the **[Algolia Kotlin API Client](https://www.algolia.com/doc/libraries/sdk/install#kotlin)**.
 
+## Optional Kotlin DSL
+
+The client includes an optional Kotlin DSL for search parameters and index settings. The DSL is optional, experimental on the first 3.x minor (`@OptIn(AlgoliaExperimentalDsl::class)`), and is not source compatible with version 2. Data-class constructors stay supported.
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val params = query {
+  query = "shoes"
+  filters { facet("brand", "Apple") }
+}
+```
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val indexSettings = settings {
+  searchableAttributes {
+    ordered("name")
+    unordered("description")
+  }
+}
+```
+
+### Migrating from version 2
+
+Map version 2 types to version 3 types:
+
+- `Query` → `SearchParamsObject` via `query { }`
+- `Settings` → `IndexSettings` via `settings { }`
+- `Attribute` → `String`
+- `initIndex` is gone. Pass the index name to the client method.
+- `index.search { }` → `client.searchSingleIndex(indexName) { }`
+
+`SearchClient.search` is multi-query. Use `searchSingleIndex` for a single index.
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val response = client.searchSingleIndex("products") {
+  query = "shoes"
+  filters { facet("brand", "Apple") }
+}
+```
+
+See the [Kotlin upgrade guide](https://www.algolia.com/doc/libraries/sdk/upgrade/kotlin).
+
 ## ❓ Troubleshooting
 
 Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://support.algolia.com/hc/sections/15061037630609-API-Client-FAQs) where you will find answers for the most common issues and gotchas with the client.

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/AlgoliaDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/AlgoliaDsl.kt
@@ -1,0 +1,35 @@
+/**
+ * Optional, additive Kotlin DSL for the Algolia client.
+ *
+ * This package is experimental on the first 3.x minor. It is not source compatible with version 2.
+ * Data-class constructors stay the default.
+ */
+package com.algolia.client.dsl
+
+/**
+ * Marks types that belong to the Algolia Kotlin DSL.
+ *
+ * Nested DSL receivers cannot access outer receivers that share this marker.
+ */
+@DslMarker public annotation class AlgoliaDsl
+
+/**
+ * Marks the Algolia Kotlin DSL as experimental.
+ *
+ * The DSL is optional and additive. It is not source compatible with version 2. The first 3.x minor
+ * may change the shape.
+ */
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message =
+    "This DSL is experimental, optional, additive, and not v2 source compatible. The first 3.x minor may change its shape.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.TYPEALIAS,
+)
+public annotation class AlgoliaExperimentalDsl

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/BrowseDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/BrowseDsl.kt
@@ -1,0 +1,78 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.filter.FilterDsl
+import com.algolia.client.dsl.filter.filters as buildFilters
+import com.algolia.client.dsl.generated.BrowseParamsObjectBuilder
+import com.algolia.client.model.search.BrowseParamsObject
+
+/**
+ * Constructs a [BrowseParamsObject] from the generated [BrowseParamsObjectBuilder].
+ *
+ * Last write wins: a later assignment to the same builder property replaces an earlier one. A later
+ * `filters { }` or `filters = "..."` assignment replaces an earlier `filters` value. The same rule
+ * applies to `facetFilters`, `optionalFilters`, `numericFilters`, and `tagFilters`. The DSL does
+ * not merge filter parameters.
+ *
+ * ```
+ * val params =
+ *   browse {
+ *     query = "shoes"
+ *     filters { facet("brand", "Apple") }
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun browse(block: BrowseParamsObjectBuilder.() -> Unit): BrowseParamsObject =
+  BrowseParamsObjectBuilder().apply(block).build()
+
+/**
+ * Sets [BrowseParamsObjectBuilder.filters] from a typed filter block as a SQL string.
+ *
+ * Last write wins: this replaces any earlier `filters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun BrowseParamsObjectBuilder.filters(block: FilterDsl.() -> Unit) {
+  filters = buildFilters(block).asSql()
+}
+
+/**
+ * Sets [BrowseParamsObjectBuilder.facetFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun BrowseParamsObjectBuilder.facetFilters(block: FilterDsl.() -> Unit) {
+  facetFilters = buildFilters(block).asFacetFilters()
+}
+
+/**
+ * Sets [BrowseParamsObjectBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun BrowseParamsObjectBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
+  optionalFilters = buildFilters(block).asOptionalFilters()
+}
+
+/**
+ * Sets [BrowseParamsObjectBuilder.numericFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun BrowseParamsObjectBuilder.numericFilters(block: FilterDsl.() -> Unit) {
+  numericFilters = buildFilters(block).asNumericFilters()
+}
+
+/**
+ * Sets [BrowseParamsObjectBuilder.tagFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun BrowseParamsObjectBuilder.tagFilters(block: FilterDsl.() -> Unit) {
+  tagFilters = buildFilters(block).asTagFilters()
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/BrowseDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/BrowseDsl.kt
@@ -2,8 +2,6 @@
 
 package com.algolia.client.dsl
 
-import com.algolia.client.dsl.filter.FilterDsl
-import com.algolia.client.dsl.filter.filters as buildFilters
 import com.algolia.client.dsl.generated.BrowseParamsObjectBuilder
 import com.algolia.client.model.search.BrowseParamsObject
 
@@ -26,53 +24,3 @@ import com.algolia.client.model.search.BrowseParamsObject
 @AlgoliaExperimentalDsl
 public fun browse(block: BrowseParamsObjectBuilder.() -> Unit): BrowseParamsObject =
   BrowseParamsObjectBuilder().apply(block).build()
-
-/**
- * Sets [BrowseParamsObjectBuilder.filters] from a typed filter block as a SQL string.
- *
- * Last write wins: this replaces any earlier `filters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun BrowseParamsObjectBuilder.filters(block: FilterDsl.() -> Unit) {
-  filters = buildFilters(block).asSql()
-}
-
-/**
- * Sets [BrowseParamsObjectBuilder.facetFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun BrowseParamsObjectBuilder.facetFilters(block: FilterDsl.() -> Unit) {
-  facetFilters = buildFilters(block).asFacetFilters()
-}
-
-/**
- * Sets [BrowseParamsObjectBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun BrowseParamsObjectBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
-  optionalFilters = buildFilters(block).asOptionalFilters()
-}
-
-/**
- * Sets [BrowseParamsObjectBuilder.numericFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun BrowseParamsObjectBuilder.numericFilters(block: FilterDsl.() -> Unit) {
-  numericFilters = buildFilters(block).asNumericFilters()
-}
-
-/**
- * Sets [BrowseParamsObjectBuilder.tagFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun BrowseParamsObjectBuilder.tagFilters(block: FilterDsl.() -> Unit) {
-  tagFilters = buildFilters(block).asTagFilters()
-}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/ClientDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/ClientDsl.kt
@@ -1,0 +1,82 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.api.SearchClient
+import com.algolia.client.dsl.deleteBy as buildDeleteBy
+import com.algolia.client.dsl.generated.DeleteByParamsBuilder
+import com.algolia.client.dsl.generated.IndexSettingsBuilder
+import com.algolia.client.dsl.generated.SearchParamsObjectBuilder
+import com.algolia.client.model.search.SearchParams
+import com.algolia.client.model.search.SearchResponse
+import com.algolia.client.model.search.UpdatedAtResponse
+import com.algolia.client.transport.RequestOptions
+
+/**
+ * Searches a single index with a [query] DSL block.
+ *
+ * [SearchParamsObject] is not a [SearchParams]. This wraps [query] with [SearchParams.of].
+ *
+ * Do not use [SearchClient.search] for this: that method is multi-query.
+ *
+ * ```
+ * val response =
+ *   client.searchSingleIndex("idx") {
+ *     query = "shoes"
+ *     filters { facet("brand", "Apple") }
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public suspend fun SearchClient.searchSingleIndex(
+  indexName: String,
+  requestOptions: RequestOptions? = null,
+  block: SearchParamsObjectBuilder.() -> Unit,
+): SearchResponse =
+  searchSingleIndex(
+    indexName = indexName,
+    searchParams = SearchParams.of(query(block = block)),
+    requestOptions = requestOptions,
+  )
+
+/**
+ * Updates index settings with a [settings] DSL block.
+ *
+ * ```
+ * client.setSettings("idx") {
+ *   searchableAttributes { ordered("name") }
+ * }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public suspend fun SearchClient.setSettings(
+  indexName: String,
+  forwardToReplicas: Boolean? = null,
+  requestOptions: RequestOptions? = null,
+  block: IndexSettingsBuilder.() -> Unit,
+): UpdatedAtResponse =
+  setSettings(
+    indexName = indexName,
+    indexSettings = settings(block),
+    forwardToReplicas = forwardToReplicas,
+    requestOptions = requestOptions,
+  )
+
+/**
+ * Deletes records that match a [deleteBy] DSL block.
+ *
+ * ```
+ * client.deleteBy("idx") { filters { facet("brand", "Apple") } }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public suspend fun SearchClient.deleteBy(
+  indexName: String,
+  requestOptions: RequestOptions? = null,
+  block: DeleteByParamsBuilder.() -> Unit,
+): UpdatedAtResponse =
+  deleteBy(
+    indexName = indexName,
+    deleteByParams = buildDeleteBy(block),
+    requestOptions = requestOptions,
+  )

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/DeleteByDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/DeleteByDsl.kt
@@ -2,8 +2,6 @@
 
 package com.algolia.client.dsl
 
-import com.algolia.client.dsl.filter.FilterDsl
-import com.algolia.client.dsl.filter.filters as buildFilters
 import com.algolia.client.dsl.generated.DeleteByParamsBuilder
 import com.algolia.client.model.search.DeleteByParams
 
@@ -28,47 +26,3 @@ import com.algolia.client.model.search.DeleteByParams
 @AlgoliaExperimentalDsl
 public fun deleteBy(block: DeleteByParamsBuilder.() -> Unit): DeleteByParams =
   DeleteByParamsBuilder().apply(block).build()
-
-/**
- * Sets [DeleteByParamsBuilder.filters] from the typed filter DSL.
- *
- * Emits the SQL `filters` string. Last write wins if this property was already set in the same
- * block.
- */
-@AlgoliaExperimentalDsl
-public fun DeleteByParamsBuilder.filters(block: FilterDsl.() -> Unit) {
-  filters = buildFilters(block).asSql()
-}
-
-/**
- * Sets [DeleteByParamsBuilder.facetFilters] from the typed filter DSL.
- *
- * Emits the legacy facet-filters wrapper. Last write wins if this property was already set in the
- * same block.
- */
-@AlgoliaExperimentalDsl
-public fun DeleteByParamsBuilder.facetFilters(block: FilterDsl.() -> Unit) {
-  facetFilters = buildFilters(block).asFacetFilters()
-}
-
-/**
- * Sets [DeleteByParamsBuilder.numericFilters] from the typed filter DSL.
- *
- * Emits the legacy numeric-filters wrapper. Last write wins if this property was already set in the
- * same block.
- */
-@AlgoliaExperimentalDsl
-public fun DeleteByParamsBuilder.numericFilters(block: FilterDsl.() -> Unit) {
-  numericFilters = buildFilters(block).asNumericFilters()
-}
-
-/**
- * Sets [DeleteByParamsBuilder.tagFilters] from the typed filter DSL.
- *
- * Emits the legacy tag-filters wrapper. Last write wins if this property was already set in the
- * same block.
- */
-@AlgoliaExperimentalDsl
-public fun DeleteByParamsBuilder.tagFilters(block: FilterDsl.() -> Unit) {
-  tagFilters = buildFilters(block).asTagFilters()
-}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/DeleteByDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/DeleteByDsl.kt
@@ -1,0 +1,74 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.filter.FilterDsl
+import com.algolia.client.dsl.filter.filters as buildFilters
+import com.algolia.client.dsl.generated.DeleteByParamsBuilder
+import com.algolia.client.model.search.DeleteByParams
+
+/**
+ * Constructs a [DeleteByParams] value from the generated [DeleteByParamsBuilder].
+ *
+ * Last write wins: a later assignment to the same builder property replaces an earlier one,
+ * including values set by [filters], [facetFilters], [numericFilters], and [tagFilters].
+ * [DeleteByParams] has no `optionalFilters` field.
+ *
+ * Geo fields (`aroundLatLng`, `aroundRadius`, `insideBoundingBox`, `insidePolygon`) are set as
+ * builder properties.
+ *
+ * ```
+ * val params =
+ *   deleteBy {
+ *     aroundLatLng = "40.71,-74.01"
+ *     filters { facet("brand", "Apple") }
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun deleteBy(block: DeleteByParamsBuilder.() -> Unit): DeleteByParams =
+  DeleteByParamsBuilder().apply(block).build()
+
+/**
+ * Sets [DeleteByParamsBuilder.filters] from the typed filter DSL.
+ *
+ * Emits the SQL `filters` string. Last write wins if this property was already set in the same
+ * block.
+ */
+@AlgoliaExperimentalDsl
+public fun DeleteByParamsBuilder.filters(block: FilterDsl.() -> Unit) {
+  filters = buildFilters(block).asSql()
+}
+
+/**
+ * Sets [DeleteByParamsBuilder.facetFilters] from the typed filter DSL.
+ *
+ * Emits the legacy facet-filters wrapper. Last write wins if this property was already set in the
+ * same block.
+ */
+@AlgoliaExperimentalDsl
+public fun DeleteByParamsBuilder.facetFilters(block: FilterDsl.() -> Unit) {
+  facetFilters = buildFilters(block).asFacetFilters()
+}
+
+/**
+ * Sets [DeleteByParamsBuilder.numericFilters] from the typed filter DSL.
+ *
+ * Emits the legacy numeric-filters wrapper. Last write wins if this property was already set in the
+ * same block.
+ */
+@AlgoliaExperimentalDsl
+public fun DeleteByParamsBuilder.numericFilters(block: FilterDsl.() -> Unit) {
+  numericFilters = buildFilters(block).asNumericFilters()
+}
+
+/**
+ * Sets [DeleteByParamsBuilder.tagFilters] from the typed filter DSL.
+ *
+ * Emits the legacy tag-filters wrapper. Last write wins if this property was already set in the
+ * same block.
+ */
+@AlgoliaExperimentalDsl
+public fun DeleteByParamsBuilder.tagFilters(block: FilterDsl.() -> Unit) {
+  tagFilters = buildFilters(block).asTagFilters()
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/QueryDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/QueryDsl.kt
@@ -2,8 +2,6 @@
 
 package com.algolia.client.dsl
 
-import com.algolia.client.dsl.filter.FilterDsl
-import com.algolia.client.dsl.filter.filters as buildFilters
 import com.algolia.client.dsl.generated.SearchParamsObjectBuilder
 import com.algolia.client.model.search.SearchParamsObject
 
@@ -42,53 +40,3 @@ public fun query(
       block()
     }
     .build()
-
-/**
- * Sets [SearchParamsObjectBuilder.filters] from a typed filter block as a SQL string.
- *
- * Last write wins: this replaces any earlier `filters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun SearchParamsObjectBuilder.filters(block: FilterDsl.() -> Unit) {
-  filters = buildFilters(block).asSql()
-}
-
-/**
- * Sets [SearchParamsObjectBuilder.facetFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun SearchParamsObjectBuilder.facetFilters(block: FilterDsl.() -> Unit) {
-  facetFilters = buildFilters(block).asFacetFilters()
-}
-
-/**
- * Sets [SearchParamsObjectBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun SearchParamsObjectBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
-  optionalFilters = buildFilters(block).asOptionalFilters()
-}
-
-/**
- * Sets [SearchParamsObjectBuilder.numericFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun SearchParamsObjectBuilder.numericFilters(block: FilterDsl.() -> Unit) {
-  numericFilters = buildFilters(block).asNumericFilters()
-}
-
-/**
- * Sets [SearchParamsObjectBuilder.tagFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun SearchParamsObjectBuilder.tagFilters(block: FilterDsl.() -> Unit) {
-  tagFilters = buildFilters(block).asTagFilters()
-}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/QueryDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/QueryDsl.kt
@@ -1,0 +1,94 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.filter.FilterDsl
+import com.algolia.client.dsl.filter.filters as buildFilters
+import com.algolia.client.dsl.generated.SearchParamsObjectBuilder
+import com.algolia.client.model.search.SearchParamsObject
+
+/**
+ * Constructs a [SearchParamsObject] from the generated [SearchParamsObjectBuilder].
+ *
+ * Last write wins: a later assignment to the same builder property replaces an earlier one. If
+ * [query] is non-null, it is written first. The [block] may overwrite it. A later `filters { }` or
+ * `filters = "..."` assignment replaces an earlier `filters` value. The same rule applies to
+ * `facetFilters`, `optionalFilters`, `numericFilters`, and `tagFilters`. The DSL does not merge
+ * filter parameters.
+ *
+ * ```
+ * val params =
+ *   query {
+ *     query = "x"
+ *     filters { facet("brand", "Apple") }
+ *   }
+ * ```
+ *
+ * Or pass the query string as the first argument:
+ * ```
+ * val params = query("x") { filters { facet("brand", "Apple") } }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun query(
+  query: String? = null,
+  block: SearchParamsObjectBuilder.() -> Unit,
+): SearchParamsObject =
+  SearchParamsObjectBuilder()
+    .apply {
+      if (query != null) {
+        this.query = query
+      }
+      block()
+    }
+    .build()
+
+/**
+ * Sets [SearchParamsObjectBuilder.filters] from a typed filter block as a SQL string.
+ *
+ * Last write wins: this replaces any earlier `filters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SearchParamsObjectBuilder.filters(block: FilterDsl.() -> Unit) {
+  filters = buildFilters(block).asSql()
+}
+
+/**
+ * Sets [SearchParamsObjectBuilder.facetFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SearchParamsObjectBuilder.facetFilters(block: FilterDsl.() -> Unit) {
+  facetFilters = buildFilters(block).asFacetFilters()
+}
+
+/**
+ * Sets [SearchParamsObjectBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SearchParamsObjectBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
+  optionalFilters = buildFilters(block).asOptionalFilters()
+}
+
+/**
+ * Sets [SearchParamsObjectBuilder.numericFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SearchParamsObjectBuilder.numericFilters(block: FilterDsl.() -> Unit) {
+  numericFilters = buildFilters(block).asNumericFilters()
+}
+
+/**
+ * Sets [SearchParamsObjectBuilder.tagFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SearchParamsObjectBuilder.tagFilters(block: FilterDsl.() -> Unit) {
+  tagFilters = buildFilters(block).asTagFilters()
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/RequestOptionsDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/RequestOptionsDsl.kt
@@ -1,0 +1,48 @@
+package com.algolia.client.dsl
+
+import com.algolia.client.transport.RequestOptions
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Builds a [RequestOptions] value with a Kotlin DSL.
+ *
+ * The resulting value is the existing immutable transport type. This builder does not change
+ * [RequestOptions].
+ */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class RequestOptionsDsl {
+  /** The write timeout for the request. */
+  public var writeTimeout: Duration? = null
+
+  /** The read timeout for the request. */
+  public var readTimeout: Duration? = null
+
+  /** The connect timeout for the request. */
+  public var connectTimeout: Duration? = null
+
+  /** Headers to send with the request. */
+  public var headers: Map<String, Any> = emptyMap()
+
+  /** URL parameters to append to the request URL. */
+  public var urlParameters: Map<String, Any> = emptyMap()
+
+  /** A JSON object representing the request body. */
+  public var body: JsonObject? = null
+
+  internal fun build(): RequestOptions =
+    RequestOptions(
+      writeTimeout = writeTimeout,
+      readTimeout = readTimeout,
+      connectTimeout = connectTimeout,
+      headers = headers,
+      urlParameters = urlParameters,
+      body = body,
+    )
+}
+
+/** Constructs a [RequestOptions] value from the DSL block. */
+@AlgoliaExperimentalDsl
+public fun requestOptions(block: RequestOptionsDsl.() -> Unit): RequestOptions =
+  RequestOptionsDsl().apply(block).build()

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/SettingsDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/SettingsDsl.kt
@@ -1,0 +1,218 @@
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.generated.IndexSettingsBuilder
+import com.algolia.client.model.search.IndexSettings
+
+/**
+ * Constructs an [IndexSettings] value from the generated [IndexSettingsBuilder].
+ *
+ * Last write wins: a later assignment to the same builder property replaces an earlier one,
+ * including values set by the typed helpers.
+ *
+ * ```
+ * val settings = settings {
+ *   searchableAttributes {
+ *     ordered("name")
+ *     unordered("description")
+ *   }
+ *   attributesForFaceting {
+ *     +"brand"
+ *     filterOnly("internalSku")
+ *     searchable("category")
+ *   }
+ *   customRanking { desc("followers") }
+ *   ranking {
+ *     typo()
+ *     geo()
+ *     words()
+ *     filters()
+ *     proximity()
+ *     attribute()
+ *     exact()
+ *     custom()
+ *   }
+ * }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun settings(block: IndexSettingsBuilder.() -> Unit): IndexSettings =
+  IndexSettingsBuilder().apply(block).build()
+
+/**
+ * Sets [IndexSettingsBuilder.searchableAttributes] from typed helpers.
+ *
+ * Ordered attributes emit the bare name, matching v2 `SearchableAttribute.Default`. Several
+ * attributes in one [SearchableAttributesDsl.ordered] call share priority and join with `", "`.
+ * [SearchableAttributesDsl.unordered] emits `unordered(attribute)`.
+ */
+@AlgoliaExperimentalDsl
+public fun IndexSettingsBuilder.searchableAttributes(block: SearchableAttributesDsl.() -> Unit) {
+  searchableAttributes = SearchableAttributesDsl().apply(block).build()
+}
+
+/**
+ * Sets [IndexSettingsBuilder.attributesForFaceting] from typed helpers.
+ *
+ * A plain attribute emits the bare name. [AttributesForFacetingDsl.filterOnly] emits
+ * `filterOnly(attribute)`. [AttributesForFacetingDsl.searchable] emits `searchable(attribute)`.
+ */
+@AlgoliaExperimentalDsl
+public fun IndexSettingsBuilder.attributesForFaceting(block: AttributesForFacetingDsl.() -> Unit) {
+  attributesForFaceting = AttributesForFacetingDsl().apply(block).build()
+}
+
+/**
+ * Sets [IndexSettingsBuilder.customRanking] from typed helpers.
+ *
+ * [CustomRankingDsl.asc] emits `asc(attribute)`. [CustomRankingDsl.desc] emits `desc(attribute)`.
+ */
+@AlgoliaExperimentalDsl
+public fun IndexSettingsBuilder.customRanking(block: CustomRankingDsl.() -> Unit) {
+  customRanking = CustomRankingDsl().apply(block).build()
+}
+
+/**
+ * Sets [IndexSettingsBuilder.ranking] from the same modifiers version 2 exposed: `typo`, `geo`,
+ * `words`, `filters`, `proximity`, `attribute`, `exact`, `custom`, plus `asc(attribute)` and
+ * `desc(attribute)`.
+ */
+@AlgoliaExperimentalDsl
+public fun IndexSettingsBuilder.ranking(block: RankingDsl.() -> Unit) {
+  ranking = RankingDsl().apply(block).build()
+}
+
+/** Builds searchable-attribute strings for [IndexSettings.searchableAttributes]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class SearchableAttributesDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /**
+   * Adds an ordered searchable attribute, or several attributes that share the same priority.
+   *
+   * One attribute emits the bare name. Several attributes emit a comma-separated string, matching
+   * v2 `SearchableAttribute.Default`.
+   */
+  public fun ordered(attribute: String, vararg more: String) {
+    values += if (more.isEmpty()) attribute else listOf(attribute, *more).joinToString()
+  }
+
+  /** Adds an unordered searchable attribute as `unordered(attribute)`. */
+  public fun unordered(attribute: String) {
+    values += "unordered($attribute)"
+  }
+
+  /** Adds [this] as an ordered searchable attribute. Matches v2 `+"name"`. */
+  public operator fun String.unaryPlus() {
+    ordered(this)
+  }
+
+  internal fun build(): List<String> = values.toList()
+}
+
+/** Builds attribute-for-faceting strings for [IndexSettings.attributesForFaceting]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class AttributesForFacetingDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /** Adds a facet attribute with no modifier. */
+  public fun attribute(attribute: String) {
+    values += attribute
+  }
+
+  /** Adds a filter-only attribute as `filterOnly(attribute)`. */
+  public fun filterOnly(attribute: String) {
+    values += "filterOnly($attribute)"
+  }
+
+  /** Adds a searchable facet attribute as `searchable(attribute)`. */
+  public fun searchable(attribute: String) {
+    values += "searchable($attribute)"
+  }
+
+  /** Adds [this] as a facet attribute with no modifier. Matches v2 `+"brand"`. */
+  public operator fun String.unaryPlus() {
+    attribute(this)
+  }
+
+  internal fun build(): List<String> = values.toList()
+}
+
+/** Builds custom-ranking strings for [IndexSettings.customRanking]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class CustomRankingDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /** Adds an ascending custom-ranking criterion as `asc(attribute)`. */
+  public fun asc(attribute: String) {
+    values += "asc($attribute)"
+  }
+
+  /** Adds a descending custom-ranking criterion as `desc(attribute)`. */
+  public fun desc(attribute: String) {
+    values += "desc($attribute)"
+  }
+
+  internal fun build(): List<String> = values.toList()
+}
+
+/** Builds ranking-formula strings for [IndexSettings.ranking]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class RankingDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /** Adds the `typo` ranking criterion. */
+  public fun typo() {
+    values += "typo"
+  }
+
+  /** Adds the `geo` ranking criterion. */
+  public fun geo() {
+    values += "geo"
+  }
+
+  /** Adds the `words` ranking criterion. */
+  public fun words() {
+    values += "words"
+  }
+
+  /** Adds the `filters` ranking criterion. */
+  public fun filters() {
+    values += "filters"
+  }
+
+  /** Adds the `proximity` ranking criterion. */
+  public fun proximity() {
+    values += "proximity"
+  }
+
+  /** Adds the `attribute` ranking criterion. */
+  public fun attribute() {
+    values += "attribute"
+  }
+
+  /** Adds the `exact` ranking criterion. */
+  public fun exact() {
+    values += "exact"
+  }
+
+  /** Adds the `custom` ranking criterion. */
+  public fun custom() {
+    values += "custom"
+  }
+
+  /** Adds an ascending sort criterion as `asc(attribute)`. */
+  public fun asc(attribute: String) {
+    values += "asc($attribute)"
+  }
+
+  /** Adds a descending sort criterion as `desc(attribute)`. */
+  public fun desc(attribute: String) {
+    values += "desc($attribute)"
+  }
+
+  internal fun build(): List<String> = values.toList()
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/SettingsDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/SettingsDsl.kt
@@ -81,12 +81,28 @@ public fun IndexSettingsBuilder.ranking(block: RankingDsl.() -> Unit) {
   ranking = RankingDsl().apply(block).build()
 }
 
+/**
+ * Shared accumulator for the settings DSL classes that build a `List<String>`.
+ *
+ * Public only because its subclasses are public. It exposes no public member: subclasses add
+ * through [add] and the DSL entry points read through [build].
+ */
+@AlgoliaExperimentalDsl
+public sealed class StringListDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /** Appends one already-encoded value. */
+  protected fun add(value: String) {
+    values += value
+  }
+
+  internal fun build(): List<String> = values.toList()
+}
+
 /** Builds searchable-attribute strings for [IndexSettings.searchableAttributes]. */
 @AlgoliaDsl
 @AlgoliaExperimentalDsl
-public class SearchableAttributesDsl {
-  private val values: MutableList<String> = mutableListOf()
-
+public class SearchableAttributesDsl : StringListDsl() {
   /**
    * Adds an ordered searchable attribute, or several attributes that share the same priority.
    *
@@ -94,125 +110,111 @@ public class SearchableAttributesDsl {
    * v2 `SearchableAttribute.Default`.
    */
   public fun ordered(attribute: String, vararg more: String) {
-    values += if (more.isEmpty()) attribute else listOf(attribute, *more).joinToString()
+    add(if (more.isEmpty()) attribute else listOf(attribute, *more).joinToString(separator = ", "))
   }
 
   /** Adds an unordered searchable attribute as `unordered(attribute)`. */
   public fun unordered(attribute: String) {
-    values += "unordered($attribute)"
+    add("unordered($attribute)")
   }
 
   /** Adds [this] as an ordered searchable attribute. Matches v2 `+"name"`. */
   public operator fun String.unaryPlus() {
     ordered(this)
   }
-
-  internal fun build(): List<String> = values.toList()
 }
 
 /** Builds attribute-for-faceting strings for [IndexSettings.attributesForFaceting]. */
 @AlgoliaDsl
 @AlgoliaExperimentalDsl
-public class AttributesForFacetingDsl {
-  private val values: MutableList<String> = mutableListOf()
-
+public class AttributesForFacetingDsl : StringListDsl() {
   /** Adds a facet attribute with no modifier. */
   public fun attribute(attribute: String) {
-    values += attribute
+    add(attribute)
   }
 
   /** Adds a filter-only attribute as `filterOnly(attribute)`. */
   public fun filterOnly(attribute: String) {
-    values += "filterOnly($attribute)"
+    add("filterOnly($attribute)")
   }
 
   /** Adds a searchable facet attribute as `searchable(attribute)`. */
   public fun searchable(attribute: String) {
-    values += "searchable($attribute)"
+    add("searchable($attribute)")
   }
 
   /** Adds [this] as a facet attribute with no modifier. Matches v2 `+"brand"`. */
   public operator fun String.unaryPlus() {
     attribute(this)
   }
-
-  internal fun build(): List<String> = values.toList()
 }
 
 /** Builds custom-ranking strings for [IndexSettings.customRanking]. */
 @AlgoliaDsl
 @AlgoliaExperimentalDsl
-public class CustomRankingDsl {
-  private val values: MutableList<String> = mutableListOf()
-
+public class CustomRankingDsl : StringListDsl() {
   /** Adds an ascending custom-ranking criterion as `asc(attribute)`. */
   public fun asc(attribute: String) {
-    values += "asc($attribute)"
+    add("asc($attribute)")
   }
 
   /** Adds a descending custom-ranking criterion as `desc(attribute)`. */
   public fun desc(attribute: String) {
-    values += "desc($attribute)"
+    add("desc($attribute)")
   }
-
-  internal fun build(): List<String> = values.toList()
 }
 
 /** Builds ranking-formula strings for [IndexSettings.ranking]. */
 @AlgoliaDsl
 @AlgoliaExperimentalDsl
-public class RankingDsl {
-  private val values: MutableList<String> = mutableListOf()
-
+public class RankingDsl : StringListDsl() {
   /** Adds the `typo` ranking criterion. */
   public fun typo() {
-    values += "typo"
+    add("typo")
   }
 
   /** Adds the `geo` ranking criterion. */
   public fun geo() {
-    values += "geo"
+    add("geo")
   }
 
   /** Adds the `words` ranking criterion. */
   public fun words() {
-    values += "words"
+    add("words")
   }
 
   /** Adds the `filters` ranking criterion. */
   public fun filters() {
-    values += "filters"
+    add("filters")
   }
 
   /** Adds the `proximity` ranking criterion. */
   public fun proximity() {
-    values += "proximity"
+    add("proximity")
   }
 
   /** Adds the `attribute` ranking criterion. */
   public fun attribute() {
-    values += "attribute"
+    add("attribute")
   }
 
   /** Adds the `exact` ranking criterion. */
   public fun exact() {
-    values += "exact"
+    add("exact")
   }
 
   /** Adds the `custom` ranking criterion. */
   public fun custom() {
-    values += "custom"
+    add("custom")
   }
 
   /** Adds an ascending sort criterion as `asc(attribute)`. */
   public fun asc(attribute: String) {
-    values += "asc($attribute)"
+    add("asc($attribute)")
   }
 
   /** Adds a descending sort criterion as `desc(attribute)`. */
   public fun desc(attribute: String) {
-    values += "desc($attribute)"
+    add("desc($attribute)")
   }
-
-  internal fun build(): List<String> = values.toList()
 }

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/Filter.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/Filter.kt
@@ -1,0 +1,95 @@
+package com.algolia.client.dsl.filter
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import kotlin.jvm.JvmInline
+
+/**
+ * A single typed filter leaf.
+ *
+ * Each [Filter] is also a [FilterGroup], so [FilterGroup.And], [FilterGroup.Or], and
+ * [FilterGroup.Not] can nest leaves and groups in the same tree.
+ *
+ * Attributes and facet values are [String]. This is the v3 shape. Version 2 used an `Attribute`
+ * wrapper.
+ *
+ * [Documentation](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/)
+ */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public sealed interface Filter : FilterGroup {
+
+  /**
+   * Matches [attribute] to [value] exactly.
+   *
+   * An optional [score] assigns a priority among several [Facet] filters in the same group.
+   * [Filter scoring](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/in-depth/filter-scoring/#filters-scoring)
+   */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  public data class Facet(
+    public val attribute: String,
+    public val value: String,
+    public val score: Int? = null,
+  ) : Filter {
+
+    public constructor(
+      attribute: String,
+      value: Boolean,
+      score: Int? = null,
+    ) : this(attribute, value.toString(), score)
+
+    public constructor(
+      attribute: String,
+      value: Number,
+      score: Int? = null,
+    ) : this(attribute, value.toString(), score)
+  }
+
+  /** Filters on a `_tags` value. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  @JvmInline
+  public value class Tag(public val value: String) : Filter
+
+  /** Numeric comparison of [attribute] against [value] with [operator]. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  public data class Comparison(
+    public val attribute: String,
+    public val operator: NumericOperator,
+    public val value: Number,
+  ) : Filter
+
+  /** Numeric range of [attribute] between [lowerBound] and [upperBound], inclusive. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  public data class Range(
+    public val attribute: String,
+    public val lowerBound: Number,
+    public val upperBound: Number,
+  ) : Filter {
+
+    public constructor(
+      attribute: String,
+      range: IntRange,
+    ) : this(attribute, range.first, range.last)
+
+    public constructor(
+      attribute: String,
+      range: LongRange,
+    ) : this(attribute, range.first, range.last)
+  }
+}
+
+/** Operator for [Filter.Comparison]. Mirrors version 2 `NumericOperator`. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public enum class NumericOperator(public val raw: String) {
+  Less("<"),
+  LessOrEquals("<="),
+  Equals("="),
+  NotEquals("!="),
+  GreaterOrEquals(">="),
+  Greater(">"),
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterDsl.kt
@@ -1,0 +1,136 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl.filter
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.model.search.FacetFilters
+import com.algolia.client.model.search.NumericFilters
+import com.algolia.client.model.search.OptionalFilters
+import com.algolia.client.model.search.TagFilters
+
+/**
+ * Builds a typed [FilterGroup] tree with a Kotlin DSL.
+ *
+ * Top-level children are combined with [FilterGroup.And]. [or] is untyped: mixed-family children
+ * compile, and [FilterSqlConverter] / [FilterLegacyConverter] throw [IllegalArgumentException] at
+ * conversion time. The builder does not merge or drop illegal `Or` children.
+ *
+ * ```
+ * val built =
+ *   filters {
+ *     and {
+ *       facet("color", "red")
+ *       facet("category", "shirt")
+ *     }
+ *     or {
+ *       range("price", 0 until 10)
+ *       comparison("price", NumericOperator.Equals, 15)
+ *     }
+ *   }
+ * val sql = built.asSql()
+ * val facetFilters = built.asFacetFilters()
+ * ```
+ */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class FilterDsl {
+  private val children: MutableList<FilterGroup> = mutableListOf()
+
+  /** Adds an [FilterGroup.And] of the children in [block]. */
+  public fun and(block: FilterDsl.() -> Unit) {
+    children += FilterGroup.And(FilterDsl().apply(block).snapshot())
+  }
+
+  /**
+   * Adds an untyped [FilterGroup.Or] of the children in [block].
+   *
+   * Converters reject mixed families and nested `And` / `Or`.
+   */
+  public fun or(block: FilterDsl.() -> Unit) {
+    children += FilterGroup.Or(FilterDsl().apply(block).snapshot())
+  }
+
+  /**
+   * Adds a [FilterGroup.Not] of the children in [block].
+   *
+   * One child is negated as-is. Several children are negated as an [FilterGroup.And].
+   */
+  public fun not(block: FilterDsl.() -> Unit) {
+    children += FilterGroup.Not(FilterDsl().apply(block).asNode())
+  }
+
+  /** Adds a [Filter.Facet] on [attribute] equal to [value]. */
+  public fun facet(attribute: String, value: String, score: Int? = null): Filter.Facet =
+    Filter.Facet(attribute, value, score).also { children += it }
+
+  /** Adds a [Filter.Facet] on [attribute] equal to [value]. */
+  public fun facet(attribute: String, value: Boolean, score: Int? = null): Filter.Facet =
+    Filter.Facet(attribute, value, score).also { children += it }
+
+  /** Adds a [Filter.Facet] on [attribute] equal to [value]. */
+  public fun facet(attribute: String, value: Number, score: Int? = null): Filter.Facet =
+    Filter.Facet(attribute, value, score).also { children += it }
+
+  /** Adds a [Filter.Tag] for [value]. */
+  public fun tag(value: String): Filter.Tag = Filter.Tag(value).also { children += it }
+
+  /** Adds a [Filter.Range] on [attribute] between [lowerBound] and [upperBound], inclusive. */
+  public fun range(attribute: String, lowerBound: Number, upperBound: Number): Filter.Range =
+    Filter.Range(attribute, lowerBound, upperBound).also { children += it }
+
+  /** Adds a [Filter.Range] on [attribute] covering [range], inclusive. */
+  public fun range(attribute: String, range: IntRange): Filter.Range =
+    Filter.Range(attribute, range).also { children += it }
+
+  /** Adds a [Filter.Range] on [attribute] covering [range], inclusive. */
+  public fun range(attribute: String, range: LongRange): Filter.Range =
+    Filter.Range(attribute, range).also { children += it }
+
+  /** Adds a [Filter.Comparison] of [attribute] against [value] with [operator]. */
+  public fun comparison(
+    attribute: String,
+    operator: NumericOperator,
+    value: Number,
+  ): Filter.Comparison = Filter.Comparison(attribute, operator, value).also { children += it }
+
+  internal fun build(): Filters = Filters(asNode())
+
+  private fun snapshot(): List<FilterGroup> = children.toList()
+
+  private fun asNode(): FilterGroup =
+    when (children.size) {
+      0 -> FilterGroup.And()
+      1 -> children.single()
+      else -> FilterGroup.And(children.toList())
+    }
+}
+
+/**
+ * A [FilterGroup] tree plus converters to the SQL `filters` string and the legacy oneOf wrappers.
+ *
+ * Empty [FilterGroup.And] / [FilterGroup.Or] convert to `null`. Mixed-family [FilterGroup.Or]
+ * throws at conversion time.
+ */
+@AlgoliaExperimentalDsl
+public class Filters(public val group: FilterGroup) {
+
+  /** SQL `filters` string, or `null` when [group] is an empty And / Or. */
+  public fun asSql(): String? = FilterSqlConverter(group)
+
+  /** Legacy [FacetFilters] for [Filter.Facet] leaves, or `null` when none remain. */
+  public fun asFacetFilters(): FacetFilters? = FilterLegacyConverter.facet(group)
+
+  /** Legacy [OptionalFilters] for [Filter.Facet] leaves, or `null` when none remain. */
+  public fun asOptionalFilters(): OptionalFilters? = FilterLegacyConverter.optional(group)
+
+  /** Legacy [NumericFilters] for numeric leaves, or `null` when none remain. */
+  public fun asNumericFilters(): NumericFilters? = FilterLegacyConverter.numeric(group)
+
+  /** Legacy [TagFilters] for [Filter.Tag] leaves, or `null` when none remain. */
+  public fun asTagFilters(): TagFilters? = FilterLegacyConverter.tag(group)
+}
+
+/** Constructs a [Filters] value from the DSL block. */
+@AlgoliaExperimentalDsl
+public fun filters(block: FilterDsl.() -> Unit): Filters = FilterDsl().apply(block).build()

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterGroup.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterGroup.kt
@@ -1,0 +1,47 @@
+package com.algolia.client.dsl.filter
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import kotlin.jvm.JvmInline
+
+/**
+ * A node in the typed filter tree.
+ *
+ * Version 2 used typed groups (`And.Any`, `Or.Facet`, `Or.Numeric`, `Or.Tag`) and per-filter
+ * `isNegated`. This v3 tree uses untyped [And] / [Or] plus [Not]. Each [Filter] leaf is also a
+ * [FilterGroup], so groups nest arbitrarily:
+ * - [And] and [Or] hold a list of [FilterGroup] children (leaves or nested groups).
+ * - [Not] wraps one [FilterGroup] child.
+ *
+ * [Documentation](https://www.algolia.com/doc/guides/managing-results/refine-results/filtering/)
+ */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public sealed interface FilterGroup {
+
+  /** Children evaluated with `AND`. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  public data class And(public val children: List<FilterGroup> = emptyList()) : FilterGroup {
+
+    public constructor(vararg children: FilterGroup) : this(children.toList())
+  }
+
+  /** Children evaluated with `OR`. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  public data class Or(public val children: List<FilterGroup> = emptyList()) : FilterGroup {
+
+    public constructor(vararg children: FilterGroup) : this(children.toList())
+  }
+
+  /** Negates [child]. Replaces version 2 `Filter.isNegated`. */
+  @AlgoliaDsl
+  @AlgoliaExperimentalDsl
+  @JvmInline
+  public value class Not(public val child: FilterGroup) : FilterGroup
+}
+
+/** Unary `!` operator. Wraps this node in [FilterGroup.Not]. */
+@AlgoliaExperimentalDsl
+public operator fun FilterGroup.not(): FilterGroup.Not = FilterGroup.Not(this)

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterLegacyConverter.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterLegacyConverter.kt
@@ -58,7 +58,7 @@ public object FilterLegacyConverter {
    */
   @AlgoliaExperimentalDsl
   public fun facet(root: FilterGroup): FacetFilters? =
-    wrapFacet(toLegacyRows(root, FilterFamily.Facet))
+    wrapLegacy(toLegacyRows(root, FilterFamily.Facet), FacetFilters::of, FacetFilters::of)
 
   /**
    * Legacy [OptionalFilters] for [Filter.Facet] leaves in [root].
@@ -67,7 +67,7 @@ public object FilterLegacyConverter {
    */
   @AlgoliaExperimentalDsl
   public fun optional(root: FilterGroup): OptionalFilters? =
-    wrapOptional(toLegacyRows(root, FilterFamily.Facet))
+    wrapLegacy(toLegacyRows(root, FilterFamily.Facet), OptionalFilters::of, OptionalFilters::of)
 
   /**
    * Legacy [NumericFilters] for [Filter.Comparison] and [Filter.Range] leaves in [root].
@@ -78,7 +78,7 @@ public object FilterLegacyConverter {
    */
   @AlgoliaExperimentalDsl
   public fun numeric(root: FilterGroup): NumericFilters? =
-    wrapNumeric(toLegacyRows(root, FilterFamily.Numeric))
+    wrapLegacy(toLegacyRows(root, FilterFamily.Numeric), NumericFilters::of, NumericFilters::of)
 
   /**
    * Legacy [TagFilters] for [Filter.Tag] leaves in [root].
@@ -88,7 +88,8 @@ public object FilterLegacyConverter {
    * the nested-list format cannot encode. Returns `null` when no Tag leaf remains.
    */
   @AlgoliaExperimentalDsl
-  public fun tag(root: FilterGroup): TagFilters? = wrapTag(toLegacyRows(root, FilterFamily.Tag))
+  public fun tag(root: FilterGroup): TagFilters? =
+    wrapLegacy(toLegacyRows(root, FilterFamily.Tag), TagFilters::of, TagFilters::of)
 }
 
 private enum class FilterFamily {
@@ -226,30 +227,17 @@ private fun String.escapeQuotation(): String = replace("\"", "\\\"")
 
 private fun String.escape(): String = "\"${escapeQuotation()}\""
 
-private fun wrapFacet(rows: List<List<String>>): FacetFilters? {
+/**
+ * Wraps legacy rows with a generated oneOf factory pair. [ofString] builds a leaf, [ofList] builds
+ * an inner `OR` row and the outer `AND` list. Rows that hold no literal are dropped; an empty
+ * result is `null`.
+ */
+private fun <T> wrapLegacy(
+  rows: List<List<String>>,
+  ofString: (String) -> T,
+  ofList: (List<T>) -> T,
+): T? {
   val compact = rows.filter { it.isNotEmpty() }
   if (compact.isEmpty()) return null
-  return FacetFilters.of(compact.map { row -> FacetFilters.of(row.map { FacetFilters.of(it) }) })
-}
-
-private fun wrapOptional(rows: List<List<String>>): OptionalFilters? {
-  val compact = rows.filter { it.isNotEmpty() }
-  if (compact.isEmpty()) return null
-  return OptionalFilters.of(
-    compact.map { row -> OptionalFilters.of(row.map { OptionalFilters.of(it) }) }
-  )
-}
-
-private fun wrapNumeric(rows: List<List<String>>): NumericFilters? {
-  val compact = rows.filter { it.isNotEmpty() }
-  if (compact.isEmpty()) return null
-  return NumericFilters.of(
-    compact.map { row -> NumericFilters.of(row.map { NumericFilters.of(it) }) }
-  )
-}
-
-private fun wrapTag(rows: List<List<String>>): TagFilters? {
-  val compact = rows.filter { it.isNotEmpty() }
-  if (compact.isEmpty()) return null
-  return TagFilters.of(compact.map { row -> TagFilters.of(row.map { TagFilters.of(it) }) })
+  return ofList(compact.map { row -> ofList(row.map(ofString)) })
 }

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterLegacyConverter.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterLegacyConverter.kt
@@ -1,0 +1,255 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl.filter
+
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.model.search.FacetFilters
+import com.algolia.client.model.search.NumericFilters
+import com.algolia.client.model.search.OptionalFilters
+import com.algolia.client.model.search.TagFilters
+
+/**
+ * Converts a typed [FilterGroup] tree to the legacy `List<List<String>>` form, then wraps it with
+ * the generated oneOf factories ([FacetFilters.of], [OptionalFilters.of], [NumericFilters.of],
+ * [TagFilters.of]). It never builds raw JSON.
+ *
+ * ## Nested lists
+ *
+ * The outer list is `AND`. Each inner list is an `OR` group. A single leaf in an [FilterGroup.And]
+ * becomes its own one-element inner list:
+ * - [FilterGroup.And] of leaves `A`, `B` → `[["A"], ["B"]]` → `A AND B`
+ * - [FilterGroup.Or] of leaves `A`, `B` → `[["A", "B"]]` → `A OR B`
+ * - [FilterGroup.And] of `Or(A, B)` and leaf `C` → `[["A", "B"], ["C"]]` → `(A OR B) AND C`
+ *
+ * [FilterGroup.Or] has no compile-time leaf kind. Children are classified at runtime.
+ *
+ * ## Family partition
+ *
+ * Each entry point keeps only its family and ignores other leaves (including under
+ * [FilterGroup.And] and [FilterGroup.Not]):
+ * - [facet] / [optional]: [Filter.Facet] only
+ * - [numeric]: [Filter.Comparison] and [Filter.Range] only
+ * - [tag]: [Filter.Tag] only
+ *
+ * An empty result after that partition is `null`.
+ *
+ * ## Reject cases ([IllegalArgumentException])
+ *
+ * - **Mixed-family [FilterGroup.Or]:** the `Or` subtree contains more than one of Facet, Numeric,
+ *   Tag. The converter does not drop the foreign side or emit invalid JSON.
+ * - **[FilterGroup.And] nested in [FilterGroup.Or]:** a child of `Or` encodes as more than one
+ *   `AND` row (OR-of-ANDs). `List<List<String>>` cannot represent that. A single-child `And` is
+ *   flattened to that child.
+ * - **De Morgan OR-of-ANDs:** [FilterGroup.Not] of an [FilterGroup.And] whose negated children
+ *   include a conjunction (for example `Not(And(Or(A, B), C))`).
+ *
+ * Version 2 used typed `Or.Facet` / `Or.Numeric` / `Or.Tag`. This converter enforces the same
+ * homogeneity at runtime.
+ */
+@AlgoliaExperimentalDsl
+public object FilterLegacyConverter {
+
+  /**
+   * Legacy [FacetFilters] for [Filter.Facet] leaves in [root].
+   *
+   * Ignores [Filter.Tag], [Filter.Comparison], and [Filter.Range]. Throws
+   * [IllegalArgumentException] for a mixed-family [FilterGroup.Or] or an `And` nested in `Or` that
+   * the nested-list format cannot encode. Returns `null` when no Facet leaf remains.
+   */
+  @AlgoliaExperimentalDsl
+  public fun facet(root: FilterGroup): FacetFilters? =
+    wrapFacet(toLegacyRows(root, FilterFamily.Facet))
+
+  /**
+   * Legacy [OptionalFilters] for [Filter.Facet] leaves in [root].
+   *
+   * Same family rule and reject cases as [facet]. Returns `null` when no Facet leaf remains.
+   */
+  @AlgoliaExperimentalDsl
+  public fun optional(root: FilterGroup): OptionalFilters? =
+    wrapOptional(toLegacyRows(root, FilterFamily.Facet))
+
+  /**
+   * Legacy [NumericFilters] for [Filter.Comparison] and [Filter.Range] leaves in [root].
+   *
+   * Ignores [Filter.Facet] and [Filter.Tag]. Throws [IllegalArgumentException] for a mixed-family
+   * [FilterGroup.Or] or an `And` nested in `Or` that the nested-list format cannot encode. Returns
+   * `null` when no numeric leaf remains.
+   */
+  @AlgoliaExperimentalDsl
+  public fun numeric(root: FilterGroup): NumericFilters? =
+    wrapNumeric(toLegacyRows(root, FilterFamily.Numeric))
+
+  /**
+   * Legacy [TagFilters] for [Filter.Tag] leaves in [root].
+   *
+   * Ignores [Filter.Facet], [Filter.Comparison], and [Filter.Range]. Throws
+   * [IllegalArgumentException] for a mixed-family [FilterGroup.Or] or an `And` nested in `Or` that
+   * the nested-list format cannot encode. Returns `null` when no Tag leaf remains.
+   */
+  @AlgoliaExperimentalDsl
+  public fun tag(root: FilterGroup): TagFilters? = wrapTag(toLegacyRows(root, FilterFamily.Tag))
+}
+
+private enum class FilterFamily {
+  Facet,
+  Numeric,
+  Tag,
+}
+
+private fun toLegacyRows(root: FilterGroup, family: FilterFamily): List<List<String>> =
+  toRows(root, family, negated = false)
+
+private fun toRows(
+  group: FilterGroup,
+  family: FilterFamily,
+  negated: Boolean,
+): List<List<String>> {
+  return when (group) {
+    is Filter -> {
+      if (familyOf(group) != family) {
+        emptyList()
+      } else {
+        listOf(encodeLeaf(group, negated))
+      }
+    }
+    is FilterGroup.Not -> toRows(group.child, family, !negated)
+    is FilterGroup.And -> convertAnd(group.children, family, negated)
+    is FilterGroup.Or -> convertOr(group.children, family, negated)
+  }
+}
+
+private fun convertAnd(
+  children: List<FilterGroup>,
+  family: FilterFamily,
+  negated: Boolean,
+): List<List<String>> {
+  val relevant = children.filter { family in leafFamilies(it) }
+  if (relevant.isEmpty()) return emptyList()
+  if (negated) {
+    return if (relevant.size == 1) {
+      toRows(relevant.single(), family, negated = true)
+    } else {
+      convertOr(relevant.map { FilterGroup.Not(it) }, family, negated = false)
+    }
+  }
+  return relevant.flatMap { toRows(it, family, negated = false) }.filter { it.isNotEmpty() }
+}
+
+private fun convertOr(
+  children: List<FilterGroup>,
+  family: FilterFamily,
+  negated: Boolean,
+): List<List<String>> {
+  val families = children.fold(emptySet<FilterFamily>()) { acc, child -> acc + leafFamilies(child) }
+  require(families.size <= 1) {
+    "Or mixes filter families $families. List<List<String>> cannot encode a mixed-family Or."
+  }
+  if (family !in families) return emptyList()
+  if (negated) {
+    return children.flatMap { toRows(it, family, negated = true) }.filter { it.isNotEmpty() }
+  }
+  val literals = mutableListOf<String>()
+  for (child in children) {
+    val rows = toRows(child, family, negated = false).filter { it.isNotEmpty() }
+    when (rows.size) {
+      0 -> Unit
+      1 -> literals += rows.single()
+      else ->
+        throw IllegalArgumentException(
+          "Or contains an And that List<List<String>> cannot encode. " +
+            "A nested And inside Or would require OR-of-ANDs."
+        )
+    }
+  }
+  return if (literals.isEmpty()) emptyList() else listOf(literals)
+}
+
+private fun familyOf(filter: Filter): FilterFamily =
+  when (filter) {
+    is Filter.Facet -> FilterFamily.Facet
+    is Filter.Tag -> FilterFamily.Tag
+    is Filter.Comparison,
+    is Filter.Range -> FilterFamily.Numeric
+  }
+
+private fun leafFamilies(group: FilterGroup): Set<FilterFamily> =
+  when (group) {
+    is Filter -> setOf(familyOf(group))
+    is FilterGroup.And ->
+      group.children.fold(emptySet()) { acc, child -> acc + leafFamilies(child) }
+    is FilterGroup.Or -> group.children.fold(emptySet()) { acc, child -> acc + leafFamilies(child) }
+    is FilterGroup.Not -> leafFamilies(group.child)
+  }
+
+private fun encodeLeaf(filter: Filter, negated: Boolean): List<String> {
+  return when (filter) {
+    is Filter.Facet -> {
+      val attribute = filter.attribute.escape()
+      val value = buildString {
+        if (negated) append('-')
+        append(filter.value.escape())
+      }
+      val score = filter.score?.let { "<score=$it>" }.orEmpty()
+      listOf("$attribute:$value$score")
+    }
+    is Filter.Tag -> {
+      val raw = filter.value.escape()
+      listOf(if (negated) "-$raw" else raw)
+    }
+    is Filter.Comparison -> {
+      val operator = if (negated) filter.operator.negated() else filter.operator
+      listOf("${filter.attribute.escape()} ${operator.raw} ${filter.value}")
+    }
+    is Filter.Range -> {
+      val attribute = filter.attribute.escape()
+      if (negated) {
+        listOf("$attribute < ${filter.lowerBound}", "$attribute > ${filter.upperBound}")
+      } else {
+        listOf("$attribute:${filter.lowerBound} TO ${filter.upperBound}")
+      }
+    }
+  }
+}
+
+private fun NumericOperator.negated(): NumericOperator =
+  when (this) {
+    NumericOperator.Less -> NumericOperator.GreaterOrEquals
+    NumericOperator.LessOrEquals -> NumericOperator.Greater
+    NumericOperator.Equals -> NumericOperator.NotEquals
+    NumericOperator.NotEquals -> NumericOperator.Equals
+    NumericOperator.Greater -> NumericOperator.LessOrEquals
+    NumericOperator.GreaterOrEquals -> NumericOperator.Less
+  }
+
+private fun String.escapeQuotation(): String = replace("\"", "\\\"")
+
+private fun String.escape(): String = "\"${escapeQuotation()}\""
+
+private fun wrapFacet(rows: List<List<String>>): FacetFilters? {
+  val compact = rows.filter { it.isNotEmpty() }
+  if (compact.isEmpty()) return null
+  return FacetFilters.of(compact.map { row -> FacetFilters.of(row.map { FacetFilters.of(it) }) })
+}
+
+private fun wrapOptional(rows: List<List<String>>): OptionalFilters? {
+  val compact = rows.filter { it.isNotEmpty() }
+  if (compact.isEmpty()) return null
+  return OptionalFilters.of(
+    compact.map { row -> OptionalFilters.of(row.map { OptionalFilters.of(it) }) }
+  )
+}
+
+private fun wrapNumeric(rows: List<List<String>>): NumericFilters? {
+  val compact = rows.filter { it.isNotEmpty() }
+  if (compact.isEmpty()) return null
+  return NumericFilters.of(
+    compact.map { row -> NumericFilters.of(row.map { NumericFilters.of(it) }) }
+  )
+}
+
+private fun wrapTag(rows: List<List<String>>): TagFilters? {
+  val compact = rows.filter { it.isNotEmpty() }
+  if (compact.isEmpty()) return null
+  return TagFilters.of(compact.map { row -> TagFilters.of(row.map { TagFilters.of(it) }) })
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterSqlConverter.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/filter/FilterSqlConverter.kt
@@ -1,0 +1,145 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl.filter
+
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+
+/**
+ * Converts a typed [FilterGroup] tree to an Algolia `filters` SQL string.
+ *
+ * Matches version 2 `FilterGroupsConverter.SQL` leaf syntax (`attribute:value`, `_tags:value`,
+ * `attribute op number`, `attribute:lower TO upper`, `attribute:value<score=N>`) and group joining
+ * (`AND` / `OR` / `NOT`). Empty [FilterGroup.And] and [FilterGroup.Or] groups become `null` so
+ * `SearchParamsObject.filters` can stay omitted.
+ *
+ * [FilterGroup.Or] has no compile-time leaf kind. This converter classifies children at runtime:
+ * - An `Or` may contain only leaves of one family: all [Filter.Facet], all [Filter.Tag], or all
+ *   numeric ([Filter.Comparison] / [Filter.Range]). [FilterGroup.Not] around a leaf stays in that
+ *   leaf's family.
+ * - Mixed-type `Or` throws [IllegalArgumentException].
+ * - `Or` of nested [FilterGroup.And] or [FilterGroup.Or] throws [IllegalArgumentException]. The
+ *   Algolia `filters` grammar does not allow OR of conjunctions or nested disjunctions.
+ *
+ * Attributes and values are quoted when they contain spaces, quotes, or the keywords `AND`, `OR`,
+ * or `NOT`.
+ *
+ * [Documentation](https://www.algolia.com/doc/api-reference/api-parameters/filters/)
+ */
+@AlgoliaExperimentalDsl
+public object FilterSqlConverter {
+
+  /**
+   * Returns the SQL `filters` string for [root], or `null` when [root] is an empty
+   * [FilterGroup.And] or [FilterGroup.Or] (including an `And` / `Or` whose children are all empty).
+   */
+  public operator fun invoke(root: FilterGroup): String? = emit(root)
+
+  private fun emit(node: FilterGroup): String? {
+    return when (node) {
+      is Filter.Facet -> emitFacet(node)
+      is Filter.Tag -> emitTag(node)
+      is Filter.Comparison -> emitComparison(node)
+      is Filter.Range -> emitRange(node)
+      is FilterGroup.And -> emitAnd(node)
+      is FilterGroup.Or -> emitOr(node)
+      is FilterGroup.Not -> emitNot(node)
+    }
+  }
+
+  private fun emitFacet(filter: Filter.Facet): String {
+    val attribute = quote(filter.attribute)
+    val value = quote(filter.value)
+    val score = filter.score?.let { "<score=$it>" }.orEmpty()
+    return "$attribute:$value$score"
+  }
+
+  private fun emitTag(filter: Filter.Tag): String = "_tags:${quote(filter.value)}"
+
+  private fun emitComparison(filter: Filter.Comparison): String =
+    "${quote(filter.attribute)} ${filter.operator.raw} ${filter.value}"
+
+  private fun emitRange(filter: Filter.Range): String =
+    "${quote(filter.attribute)}:${filter.lowerBound} TO ${filter.upperBound}"
+
+  private fun emitAnd(group: FilterGroup.And): String? {
+    val parts = group.children.mapNotNull(::emit)
+    if (parts.isEmpty()) return null
+    return parts.joinToString(separator = " AND ", prefix = "(", postfix = ")")
+  }
+
+  private fun emitOr(group: FilterGroup.Or): String? {
+    if (group.children.isEmpty()) return null
+    validateOr(group)
+    val parts = group.children.map(::requireEmit)
+    return parts.joinToString(separator = " OR ", prefix = "(", postfix = ")")
+  }
+
+  private fun emitNot(group: FilterGroup.Not): String {
+    val child = group.child
+    val inner = requireEmit(child)
+    return when (child) {
+      is FilterGroup.And,
+      is FilterGroup.Or -> "NOT $inner"
+      is FilterGroup.Not -> "NOT ($inner)"
+      else -> "NOT $inner"
+    }
+  }
+
+  private fun requireEmit(node: FilterGroup): String =
+    emit(node)
+      ?: throw IllegalArgumentException(
+        "FilterGroup.Not and FilterGroup.Or cannot wrap an empty And or Or group."
+      )
+
+  private fun validateOr(group: FilterGroup.Or) {
+    val families = group.children.map(::orFamily)
+    val unique = families.distinct()
+    if (unique.size > 1) {
+      throw IllegalArgumentException(
+        "Or may contain only leaves of one family: all Facet, all Tag, or all " +
+          "Comparison/Range (numeric). This Or mixes ${unique.joinToString(" and ")}."
+      )
+    }
+  }
+
+  /**
+   * Classifies an `Or` child. [FilterGroup.Not] unwraps to the inner leaf family. Nested `And` /
+   * `Or` cannot be encoded in Algolia `filters` SQL.
+   */
+  private fun orFamily(node: FilterGroup): OrFamily {
+    return when (node) {
+      is Filter.Facet -> OrFamily.Facet
+      is Filter.Tag -> OrFamily.Tag
+      is Filter.Comparison,
+      is Filter.Range -> OrFamily.Numeric
+      is FilterGroup.Not -> orFamily(node.child)
+      is FilterGroup.And ->
+        throw IllegalArgumentException(
+          "Or cannot contain nested And groups. The Algolia filters grammar does not allow OR of conjunctions."
+        )
+      is FilterGroup.Or ->
+        throw IllegalArgumentException(
+          "Or cannot contain nested Or groups. The Algolia filters grammar does not allow nested disjunctions."
+        )
+    }
+  }
+
+  private fun quote(raw: String): String {
+    if (!needsQuotes(raw)) return raw
+    return "\"${raw.replace("\"", "\\\"")}\""
+  }
+
+  private fun needsQuotes(raw: String): Boolean {
+    if (raw.isEmpty()) return true
+    if (raw.any { it == ' ' || it == '"' || it == '\'' }) return true
+    return KEYWORD.containsMatchIn(raw)
+  }
+
+  private enum class OrFamily {
+    Facet,
+    Tag,
+    Numeric,
+  }
+
+  private val KEYWORD: Regex = Regex("(?i)\\b(?:AND|OR|NOT)\\b")
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
@@ -1,0 +1,338 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl.rule
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.dsl.filter.FilterDsl
+import com.algolia.client.dsl.filter.filters as buildFilters
+import com.algolia.client.dsl.generated.ConsequenceParamsBuilder
+import com.algolia.client.model.search.Anchoring
+import com.algolia.client.model.search.Condition
+import com.algolia.client.model.search.Consequence
+import com.algolia.client.model.search.ConsequenceHide
+import com.algolia.client.model.search.ConsequenceParams
+import com.algolia.client.model.search.ConsequenceQuery
+import com.algolia.client.model.search.ConsequenceRedirect
+import com.algolia.client.model.search.Promote
+import com.algolia.client.model.search.PromoteObjectID
+import com.algolia.client.model.search.PromoteObjectIDs
+import com.algolia.client.model.search.Rule
+import com.algolia.client.model.search.TimeRange
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Constructs a [Rule] from the DSL block.
+ *
+ * [Rule.objectID] is required. Set it in the block, or pass it to [rule]. Last write wins: a later
+ * assignment or `condition { }` / `consequence { }` / `conditions { }` call replaces an earlier
+ * value for the same field. An omitted [consequence] becomes an empty [Consequence].
+ *
+ * ```
+ * val built =
+ *   rule("promo-iphone") {
+ *     condition {
+ *       pattern = "smartphone"
+ *       anchoring = Anchoring.Is
+ *     }
+ *     consequence {
+ *       params {
+ *         query("iphone")
+ *         filters { facet("brand", "Apple") }
+ *       }
+ *       promote("object-1", position = 0)
+ *     }
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun rule(block: RuleDsl.() -> Unit): Rule = RuleDsl().apply(block).build()
+
+/**
+ * Constructs a [Rule] with [objectID] already set.
+ *
+ * The [block] may overwrite [RuleDsl.objectID]. Last write wins.
+ *
+ * ```
+ * val built = rule("promo-iphone") { consequence { hide("object-9") } }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun rule(objectID: String, block: RuleDsl.() -> Unit = {}): Rule =
+  RuleDsl()
+    .apply {
+      this.objectID = objectID
+      block()
+    }
+    .build()
+
+/** Builds a [Rule] with [condition] and [consequence] blocks. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class RuleDsl {
+  /** Unique identifier of the rule. Required. */
+  public var objectID: String? = null
+
+  /** Description of the rule's purpose. */
+  public var description: String? = null
+
+  /** Whether the rule is active. */
+  public var enabled: Boolean? = null
+
+  /** Rule scope. */
+  public var scope: String? = null
+
+  /** Tags attached to the rule. */
+  public var tags: List<String>? = null
+
+  /** Single condition that triggers the rule. Last write wins versus [condition]. */
+  public var condition: Condition? = null
+
+  /** Conditions that trigger the rule. Last write wins versus [conditions]. */
+  public var conditions: List<Condition>? = null
+
+  /** Effect of the rule. Last write wins versus [consequence]. */
+  public var consequence: Consequence? = null
+
+  /** Time periods when the rule is active. */
+  public var validity: List<TimeRange>? = null
+
+  /**
+   * Sets [condition] from a [ConditionDsl] block.
+   *
+   * Last write wins: this replaces any earlier [condition] value.
+   */
+  public fun condition(block: ConditionDsl.() -> Unit) {
+    condition = ConditionDsl().apply(block).build()
+  }
+
+  /**
+   * Sets [conditions] from a [ConditionsDsl] block.
+   *
+   * Last write wins: this replaces any earlier [conditions] value.
+   */
+  public fun conditions(block: ConditionsDsl.() -> Unit) {
+    conditions = ConditionsDsl().apply(block).build()
+  }
+
+  /**
+   * Sets [consequence] from a [ConsequenceDsl] block.
+   *
+   * Last write wins: this replaces any earlier [consequence] value.
+   */
+  public fun consequence(block: ConsequenceDsl.() -> Unit) {
+    consequence = ConsequenceDsl().apply(block).build()
+  }
+
+  internal fun build(): Rule {
+    val id = objectID
+    require(!id.isNullOrEmpty()) { "rule { } requires objectID" }
+    return Rule(
+      objectID = id,
+      consequence = consequence ?: Consequence(),
+      conditions = conditions,
+      description = description,
+      enabled = enabled,
+      validity = validity,
+      tags = tags,
+      scope = scope,
+      condition = condition,
+    )
+  }
+}
+
+/** Builds a [Condition] that triggers a [Rule]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class ConditionDsl {
+  /**
+   * Query pattern that triggers the rule. A literal string, or `{facet:ATTRIBUTE}` from
+   * [facetPattern].
+   */
+  public var pattern: String? = null
+
+  /** Which part of the query [pattern] must match. */
+  public var anchoring: Anchoring? = null
+
+  /** Whether the pattern should match plurals, synonyms, and typos. */
+  public var alternatives: Boolean? = null
+
+  /** Extra restriction that must match `ruleContexts`. */
+  public var context: String? = null
+
+  /** Filters that trigger the rule, as a SQL string. Last write wins versus [filters]. */
+  public var filters: String? = null
+
+  /** Sets [pattern] to `{facet:ATTRIBUTE}` for [attribute]. */
+  public fun facetPattern(attribute: String) {
+    pattern = "{facet:$attribute}"
+  }
+
+  /**
+   * Sets [filters] from a typed filter block as a SQL string.
+   *
+   * Last write wins: this replaces any earlier [filters] value.
+   */
+  public fun filters(block: FilterDsl.() -> Unit) {
+    filters = buildFilters(block).asSql()
+  }
+
+  internal fun build(): Condition =
+    Condition(
+      pattern = pattern,
+      anchoring = anchoring,
+      alternatives = alternatives,
+      context = context,
+      filters = filters,
+    )
+}
+
+/** Builds a [List] of [Condition] values. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class ConditionsDsl {
+  private val values: MutableList<Condition> = mutableListOf()
+
+  /** Adds a [Condition] from [block]. */
+  public fun condition(block: ConditionDsl.() -> Unit) {
+    values += ConditionDsl().apply(block).build()
+  }
+
+  /** Adds [this] condition. */
+  public operator fun Condition.unaryPlus() {
+    values += this
+  }
+
+  internal fun build(): List<Condition> = values.toList()
+}
+
+/** Builds a [Consequence] for a [Rule]. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class ConsequenceDsl {
+  /**
+   * Query parameters applied by the rule. Last write wins versus [params].
+   *
+   * Assign a ready [ConsequenceParams], or build one with [params].
+   */
+  public var params: ConsequenceParams? = null
+
+  /** Promoted records. [promote] appends. Assigning this property replaces the list. */
+  public var promote: List<Promote>? = null
+
+  /** Whether promoted records must also match active filters. */
+  public var filterPromotes: Boolean? = null
+
+  /** Hidden records. [hide] appends. Assigning this property replaces the list. */
+  public var hide: List<ConsequenceHide>? = null
+
+  /** Redirect to a virtual replica. Last write wins versus [redirect]. */
+  public var redirect: ConsequenceRedirect? = null
+
+  /** Custom data appended to the response `userData` array. */
+  public var userData: JsonObject? = null
+
+  /**
+   * Sets [params] from the generated [ConsequenceParamsBuilder].
+   *
+   * Last write wins: this replaces any earlier [params] value. Use [filters] and the other filter
+   * helpers on the builder for typed filter blocks.
+   */
+  public fun params(block: ConsequenceParamsBuilder.() -> Unit) {
+    params = ConsequenceParamsBuilder().apply(block).build()
+  }
+
+  /** Appends a single-record promotion at [position]. */
+  public fun promote(objectID: String, position: Int) {
+    promote = (promote ?: emptyList()) + Promote.of(PromoteObjectID(objectID, position))
+  }
+
+  /** Appends a group promotion of [objectIDs] at [position]. */
+  public fun promote(objectIDs: List<String>, position: Int) {
+    promote = (promote ?: emptyList()) + Promote.of(PromoteObjectIDs(objectIDs, position))
+  }
+
+  /** Appends a hidden record. */
+  public fun hide(objectID: String) {
+    hide = (hide ?: emptyList()) + ConsequenceHide(objectID)
+  }
+
+  /**
+   * Sets [redirect] to [indexName].
+   *
+   * Last write wins: this replaces any earlier [redirect] value.
+   */
+  public fun redirect(indexName: String) {
+    redirect = ConsequenceRedirect(indexName)
+  }
+
+  internal fun build(): Consequence =
+    Consequence(
+      params = params,
+      promote = promote,
+      filterPromotes = filterPromotes,
+      hide = hide,
+      redirect = redirect,
+      userData = userData,
+    )
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.filters] from a typed filter block as a SQL string.
+ *
+ * Last write wins: this replaces any earlier `filters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.filters(block: FilterDsl.() -> Unit) {
+  filters = buildFilters(block).asSql()
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.facetFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.facetFilters(block: FilterDsl.() -> Unit) {
+  facetFilters = buildFilters(block).asFacetFilters()
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
+  optionalFilters = buildFilters(block).asOptionalFilters()
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.numericFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.numericFilters(block: FilterDsl.() -> Unit) {
+  numericFilters = buildFilters(block).asNumericFilters()
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.tagFilters] from a typed filter block as a legacy wrapper.
+ *
+ * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.tagFilters(block: FilterDsl.() -> Unit) {
+  tagFilters = buildFilters(block).asTagFilters()
+}
+
+/**
+ * Sets [ConsequenceParamsBuilder.query] to a replacement query string.
+ *
+ * Last write wins: this replaces any earlier `query` value in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceParamsBuilder.query(value: String) {
+  query = ConsequenceQuery.of(value)
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
@@ -4,8 +4,6 @@ package com.algolia.client.dsl.rule
 
 import com.algolia.client.dsl.AlgoliaDsl
 import com.algolia.client.dsl.AlgoliaExperimentalDsl
-import com.algolia.client.dsl.filter.FilterDsl
-import com.algolia.client.dsl.filter.filters as buildFilters
 import com.algolia.client.dsl.generated.ConditionBuilder
 import com.algolia.client.dsl.generated.ConsequenceBuilder
 import com.algolia.client.dsl.generated.ConsequenceParamsBuilder
@@ -118,16 +116,6 @@ public fun ConditionBuilder.facetPattern(attribute: String) {
 }
 
 /**
- * Sets [ConditionBuilder.filters] from a typed filter block as a SQL string.
- *
- * Last write wins: this replaces any earlier `filters` value.
- */
-@AlgoliaExperimentalDsl
-public fun ConditionBuilder.filters(block: FilterDsl.() -> Unit) {
-  filters = buildFilters(block).asSql()
-}
-
-/**
  * Sets [ConsequenceBuilder.params] from the generated [ConsequenceParamsBuilder].
  *
  * Last write wins: this replaces any earlier [ConsequenceBuilder.params] value.
@@ -163,56 +151,6 @@ public fun ConsequenceBuilder.hide(objectID: String) {
 @AlgoliaExperimentalDsl
 public fun ConsequenceBuilder.redirect(indexName: String) {
   redirect = ConsequenceRedirect(indexName)
-}
-
-/**
- * Sets [ConsequenceParamsBuilder.filters] from a typed filter block as a SQL string.
- *
- * Last write wins: this replaces any earlier `filters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun ConsequenceParamsBuilder.filters(block: FilterDsl.() -> Unit) {
-  filters = buildFilters(block).asSql()
-}
-
-/**
- * Sets [ConsequenceParamsBuilder.facetFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `facetFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun ConsequenceParamsBuilder.facetFilters(block: FilterDsl.() -> Unit) {
-  facetFilters = buildFilters(block).asFacetFilters()
-}
-
-/**
- * Sets [ConsequenceParamsBuilder.optionalFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `optionalFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun ConsequenceParamsBuilder.optionalFilters(block: FilterDsl.() -> Unit) {
-  optionalFilters = buildFilters(block).asOptionalFilters()
-}
-
-/**
- * Sets [ConsequenceParamsBuilder.numericFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `numericFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun ConsequenceParamsBuilder.numericFilters(block: FilterDsl.() -> Unit) {
-  numericFilters = buildFilters(block).asNumericFilters()
-}
-
-/**
- * Sets [ConsequenceParamsBuilder.tagFilters] from a typed filter block as a legacy wrapper.
- *
- * Last write wins: this replaces any earlier `tagFilters` value in the same builder.
- */
-@AlgoliaExperimentalDsl
-public fun ConsequenceParamsBuilder.tagFilters(block: FilterDsl.() -> Unit) {
-  tagFilters = buildFilters(block).asTagFilters()
 }
 
 /**

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/rule/RuleDsl.kt
@@ -6,27 +6,25 @@ import com.algolia.client.dsl.AlgoliaDsl
 import com.algolia.client.dsl.AlgoliaExperimentalDsl
 import com.algolia.client.dsl.filter.FilterDsl
 import com.algolia.client.dsl.filter.filters as buildFilters
+import com.algolia.client.dsl.generated.ConditionBuilder
+import com.algolia.client.dsl.generated.ConsequenceBuilder
 import com.algolia.client.dsl.generated.ConsequenceParamsBuilder
-import com.algolia.client.model.search.Anchoring
+import com.algolia.client.dsl.generated.RuleBuilder
 import com.algolia.client.model.search.Condition
 import com.algolia.client.model.search.Consequence
 import com.algolia.client.model.search.ConsequenceHide
-import com.algolia.client.model.search.ConsequenceParams
 import com.algolia.client.model.search.ConsequenceQuery
 import com.algolia.client.model.search.ConsequenceRedirect
 import com.algolia.client.model.search.Promote
 import com.algolia.client.model.search.PromoteObjectID
 import com.algolia.client.model.search.PromoteObjectIDs
 import com.algolia.client.model.search.Rule
-import com.algolia.client.model.search.TimeRange
-import kotlinx.serialization.json.JsonObject
 
 /**
- * Constructs a [Rule] from the DSL block.
+ * Constructs a [Rule] from the generated [RuleBuilder].
  *
- * [Rule.objectID] is required. Set it in the block, or pass it to [rule]. Last write wins: a later
- * assignment or `condition { }` / `consequence { }` / `conditions { }` call replaces an earlier
- * value for the same field. An omitted [consequence] becomes an empty [Consequence].
+ * [Rule.objectID] is required. Set it in the block, or pass it to [rule]. An omitted [consequence]
+ * becomes an empty [Consequence]. Last write wins on each builder property.
  *
  * ```
  * val built =
@@ -46,145 +44,52 @@ import kotlinx.serialization.json.JsonObject
  * ```
  */
 @AlgoliaExperimentalDsl
-public fun rule(block: RuleDsl.() -> Unit): Rule = RuleDsl().apply(block).build()
+public fun rule(block: RuleBuilder.() -> Unit): Rule =
+  RuleBuilder().apply(block).apply { if (consequence == null) consequence = Consequence() }.build()
 
 /**
  * Constructs a [Rule] with [objectID] already set.
  *
- * The [block] may overwrite [RuleDsl.objectID]. Last write wins.
+ * The [block] may overwrite [RuleBuilder.objectID]. Last write wins.
  *
  * ```
  * val built = rule("promo-iphone") { consequence { hide("object-9") } }
  * ```
  */
 @AlgoliaExperimentalDsl
-public fun rule(objectID: String, block: RuleDsl.() -> Unit = {}): Rule =
-  RuleDsl()
-    .apply {
-      this.objectID = objectID
-      block()
-    }
-    .build()
-
-/** Builds a [Rule] with [condition] and [consequence] blocks. */
-@AlgoliaDsl
-@AlgoliaExperimentalDsl
-public class RuleDsl {
-  /** Unique identifier of the rule. Required. */
-  public var objectID: String? = null
-
-  /** Description of the rule's purpose. */
-  public var description: String? = null
-
-  /** Whether the rule is active. */
-  public var enabled: Boolean? = null
-
-  /** Rule scope. */
-  public var scope: String? = null
-
-  /** Tags attached to the rule. */
-  public var tags: List<String>? = null
-
-  /** Single condition that triggers the rule. Last write wins versus [condition]. */
-  public var condition: Condition? = null
-
-  /** Conditions that trigger the rule. Last write wins versus [conditions]. */
-  public var conditions: List<Condition>? = null
-
-  /** Effect of the rule. Last write wins versus [consequence]. */
-  public var consequence: Consequence? = null
-
-  /** Time periods when the rule is active. */
-  public var validity: List<TimeRange>? = null
-
-  /**
-   * Sets [condition] from a [ConditionDsl] block.
-   *
-   * Last write wins: this replaces any earlier [condition] value.
-   */
-  public fun condition(block: ConditionDsl.() -> Unit) {
-    condition = ConditionDsl().apply(block).build()
-  }
-
-  /**
-   * Sets [conditions] from a [ConditionsDsl] block.
-   *
-   * Last write wins: this replaces any earlier [conditions] value.
-   */
-  public fun conditions(block: ConditionsDsl.() -> Unit) {
-    conditions = ConditionsDsl().apply(block).build()
-  }
-
-  /**
-   * Sets [consequence] from a [ConsequenceDsl] block.
-   *
-   * Last write wins: this replaces any earlier [consequence] value.
-   */
-  public fun consequence(block: ConsequenceDsl.() -> Unit) {
-    consequence = ConsequenceDsl().apply(block).build()
-  }
-
-  internal fun build(): Rule {
-    val id = objectID
-    require(!id.isNullOrEmpty()) { "rule { } requires objectID" }
-    return Rule(
-      objectID = id,
-      consequence = consequence ?: Consequence(),
-      conditions = conditions,
-      description = description,
-      enabled = enabled,
-      validity = validity,
-      tags = tags,
-      scope = scope,
-      condition = condition,
-    )
-  }
+public fun rule(objectID: String, block: RuleBuilder.() -> Unit = {}): Rule = rule {
+  this.objectID = objectID
+  block()
 }
 
-/** Builds a [Condition] that triggers a [Rule]. */
-@AlgoliaDsl
+/**
+ * Sets [RuleBuilder.condition] from a [ConditionBuilder] block.
+ *
+ * Last write wins: this replaces any earlier [RuleBuilder.condition] value.
+ */
 @AlgoliaExperimentalDsl
-public class ConditionDsl {
-  /**
-   * Query pattern that triggers the rule. A literal string, or `{facet:ATTRIBUTE}` from
-   * [facetPattern].
-   */
-  public var pattern: String? = null
+public fun RuleBuilder.condition(block: ConditionBuilder.() -> Unit) {
+  condition = ConditionBuilder().apply(block).build()
+}
 
-  /** Which part of the query [pattern] must match. */
-  public var anchoring: Anchoring? = null
+/**
+ * Sets [RuleBuilder.conditions] from a [ConditionsDsl] block.
+ *
+ * Last write wins: this replaces any earlier [RuleBuilder.conditions] value.
+ */
+@AlgoliaExperimentalDsl
+public fun RuleBuilder.conditions(block: ConditionsDsl.() -> Unit) {
+  conditions = ConditionsDsl().apply(block).build()
+}
 
-  /** Whether the pattern should match plurals, synonyms, and typos. */
-  public var alternatives: Boolean? = null
-
-  /** Extra restriction that must match `ruleContexts`. */
-  public var context: String? = null
-
-  /** Filters that trigger the rule, as a SQL string. Last write wins versus [filters]. */
-  public var filters: String? = null
-
-  /** Sets [pattern] to `{facet:ATTRIBUTE}` for [attribute]. */
-  public fun facetPattern(attribute: String) {
-    pattern = "{facet:$attribute}"
-  }
-
-  /**
-   * Sets [filters] from a typed filter block as a SQL string.
-   *
-   * Last write wins: this replaces any earlier [filters] value.
-   */
-  public fun filters(block: FilterDsl.() -> Unit) {
-    filters = buildFilters(block).asSql()
-  }
-
-  internal fun build(): Condition =
-    Condition(
-      pattern = pattern,
-      anchoring = anchoring,
-      alternatives = alternatives,
-      context = context,
-      filters = filters,
-    )
+/**
+ * Sets [RuleBuilder.consequence] from a [ConsequenceBuilder] block.
+ *
+ * Last write wins: this replaces any earlier [RuleBuilder.consequence] value.
+ */
+@AlgoliaExperimentalDsl
+public fun RuleBuilder.consequence(block: ConsequenceBuilder.() -> Unit) {
+  consequence = ConsequenceBuilder().apply(block).build()
 }
 
 /** Builds a [List] of [Condition] values. */
@@ -194,8 +99,8 @@ public class ConditionsDsl {
   private val values: MutableList<Condition> = mutableListOf()
 
   /** Adds a [Condition] from [block]. */
-  public fun condition(block: ConditionDsl.() -> Unit) {
-    values += ConditionDsl().apply(block).build()
+  public fun condition(block: ConditionBuilder.() -> Unit) {
+    values += ConditionBuilder().apply(block).build()
   }
 
   /** Adds [this] condition. */
@@ -206,75 +111,58 @@ public class ConditionsDsl {
   internal fun build(): List<Condition> = values.toList()
 }
 
-/** Builds a [Consequence] for a [Rule]. */
-@AlgoliaDsl
+/** Sets [ConditionBuilder.pattern] to `{facet:ATTRIBUTE}` for [attribute]. */
 @AlgoliaExperimentalDsl
-public class ConsequenceDsl {
-  /**
-   * Query parameters applied by the rule. Last write wins versus [params].
-   *
-   * Assign a ready [ConsequenceParams], or build one with [params].
-   */
-  public var params: ConsequenceParams? = null
+public fun ConditionBuilder.facetPattern(attribute: String) {
+  pattern = "{facet:$attribute}"
+}
 
-  /** Promoted records. [promote] appends. Assigning this property replaces the list. */
-  public var promote: List<Promote>? = null
+/**
+ * Sets [ConditionBuilder.filters] from a typed filter block as a SQL string.
+ *
+ * Last write wins: this replaces any earlier `filters` value.
+ */
+@AlgoliaExperimentalDsl
+public fun ConditionBuilder.filters(block: FilterDsl.() -> Unit) {
+  filters = buildFilters(block).asSql()
+}
 
-  /** Whether promoted records must also match active filters. */
-  public var filterPromotes: Boolean? = null
+/**
+ * Sets [ConsequenceBuilder.params] from the generated [ConsequenceParamsBuilder].
+ *
+ * Last write wins: this replaces any earlier [ConsequenceBuilder.params] value.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceBuilder.params(block: ConsequenceParamsBuilder.() -> Unit) {
+  params = ConsequenceParamsBuilder().apply(block).build()
+}
 
-  /** Hidden records. [hide] appends. Assigning this property replaces the list. */
-  public var hide: List<ConsequenceHide>? = null
+/** Appends a single-record promotion at [position]. */
+@AlgoliaExperimentalDsl
+public fun ConsequenceBuilder.promote(objectID: String, position: Int) {
+  promote = (promote ?: emptyList()) + Promote.of(PromoteObjectID(objectID, position))
+}
 
-  /** Redirect to a virtual replica. Last write wins versus [redirect]. */
-  public var redirect: ConsequenceRedirect? = null
+/** Appends a group promotion of [objectIDs] at [position]. */
+@AlgoliaExperimentalDsl
+public fun ConsequenceBuilder.promote(objectIDs: List<String>, position: Int) {
+  promote = (promote ?: emptyList()) + Promote.of(PromoteObjectIDs(objectIDs, position))
+}
 
-  /** Custom data appended to the response `userData` array. */
-  public var userData: JsonObject? = null
+/** Appends a hidden record. */
+@AlgoliaExperimentalDsl
+public fun ConsequenceBuilder.hide(objectID: String) {
+  hide = (hide ?: emptyList()) + ConsequenceHide(objectID)
+}
 
-  /**
-   * Sets [params] from the generated [ConsequenceParamsBuilder].
-   *
-   * Last write wins: this replaces any earlier [params] value. Use [filters] and the other filter
-   * helpers on the builder for typed filter blocks.
-   */
-  public fun params(block: ConsequenceParamsBuilder.() -> Unit) {
-    params = ConsequenceParamsBuilder().apply(block).build()
-  }
-
-  /** Appends a single-record promotion at [position]. */
-  public fun promote(objectID: String, position: Int) {
-    promote = (promote ?: emptyList()) + Promote.of(PromoteObjectID(objectID, position))
-  }
-
-  /** Appends a group promotion of [objectIDs] at [position]. */
-  public fun promote(objectIDs: List<String>, position: Int) {
-    promote = (promote ?: emptyList()) + Promote.of(PromoteObjectIDs(objectIDs, position))
-  }
-
-  /** Appends a hidden record. */
-  public fun hide(objectID: String) {
-    hide = (hide ?: emptyList()) + ConsequenceHide(objectID)
-  }
-
-  /**
-   * Sets [redirect] to [indexName].
-   *
-   * Last write wins: this replaces any earlier [redirect] value.
-   */
-  public fun redirect(indexName: String) {
-    redirect = ConsequenceRedirect(indexName)
-  }
-
-  internal fun build(): Consequence =
-    Consequence(
-      params = params,
-      promote = promote,
-      filterPromotes = filterPromotes,
-      hide = hide,
-      redirect = redirect,
-      userData = userData,
-    )
+/**
+ * Sets [ConsequenceBuilder.redirect] to [indexName].
+ *
+ * Last write wins: this replaces any earlier [ConsequenceBuilder.redirect] value.
+ */
+@AlgoliaExperimentalDsl
+public fun ConsequenceBuilder.redirect(indexName: String) {
+  redirect = ConsequenceRedirect(indexName)
 }
 
 /**

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
@@ -11,18 +11,16 @@ import com.algolia.client.model.search.SynonymType
 /**
  * Constructs a [SynonymHit] from the generated [SynonymHitBuilder].
  *
- * Prefer the typed helpers ([regular], [oneWay], [altCorrection1], [altCorrection2], [placeholder])
- * so unused variant fields stay unset. Last write wins: a later assignment or helper call replaces
- * earlier values for the same field.
+ * Prefer the typed helpers ([synonym], [oneWaySynonym], [altCorrection1], [altCorrection2],
+ * [placeholder]) so unused variant fields stay unset. Last write wins: a later assignment or helper
+ * call replaces earlier values for the same field.
  *
  * ```
- * val regular =
- *   synonym {
- *     regular("syn-1") {
- *       +"car"
- *       +"auto"
- *       +"vehicle"
- *     }
+ * val hit =
+ *   synonym("syn-1") {
+ *     +"car"
+ *     +"auto"
+ *     +"vehicle"
  *   }
  * ```
  */
@@ -42,20 +40,14 @@ public fun synonym(block: SynonymHitBuilder.() -> Unit): SynonymHit =
  * ```
  */
 @AlgoliaExperimentalDsl
-public fun synonym(objectID: String, block: SynonymWordsDsl.() -> Unit): SynonymHit = synonym {
-  regular(objectID, block)
-}
-
-/**
- * Constructs a regular ([SynonymType.Synonym]) [SynonymHit] from [synonyms].
- *
- * ```
- * val hit = synonym("syn-1", listOf("car", "auto", "vehicle"))
- * ```
- */
-@AlgoliaExperimentalDsl
-public fun synonym(objectID: String, synonyms: List<String>): SynonymHit =
-  synonym(objectID) { synonyms.forEach { +it } }
+public fun synonym(objectID: String, block: SynonymWordsDsl.() -> Unit): SynonymHit =
+  SynonymHitBuilder()
+    .apply {
+      this.objectID = objectID
+      type = SynonymType.Synonym
+      synonyms(block)
+    }
+    .build()
 
 /**
  * Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit].
@@ -67,12 +59,15 @@ public fun oneWaySynonym(
   objectID: String,
   input: String,
   block: SynonymWordsDsl.() -> Unit,
-): SynonymHit = synonym { oneWay(objectID, input, block) }
-
-/** Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit] from [synonyms]. */
-@AlgoliaExperimentalDsl
-public fun oneWaySynonym(objectID: String, input: String, synonyms: List<String>): SynonymHit =
-  oneWaySynonym(objectID, input) { synonyms.forEach { +it } }
+): SynonymHit =
+  SynonymHitBuilder()
+    .apply {
+      this.objectID = objectID
+      type = SynonymType.OneWaySynonym
+      this.input = input
+      synonyms(block)
+    }
+    .build()
 
 /** Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
@@ -80,15 +75,15 @@ public fun altCorrection1(
   objectID: String,
   word: String,
   block: SynonymWordsDsl.() -> Unit,
-): SynonymHit = synonym { altCorrection1(objectID, word, block) }
-
-/**
- * Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit] from
- * [corrections].
- */
-@AlgoliaExperimentalDsl
-public fun altCorrection1(objectID: String, word: String, corrections: List<String>): SynonymHit =
-  altCorrection1(objectID, word) { corrections.forEach { +it } }
+): SynonymHit =
+  SynonymHitBuilder()
+    .apply {
+      this.objectID = objectID
+      type = SynonymType.AltCorrection1
+      this.word = word
+      corrections(block)
+    }
+    .build()
 
 /** Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
@@ -96,15 +91,15 @@ public fun altCorrection2(
   objectID: String,
   word: String,
   block: SynonymWordsDsl.() -> Unit,
-): SynonymHit = synonym { altCorrection2(objectID, word, block) }
-
-/**
- * Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit] from
- * [corrections].
- */
-@AlgoliaExperimentalDsl
-public fun altCorrection2(objectID: String, word: String, corrections: List<String>): SynonymHit =
-  altCorrection2(objectID, word) { corrections.forEach { +it } }
+): SynonymHit =
+  SynonymHitBuilder()
+    .apply {
+      this.objectID = objectID
+      type = SynonymType.AltCorrection2
+      this.word = word
+      corrections(block)
+    }
+    .build()
 
 /** Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
@@ -112,15 +107,15 @@ public fun placeholder(
   objectID: String,
   placeholder: String,
   block: SynonymWordsDsl.() -> Unit,
-): SynonymHit = synonym { placeholder(objectID, placeholder, block) }
-
-/** Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit] from [replacements]. */
-@AlgoliaExperimentalDsl
-public fun placeholder(
-  objectID: String,
-  placeholder: String,
-  replacements: List<String>,
-): SynonymHit = placeholder(objectID, placeholder) { replacements.forEach { +it } }
+): SynonymHit =
+  SynonymHitBuilder()
+    .apply {
+      this.objectID = objectID
+      type = SynonymType.Placeholder
+      this.placeholder = placeholder
+      replacements(block)
+    }
+    .build()
 
 /**
  * Sets [SynonymHitBuilder.synonyms] from [block]. Last write wins if [synonyms] was already set in
@@ -147,107 +142,6 @@ public fun SynonymHitBuilder.corrections(block: SynonymWordsDsl.() -> Unit) {
 @AlgoliaExperimentalDsl
 public fun SynonymHitBuilder.replacements(block: SynonymWordsDsl.() -> Unit) {
   replacements = SynonymWordsDsl().apply(block).build()
-}
-
-/**
- * Fills this builder as a regular ([SynonymType.Synonym]) synonym.
- *
- * Clears fields that other variants use.
- */
-@AlgoliaExperimentalDsl
-public fun SynonymHitBuilder.regular(objectID: String, block: SynonymWordsDsl.() -> Unit) {
-  this.objectID = objectID
-  type = SynonymType.Synonym
-  synonyms = SynonymWordsDsl().apply(block).build()
-  clearUnused(keepSynonyms = true)
-}
-
-/**
- * Fills this builder as a one-way ([SynonymType.OneWaySynonym]) synonym.
- *
- * Clears fields that other variants use.
- */
-@AlgoliaExperimentalDsl
-public fun SynonymHitBuilder.oneWay(
-  objectID: String,
-  input: String,
-  block: SynonymWordsDsl.() -> Unit,
-) {
-  this.objectID = objectID
-  type = SynonymType.OneWaySynonym
-  this.input = input
-  synonyms = SynonymWordsDsl().apply(block).build()
-  clearUnused(keepSynonyms = true, keepInput = true)
-}
-
-/**
- * Fills this builder as a one-typo alternative correction ([SynonymType.AltCorrection1]).
- *
- * Clears fields that other variants use.
- */
-@AlgoliaExperimentalDsl
-public fun SynonymHitBuilder.altCorrection1(
-  objectID: String,
-  word: String,
-  block: SynonymWordsDsl.() -> Unit,
-) {
-  this.objectID = objectID
-  type = SynonymType.AltCorrection1
-  this.word = word
-  corrections = SynonymWordsDsl().apply(block).build()
-  clearUnused(keepWord = true, keepCorrections = true)
-}
-
-/**
- * Fills this builder as a two-typo alternative correction ([SynonymType.AltCorrection2]).
- *
- * Clears fields that other variants use.
- */
-@AlgoliaExperimentalDsl
-public fun SynonymHitBuilder.altCorrection2(
-  objectID: String,
-  word: String,
-  block: SynonymWordsDsl.() -> Unit,
-) {
-  this.objectID = objectID
-  type = SynonymType.AltCorrection2
-  this.word = word
-  corrections = SynonymWordsDsl().apply(block).build()
-  clearUnused(keepWord = true, keepCorrections = true)
-}
-
-/**
- * Fills this builder as a placeholder ([SynonymType.Placeholder]) synonym.
- *
- * Clears fields that other variants use.
- */
-@AlgoliaExperimentalDsl
-public fun SynonymHitBuilder.placeholder(
-  objectID: String,
-  placeholder: String,
-  block: SynonymWordsDsl.() -> Unit,
-) {
-  this.objectID = objectID
-  type = SynonymType.Placeholder
-  this.placeholder = placeholder
-  replacements = SynonymWordsDsl().apply(block).build()
-  clearUnused(keepPlaceholder = true, keepReplacements = true)
-}
-
-private fun SynonymHitBuilder.clearUnused(
-  keepSynonyms: Boolean = false,
-  keepInput: Boolean = false,
-  keepWord: Boolean = false,
-  keepCorrections: Boolean = false,
-  keepPlaceholder: Boolean = false,
-  keepReplacements: Boolean = false,
-) {
-  if (!keepSynonyms) synonyms = null
-  if (!keepInput) input = null
-  if (!keepWord) word = null
-  if (!keepCorrections) corrections = null
-  if (!keepPlaceholder) placeholder = null
-  if (!keepReplacements) replacements = null
 }
 
 /** Collects synonym, correction, or replacement words. */

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
@@ -4,11 +4,12 @@ package com.algolia.client.dsl.synonym
 
 import com.algolia.client.dsl.AlgoliaDsl
 import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.dsl.generated.SynonymHitBuilder
 import com.algolia.client.model.search.SynonymHit
 import com.algolia.client.model.search.SynonymType
 
 /**
- * Constructs a [SynonymHit] from the DSL block.
+ * Constructs a [SynonymHit] from the generated [SynonymHitBuilder].
  *
  * Prefer the typed helpers ([regular], [oneWay], [altCorrection1], [altCorrection2], [placeholder])
  * so unused variant fields stay unset. Last write wins: a later assignment or helper call replaces
@@ -23,36 +24,11 @@ import com.algolia.client.model.search.SynonymType
  *       +"vehicle"
  *     }
  *   }
- *
- * val oneWay =
- *   synonym {
- *     oneWay("syn-2", input = "tablet") {
- *       +"ipad"
- *       +"galaxy tab"
- *     }
- *   }
- *
- * val alt1 =
- *   synonym {
- *     altCorrection1("syn-3", word = "trousers") { +"pants" }
- *   }
- *
- * val alt2 =
- *   synonym {
- *     altCorrection2("syn-4", word = "trousers") { +"pants" }
- *   }
- *
- * val token =
- *   synonym {
- *     placeholder("syn-5", placeholder = "<Street>") {
- *       +"street"
- *       +"st"
- *     }
- *   }
  * ```
  */
 @AlgoliaExperimentalDsl
-public fun synonym(block: SynonymDsl.() -> Unit): SynonymHit = SynonymDsl().apply(block).build()
+public fun synonym(block: SynonymHitBuilder.() -> Unit): SynonymHit =
+  SynonymHitBuilder().apply(block).build()
 
 /**
  * Constructs a regular ([SynonymType.Synonym]) [SynonymHit].
@@ -85,14 +61,6 @@ public fun synonym(objectID: String, synonyms: List<String>): SynonymHit =
  * Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit].
  *
  * A query for [input] matches [block] words. The reverse does not apply.
- *
- * ```
- * val hit =
- *   oneWaySynonym("syn-2", input = "tablet") {
- *     +"ipad"
- *     +"galaxy tab"
- *   }
- * ```
  */
 @AlgoliaExperimentalDsl
 public fun oneWaySynonym(
@@ -101,24 +69,12 @@ public fun oneWaySynonym(
   block: SynonymWordsDsl.() -> Unit,
 ): SynonymHit = synonym { oneWay(objectID, input, block) }
 
-/**
- * Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit] from [synonyms].
- *
- * ```
- * val hit = oneWaySynonym("syn-2", input = "tablet", synonyms = listOf("ipad", "galaxy tab"))
- * ```
- */
+/** Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit] from [synonyms]. */
 @AlgoliaExperimentalDsl
 public fun oneWaySynonym(objectID: String, input: String, synonyms: List<String>): SynonymHit =
   oneWaySynonym(objectID, input) { synonyms.forEach { +it } }
 
-/**
- * Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit].
- *
- * ```
- * val hit = altCorrection1("syn-3", word = "trousers") { +"pants" }
- * ```
- */
+/** Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
 public fun altCorrection1(
   objectID: String,
@@ -129,22 +85,12 @@ public fun altCorrection1(
 /**
  * Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit] from
  * [corrections].
- *
- * ```
- * val hit = altCorrection1("syn-3", word = "trousers", corrections = listOf("pants"))
- * ```
  */
 @AlgoliaExperimentalDsl
 public fun altCorrection1(objectID: String, word: String, corrections: List<String>): SynonymHit =
   altCorrection1(objectID, word) { corrections.forEach { +it } }
 
-/**
- * Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit].
- *
- * ```
- * val hit = altCorrection2("syn-4", word = "trousers") { +"pants" }
- * ```
- */
+/** Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
 public fun altCorrection2(
   objectID: String,
@@ -155,26 +101,12 @@ public fun altCorrection2(
 /**
  * Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit] from
  * [corrections].
- *
- * ```
- * val hit = altCorrection2("syn-4", word = "trousers", corrections = listOf("pants"))
- * ```
  */
 @AlgoliaExperimentalDsl
 public fun altCorrection2(objectID: String, word: String, corrections: List<String>): SynonymHit =
   altCorrection2(objectID, word) { corrections.forEach { +it } }
 
-/**
- * Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit].
- *
- * ```
- * val hit =
- *   placeholder("syn-5", placeholder = "<Street>") {
- *     +"street"
- *     +"st"
- *   }
- * ```
- */
+/** Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit]. */
 @AlgoliaExperimentalDsl
 public fun placeholder(
   objectID: String,
@@ -182,13 +114,7 @@ public fun placeholder(
   block: SynonymWordsDsl.() -> Unit,
 ): SynonymHit = synonym { placeholder(objectID, placeholder, block) }
 
-/**
- * Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit] from [replacements].
- *
- * ```
- * val hit = placeholder("syn-5", placeholder = "<Street>", replacements = listOf("street", "st"))
- * ```
- */
+/** Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit] from [replacements]. */
 @AlgoliaExperimentalDsl
 public fun placeholder(
   objectID: String,
@@ -197,157 +123,131 @@ public fun placeholder(
 ): SynonymHit = placeholder(objectID, placeholder) { replacements.forEach { +it } }
 
 /**
- * Builder for a [SynonymHit].
- *
- * Variant helpers set [type] and the fields that variant uses, and clear the rest. Last write wins
- * if a later assignment or helper call replaces a field.
+ * Sets [SynonymHitBuilder.synonyms] from [block]. Last write wins if [synonyms] was already set in
+ * the same builder.
  */
-@AlgoliaDsl
 @AlgoliaExperimentalDsl
-public class SynonymDsl {
-  /** Unique identifier of a synonym object. */
-  public var objectID: String? = null
+public fun SynonymHitBuilder.synonyms(block: SynonymWordsDsl.() -> Unit) {
+  synonyms = SynonymWordsDsl().apply(block).build()
+}
 
-  /** Synonym type. */
-  public var type: SynonymType? = null
+/**
+ * Sets [SynonymHitBuilder.corrections] from [block]. Last write wins if [corrections] was already
+ * set in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.corrections(block: SynonymWordsDsl.() -> Unit) {
+  corrections = SynonymWordsDsl().apply(block).build()
+}
 
-  /** Words or phrases considered equivalent. Used by regular and one-way synonyms. */
-  public var synonyms: List<String>? = null
+/**
+ * Sets [SynonymHitBuilder.replacements] from [block]. Last write wins if [replacements] was already
+ * set in the same builder.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.replacements(block: SynonymWordsDsl.() -> Unit) {
+  replacements = SynonymWordsDsl().apply(block).build()
+}
 
-  /** Query word or phrase for a one-way synonym. */
-  public var input: String? = null
+/**
+ * Fills this builder as a regular ([SynonymType.Synonym]) synonym.
+ *
+ * Clears fields that other variants use.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.regular(objectID: String, block: SynonymWordsDsl.() -> Unit) {
+  this.objectID = objectID
+  type = SynonymType.Synonym
+  synonyms = SynonymWordsDsl().apply(block).build()
+  clearUnused(keepSynonyms = true)
+}
 
-  /** Query word or phrase for an alternative correction. */
-  public var word: String? = null
+/**
+ * Fills this builder as a one-way ([SynonymType.OneWaySynonym]) synonym.
+ *
+ * Clears fields that other variants use.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.oneWay(
+  objectID: String,
+  input: String,
+  block: SynonymWordsDsl.() -> Unit,
+) {
+  this.objectID = objectID
+  type = SynonymType.OneWaySynonym
+  this.input = input
+  synonyms = SynonymWordsDsl().apply(block).build()
+  clearUnused(keepSynonyms = true, keepInput = true)
+}
 
-  /** Record words for an alternative correction. */
-  public var corrections: List<String>? = null
+/**
+ * Fills this builder as a one-typo alternative correction ([SynonymType.AltCorrection1]).
+ *
+ * Clears fields that other variants use.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.altCorrection1(
+  objectID: String,
+  word: String,
+  block: SynonymWordsDsl.() -> Unit,
+) {
+  this.objectID = objectID
+  type = SynonymType.AltCorrection1
+  this.word = word
+  corrections = SynonymWordsDsl().apply(block).build()
+  clearUnused(keepWord = true, keepCorrections = true)
+}
 
-  /** Placeholder token to put inside records. */
-  public var placeholder: String? = null
+/**
+ * Fills this builder as a two-typo alternative correction ([SynonymType.AltCorrection2]).
+ *
+ * Clears fields that other variants use.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.altCorrection2(
+  objectID: String,
+  word: String,
+  block: SynonymWordsDsl.() -> Unit,
+) {
+  this.objectID = objectID
+  type = SynonymType.AltCorrection2
+  this.word = word
+  corrections = SynonymWordsDsl().apply(block).build()
+  clearUnused(keepWord = true, keepCorrections = true)
+}
 
-  /** Query words that match [placeholder]. */
-  public var replacements: List<String>? = null
+/**
+ * Fills this builder as a placeholder ([SynonymType.Placeholder]) synonym.
+ *
+ * Clears fields that other variants use.
+ */
+@AlgoliaExperimentalDsl
+public fun SynonymHitBuilder.placeholder(
+  objectID: String,
+  placeholder: String,
+  block: SynonymWordsDsl.() -> Unit,
+) {
+  this.objectID = objectID
+  type = SynonymType.Placeholder
+  this.placeholder = placeholder
+  replacements = SynonymWordsDsl().apply(block).build()
+  clearUnused(keepPlaceholder = true, keepReplacements = true)
+}
 
-  /**
-   * Sets [synonyms] from [block]. Last write wins if [synonyms] was already set in the same
-   * builder.
-   */
-  public fun synonyms(block: SynonymWordsDsl.() -> Unit) {
-    synonyms = SynonymWordsDsl().apply(block).build()
-  }
-
-  /**
-   * Sets [corrections] from [block]. Last write wins if [corrections] was already set in the same
-   * builder.
-   */
-  public fun corrections(block: SynonymWordsDsl.() -> Unit) {
-    corrections = SynonymWordsDsl().apply(block).build()
-  }
-
-  /**
-   * Sets [replacements] from [block]. Last write wins if [replacements] was already set in the same
-   * builder.
-   */
-  public fun replacements(block: SynonymWordsDsl.() -> Unit) {
-    replacements = SynonymWordsDsl().apply(block).build()
-  }
-
-  /**
-   * Fills this builder as a regular ([SynonymType.Synonym]) synonym.
-   *
-   * Clears fields that other variants use.
-   */
-  public fun regular(objectID: String, block: SynonymWordsDsl.() -> Unit) {
-    this.objectID = objectID
-    type = SynonymType.Synonym
-    synonyms = SynonymWordsDsl().apply(block).build()
-    clearUnused(keepSynonyms = true)
-  }
-
-  /**
-   * Fills this builder as a one-way ([SynonymType.OneWaySynonym]) synonym.
-   *
-   * Clears fields that other variants use.
-   */
-  public fun oneWay(objectID: String, input: String, block: SynonymWordsDsl.() -> Unit) {
-    this.objectID = objectID
-    type = SynonymType.OneWaySynonym
-    this.input = input
-    synonyms = SynonymWordsDsl().apply(block).build()
-    clearUnused(keepSynonyms = true, keepInput = true)
-  }
-
-  /**
-   * Fills this builder as a one-typo alternative correction ([SynonymType.AltCorrection1]).
-   *
-   * Clears fields that other variants use.
-   */
-  public fun altCorrection1(objectID: String, word: String, block: SynonymWordsDsl.() -> Unit) {
-    this.objectID = objectID
-    type = SynonymType.AltCorrection1
-    this.word = word
-    corrections = SynonymWordsDsl().apply(block).build()
-    clearUnused(keepWord = true, keepCorrections = true)
-  }
-
-  /**
-   * Fills this builder as a two-typo alternative correction ([SynonymType.AltCorrection2]).
-   *
-   * Clears fields that other variants use.
-   */
-  public fun altCorrection2(objectID: String, word: String, block: SynonymWordsDsl.() -> Unit) {
-    this.objectID = objectID
-    type = SynonymType.AltCorrection2
-    this.word = word
-    corrections = SynonymWordsDsl().apply(block).build()
-    clearUnused(keepWord = true, keepCorrections = true)
-  }
-
-  /**
-   * Fills this builder as a placeholder ([SynonymType.Placeholder]) synonym.
-   *
-   * Clears fields that other variants use.
-   */
-  public fun placeholder(
-    objectID: String,
-    placeholder: String,
-    block: SynonymWordsDsl.() -> Unit,
-  ) {
-    this.objectID = objectID
-    type = SynonymType.Placeholder
-    this.placeholder = placeholder
-    replacements = SynonymWordsDsl().apply(block).build()
-    clearUnused(keepPlaceholder = true, keepReplacements = true)
-  }
-
-  internal fun build(): SynonymHit =
-    SynonymHit(
-      objectID = requireNotNull(objectID) { "objectID is required" },
-      type = requireNotNull(type) { "type is required" },
-      synonyms = synonyms,
-      input = input,
-      word = word,
-      corrections = corrections,
-      placeholder = placeholder,
-      replacements = replacements,
-    )
-
-  private fun clearUnused(
-    keepSynonyms: Boolean = false,
-    keepInput: Boolean = false,
-    keepWord: Boolean = false,
-    keepCorrections: Boolean = false,
-    keepPlaceholder: Boolean = false,
-    keepReplacements: Boolean = false,
-  ) {
-    if (!keepSynonyms) synonyms = null
-    if (!keepInput) input = null
-    if (!keepWord) word = null
-    if (!keepCorrections) corrections = null
-    if (!keepPlaceholder) placeholder = null
-    if (!keepReplacements) replacements = null
-  }
+private fun SynonymHitBuilder.clearUnused(
+  keepSynonyms: Boolean = false,
+  keepInput: Boolean = false,
+  keepWord: Boolean = false,
+  keepCorrections: Boolean = false,
+  keepPlaceholder: Boolean = false,
+  keepReplacements: Boolean = false,
+) {
+  if (!keepSynonyms) synonyms = null
+  if (!keepInput) input = null
+  if (!keepWord) word = null
+  if (!keepCorrections) corrections = null
+  if (!keepPlaceholder) placeholder = null
+  if (!keepReplacements) replacements = null
 }
 
 /** Collects synonym, correction, or replacement words. */

--- a/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/synonym/SynonymDsl.kt
@@ -1,0 +1,365 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl.synonym
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.model.search.SynonymHit
+import com.algolia.client.model.search.SynonymType
+
+/**
+ * Constructs a [SynonymHit] from the DSL block.
+ *
+ * Prefer the typed helpers ([regular], [oneWay], [altCorrection1], [altCorrection2], [placeholder])
+ * so unused variant fields stay unset. Last write wins: a later assignment or helper call replaces
+ * earlier values for the same field.
+ *
+ * ```
+ * val regular =
+ *   synonym {
+ *     regular("syn-1") {
+ *       +"car"
+ *       +"auto"
+ *       +"vehicle"
+ *     }
+ *   }
+ *
+ * val oneWay =
+ *   synonym {
+ *     oneWay("syn-2", input = "tablet") {
+ *       +"ipad"
+ *       +"galaxy tab"
+ *     }
+ *   }
+ *
+ * val alt1 =
+ *   synonym {
+ *     altCorrection1("syn-3", word = "trousers") { +"pants" }
+ *   }
+ *
+ * val alt2 =
+ *   synonym {
+ *     altCorrection2("syn-4", word = "trousers") { +"pants" }
+ *   }
+ *
+ * val token =
+ *   synonym {
+ *     placeholder("syn-5", placeholder = "<Street>") {
+ *       +"street"
+ *       +"st"
+ *     }
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun synonym(block: SynonymDsl.() -> Unit): SynonymHit = SynonymDsl().apply(block).build()
+
+/**
+ * Constructs a regular ([SynonymType.Synonym]) [SynonymHit].
+ *
+ * ```
+ * val hit = synonym("syn-1") {
+ *   +"car"
+ *   +"auto"
+ *   +"vehicle"
+ * }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun synonym(objectID: String, block: SynonymWordsDsl.() -> Unit): SynonymHit = synonym {
+  regular(objectID, block)
+}
+
+/**
+ * Constructs a regular ([SynonymType.Synonym]) [SynonymHit] from [synonyms].
+ *
+ * ```
+ * val hit = synonym("syn-1", listOf("car", "auto", "vehicle"))
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun synonym(objectID: String, synonyms: List<String>): SynonymHit =
+  synonym(objectID) { synonyms.forEach { +it } }
+
+/**
+ * Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit].
+ *
+ * A query for [input] matches [block] words. The reverse does not apply.
+ *
+ * ```
+ * val hit =
+ *   oneWaySynonym("syn-2", input = "tablet") {
+ *     +"ipad"
+ *     +"galaxy tab"
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun oneWaySynonym(
+  objectID: String,
+  input: String,
+  block: SynonymWordsDsl.() -> Unit,
+): SynonymHit = synonym { oneWay(objectID, input, block) }
+
+/**
+ * Constructs a one-way ([SynonymType.OneWaySynonym]) [SynonymHit] from [synonyms].
+ *
+ * ```
+ * val hit = oneWaySynonym("syn-2", input = "tablet", synonyms = listOf("ipad", "galaxy tab"))
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun oneWaySynonym(objectID: String, input: String, synonyms: List<String>): SynonymHit =
+  oneWaySynonym(objectID, input) { synonyms.forEach { +it } }
+
+/**
+ * Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit].
+ *
+ * ```
+ * val hit = altCorrection1("syn-3", word = "trousers") { +"pants" }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun altCorrection1(
+  objectID: String,
+  word: String,
+  block: SynonymWordsDsl.() -> Unit,
+): SynonymHit = synonym { altCorrection1(objectID, word, block) }
+
+/**
+ * Constructs a one-typo alternative-correction ([SynonymType.AltCorrection1]) [SynonymHit] from
+ * [corrections].
+ *
+ * ```
+ * val hit = altCorrection1("syn-3", word = "trousers", corrections = listOf("pants"))
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun altCorrection1(objectID: String, word: String, corrections: List<String>): SynonymHit =
+  altCorrection1(objectID, word) { corrections.forEach { +it } }
+
+/**
+ * Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit].
+ *
+ * ```
+ * val hit = altCorrection2("syn-4", word = "trousers") { +"pants" }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun altCorrection2(
+  objectID: String,
+  word: String,
+  block: SynonymWordsDsl.() -> Unit,
+): SynonymHit = synonym { altCorrection2(objectID, word, block) }
+
+/**
+ * Constructs a two-typo alternative-correction ([SynonymType.AltCorrection2]) [SynonymHit] from
+ * [corrections].
+ *
+ * ```
+ * val hit = altCorrection2("syn-4", word = "trousers", corrections = listOf("pants"))
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun altCorrection2(objectID: String, word: String, corrections: List<String>): SynonymHit =
+  altCorrection2(objectID, word) { corrections.forEach { +it } }
+
+/**
+ * Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit].
+ *
+ * ```
+ * val hit =
+ *   placeholder("syn-5", placeholder = "<Street>") {
+ *     +"street"
+ *     +"st"
+ *   }
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun placeholder(
+  objectID: String,
+  placeholder: String,
+  block: SynonymWordsDsl.() -> Unit,
+): SynonymHit = synonym { placeholder(objectID, placeholder, block) }
+
+/**
+ * Constructs a placeholder ([SynonymType.Placeholder]) [SynonymHit] from [replacements].
+ *
+ * ```
+ * val hit = placeholder("syn-5", placeholder = "<Street>", replacements = listOf("street", "st"))
+ * ```
+ */
+@AlgoliaExperimentalDsl
+public fun placeholder(
+  objectID: String,
+  placeholder: String,
+  replacements: List<String>,
+): SynonymHit = placeholder(objectID, placeholder) { replacements.forEach { +it } }
+
+/**
+ * Builder for a [SynonymHit].
+ *
+ * Variant helpers set [type] and the fields that variant uses, and clear the rest. Last write wins
+ * if a later assignment or helper call replaces a field.
+ */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class SynonymDsl {
+  /** Unique identifier of a synonym object. */
+  public var objectID: String? = null
+
+  /** Synonym type. */
+  public var type: SynonymType? = null
+
+  /** Words or phrases considered equivalent. Used by regular and one-way synonyms. */
+  public var synonyms: List<String>? = null
+
+  /** Query word or phrase for a one-way synonym. */
+  public var input: String? = null
+
+  /** Query word or phrase for an alternative correction. */
+  public var word: String? = null
+
+  /** Record words for an alternative correction. */
+  public var corrections: List<String>? = null
+
+  /** Placeholder token to put inside records. */
+  public var placeholder: String? = null
+
+  /** Query words that match [placeholder]. */
+  public var replacements: List<String>? = null
+
+  /**
+   * Sets [synonyms] from [block]. Last write wins if [synonyms] was already set in the same
+   * builder.
+   */
+  public fun synonyms(block: SynonymWordsDsl.() -> Unit) {
+    synonyms = SynonymWordsDsl().apply(block).build()
+  }
+
+  /**
+   * Sets [corrections] from [block]. Last write wins if [corrections] was already set in the same
+   * builder.
+   */
+  public fun corrections(block: SynonymWordsDsl.() -> Unit) {
+    corrections = SynonymWordsDsl().apply(block).build()
+  }
+
+  /**
+   * Sets [replacements] from [block]. Last write wins if [replacements] was already set in the same
+   * builder.
+   */
+  public fun replacements(block: SynonymWordsDsl.() -> Unit) {
+    replacements = SynonymWordsDsl().apply(block).build()
+  }
+
+  /**
+   * Fills this builder as a regular ([SynonymType.Synonym]) synonym.
+   *
+   * Clears fields that other variants use.
+   */
+  public fun regular(objectID: String, block: SynonymWordsDsl.() -> Unit) {
+    this.objectID = objectID
+    type = SynonymType.Synonym
+    synonyms = SynonymWordsDsl().apply(block).build()
+    clearUnused(keepSynonyms = true)
+  }
+
+  /**
+   * Fills this builder as a one-way ([SynonymType.OneWaySynonym]) synonym.
+   *
+   * Clears fields that other variants use.
+   */
+  public fun oneWay(objectID: String, input: String, block: SynonymWordsDsl.() -> Unit) {
+    this.objectID = objectID
+    type = SynonymType.OneWaySynonym
+    this.input = input
+    synonyms = SynonymWordsDsl().apply(block).build()
+    clearUnused(keepSynonyms = true, keepInput = true)
+  }
+
+  /**
+   * Fills this builder as a one-typo alternative correction ([SynonymType.AltCorrection1]).
+   *
+   * Clears fields that other variants use.
+   */
+  public fun altCorrection1(objectID: String, word: String, block: SynonymWordsDsl.() -> Unit) {
+    this.objectID = objectID
+    type = SynonymType.AltCorrection1
+    this.word = word
+    corrections = SynonymWordsDsl().apply(block).build()
+    clearUnused(keepWord = true, keepCorrections = true)
+  }
+
+  /**
+   * Fills this builder as a two-typo alternative correction ([SynonymType.AltCorrection2]).
+   *
+   * Clears fields that other variants use.
+   */
+  public fun altCorrection2(objectID: String, word: String, block: SynonymWordsDsl.() -> Unit) {
+    this.objectID = objectID
+    type = SynonymType.AltCorrection2
+    this.word = word
+    corrections = SynonymWordsDsl().apply(block).build()
+    clearUnused(keepWord = true, keepCorrections = true)
+  }
+
+  /**
+   * Fills this builder as a placeholder ([SynonymType.Placeholder]) synonym.
+   *
+   * Clears fields that other variants use.
+   */
+  public fun placeholder(
+    objectID: String,
+    placeholder: String,
+    block: SynonymWordsDsl.() -> Unit,
+  ) {
+    this.objectID = objectID
+    type = SynonymType.Placeholder
+    this.placeholder = placeholder
+    replacements = SynonymWordsDsl().apply(block).build()
+    clearUnused(keepPlaceholder = true, keepReplacements = true)
+  }
+
+  internal fun build(): SynonymHit =
+    SynonymHit(
+      objectID = requireNotNull(objectID) { "objectID is required" },
+      type = requireNotNull(type) { "type is required" },
+      synonyms = synonyms,
+      input = input,
+      word = word,
+      corrections = corrections,
+      placeholder = placeholder,
+      replacements = replacements,
+    )
+
+  private fun clearUnused(
+    keepSynonyms: Boolean = false,
+    keepInput: Boolean = false,
+    keepWord: Boolean = false,
+    keepCorrections: Boolean = false,
+    keepPlaceholder: Boolean = false,
+    keepReplacements: Boolean = false,
+  ) {
+    if (!keepSynonyms) synonyms = null
+    if (!keepInput) input = null
+    if (!keepWord) word = null
+    if (!keepCorrections) corrections = null
+    if (!keepPlaceholder) placeholder = null
+    if (!keepReplacements) replacements = null
+  }
+}
+
+/** Collects synonym, correction, or replacement words. */
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class SynonymWordsDsl {
+  private val values: MutableList<String> = mutableListOf()
+
+  /** Adds [this] word or phrase. Matches other DSL `+"word"` helpers. */
+  public operator fun String.unaryPlus() {
+    values += this
+  }
+
+  internal fun build(): List<String> = values.toList()
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/TestForgeSecuredUserToken.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/TestForgeSecuredUserToken.kt
@@ -13,6 +13,12 @@ import kotlinx.serialization.json.jsonPrimitive
 
 class TestForgeSecuredUserToken {
 
+  /**
+   * JWT parts are base64url without `=`. Default [Base64.UrlSafe] requires padding and rejects those
+   * parts. Java's `Base64.getUrlDecoder()` accepts missing padding; this matches that.
+   */
+  private val jwtBase64 = Base64.UrlSafe.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL)
+
   @Test
   fun forgeSecuredUserToken() {
     val client = AgentStudioClient(appId = "appID", apiKey = "apiKey")
@@ -22,13 +28,13 @@ class TestForgeSecuredUserToken {
     val parts = token.split(".")
     assertEquals(3, parts.size)
 
-    val headerJson = Base64.UrlSafe.decode(parts[0]).decodeToString()
+    val headerJson = jwtBase64.decode(parts[0]).decodeToString()
     val header = Json.decodeFromString<JsonObject>(headerJson)
     assertEquals("HS256", header["alg"]!!.jsonPrimitive.content)
     assertEquals("JWT", header["typ"]!!.jsonPrimitive.content)
     assertEquals("my-key-id", header["kid"]!!.jsonPrimitive.content)
 
-    val payloadJson = Base64.UrlSafe.decode(parts[1]).decodeToString()
+    val payloadJson = jwtBase64.decode(parts[1]).decodeToString()
     val payload = Json.decodeFromString<JsonObject>(payloadJson)
     assertEquals("user-123", payload["sub"]!!.jsonPrimitive.content)
     val exp = payload["exp"]!!.jsonPrimitive.content.toLong()
@@ -40,7 +46,7 @@ class TestForgeSecuredUserToken {
 
     val expectedHmacHex =
       encodeKeySHA256(key = "my-secret-key", message = "${parts[0]}.${parts[1]}")
-    val actualSigBytes = Base64.UrlSafe.decode(parts[2])
+    val actualSigBytes = jwtBase64.decode(parts[2])
     val actualSigHex =
       actualSigBytes.joinToString("") {
         val i = it.toInt() and 0xFF
@@ -56,7 +62,7 @@ class TestForgeSecuredUserToken {
     val token = client.forgeSecuredUserToken("my-secret-key", "my-key-id", "user-456", 3600)
 
     val parts = token.split(".")
-    val payloadJson = Base64.UrlSafe.decode(parts[1]).decodeToString()
+    val payloadJson = jwtBase64.decode(parts[1]).decodeToString()
     val payload = Json.decodeFromString<JsonObject>(payloadJson)
     val exp = payload["exp"]!!.jsonPrimitive.content.toLong()
     val expectedExp = Clock.System.now().epochSeconds + 3600

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
@@ -3,6 +3,7 @@
 package com.algolia.client.dsl
 
 import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.dsl.filter.NumericOperator
 import com.algolia.client.model.search.BrowseParamsObject
 import com.algolia.client.model.search.DeleteByParams
 import com.algolia.client.model.search.IndexSettings
@@ -149,6 +150,77 @@ internal class DslSerializationTest {
       searchableAttributes { ordered("name") }
     }
     assertJsonEquals(IndexSettings(searchableAttributes = listOf("name")), dsl)
+  }
+
+  @Test
+  fun queryLegacyFilterHelpersMatchExpectedJson() {
+    val dsl = query {
+      facetFilters { facet("brand", "Apple") }
+      optionalFilters { facet("category", "Book") }
+      numericFilters { comparison("price", NumericOperator.Equals, 15) }
+      tagFilters { tag("featured") }
+    }
+    assertEncodedJson(
+      dsl,
+      """
+      {
+        "facetFilters": [["\"brand\":\"Apple\""]],
+        "optionalFilters": [["\"category\":\"Book\""]],
+        "numericFilters": [["\"price\" = 15"]],
+        "tagFilters": [["\"featured\""]]
+      }
+      """,
+    )
+  }
+
+  @Test
+  fun browseLegacyFilterHelpersMatchExpectedJson() {
+    val dsl = browse {
+      facetFilters { facet("brand", "Apple") }
+      optionalFilters { facet("category", "Book") }
+      numericFilters { comparison("price", NumericOperator.Equals, 15) }
+      tagFilters { tag("featured") }
+    }
+    assertEncodedJson(
+      dsl,
+      """
+      {
+        "facetFilters": [["\"brand\":\"Apple\""]],
+        "optionalFilters": [["\"category\":\"Book\""]],
+        "numericFilters": [["\"price\" = 15"]],
+        "tagFilters": [["\"featured\""]]
+      }
+      """,
+    )
+  }
+
+  @Test
+  fun deleteByLegacyFilterHelpersMatchExpectedJson() {
+    val dsl = deleteBy {
+      facetFilters { facet("brand", "Apple") }
+      numericFilters { comparison("price", NumericOperator.Equals, 15) }
+      tagFilters { tag("featured") }
+    }
+    assertEncodedJson(
+      dsl,
+      """
+      {
+        "facetFilters": [["\"brand\":\"Apple\""]],
+        "numericFilters": [["\"price\" = 15"]],
+        "tagFilters": [["\"featured\""]]
+      }
+      """,
+    )
+  }
+
+  @Test
+  fun emptyFilterBlockLeavesFieldUnset() {
+    assertEncodedJson(query { filters {} }, "{}")
+    assertEncodedJson(query { facetFilters {} }, "{}")
+  }
+
+  private inline fun <reified T> assertEncodedJson(dsl: T, expectedJson: String) {
+    assertEquals(json.parseToJsonElement(expectedJson), json.encodeToJsonElement(dsl))
   }
 
   private inline fun <reified T> assertJsonEquals(constructor: T, dsl: T) {

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
@@ -153,6 +153,31 @@ internal class DslSerializationTest {
   }
 
   @Test
+  fun settingsOrderedVarargJoinsWithCommaSpace() {
+    val dsl = settings { searchableAttributes { ordered("title", "name") } }
+    assertJsonEquals(IndexSettings(searchableAttributes = listOf("title, name")), dsl)
+  }
+
+  @Test
+  fun settingsDslClassesShareTheStringListBase() {
+    val dsl = settings {
+      searchableAttributes { +"name" }
+      attributesForFaceting { +"brand" }
+      customRanking { asc("price") }
+      ranking { desc("rating") }
+    }
+    assertJsonEquals(
+      IndexSettings(
+        searchableAttributes = listOf("name"),
+        attributesForFaceting = listOf("brand"),
+        customRanking = listOf("asc(price)"),
+        ranking = listOf("desc(rating)"),
+      ),
+      dsl,
+    )
+  }
+
+  @Test
   fun queryLegacyFilterHelpersMatchExpectedJson() {
     val dsl = query {
       facetFilters { facet("brand", "Apple") }

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/DslSerializationTest.kt
@@ -1,0 +1,161 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.model.search.BrowseParamsObject
+import com.algolia.client.model.search.DeleteByParams
+import com.algolia.client.model.search.IndexSettings
+import com.algolia.client.model.search.SearchParamsObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Serialization equivalence between DSL builders and data-class constructors.
+ *
+ * Uses [ClientOptions.json], the same [kotlinx.serialization.json.Json] the client sends on
+ * requests. That instance leaves `encodeDefaults` off (kotlinx default), so unset null properties
+ * are omitted. Comparison is on parsed [JsonObject], never on encoded strings.
+ */
+internal class DslSerializationTest {
+
+  private val json = ClientOptions().json
+
+  @Test
+  fun queryDslMatchesConstructor() {
+    val dsl =
+      query("shoes") {
+        hitsPerPage = 10
+        filters { facet("brand", "Apple") }
+      }
+    val ctor =
+      SearchParamsObject(
+        query = "shoes",
+        hitsPerPage = 10,
+        filters = "brand:Apple",
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun browseDslMatchesConstructor() {
+    val dsl = browse {
+      query = "shoes"
+      cursor = "cursor-1"
+      filters { facet("brand", "Apple") }
+    }
+    val ctor =
+      BrowseParamsObject(
+        query = "shoes",
+        cursor = "cursor-1",
+        filters = "brand:Apple",
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun settingsDslMatchesConstructor() {
+    val dsl = settings {
+      searchableAttributes {
+        ordered("name")
+        unordered("description")
+      }
+      attributesForFaceting {
+        +"brand"
+        filterOnly("internalSku")
+        searchable("category")
+      }
+      customRanking { desc("followers") }
+      ranking {
+        typo()
+        geo()
+        words()
+        filters()
+        proximity()
+        attribute()
+        exact()
+        custom()
+      }
+    }
+    val ctor =
+      IndexSettings(
+        searchableAttributes = listOf("name", "unordered(description)"),
+        attributesForFaceting = listOf("brand", "filterOnly(internalSku)", "searchable(category)"),
+        customRanking = listOf("desc(followers)"),
+        ranking =
+          listOf("typo", "geo", "words", "filters", "proximity", "attribute", "exact", "custom"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun deleteByDslMatchesConstructor() {
+    val dsl = deleteBy {
+      aroundLatLng = "40.71,-74.01"
+      filters { facet("brand", "Apple") }
+    }
+    val ctor =
+      DeleteByParams(
+        aroundLatLng = "40.71,-74.01",
+        filters = "brand:Apple",
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun queryLastWriteWinsFiltersBlockOverwritesString() {
+    val dsl = query {
+      filters = "brand:Nike"
+      filters { facet("brand", "Apple") }
+    }
+    assertJsonEquals(SearchParamsObject(filters = "brand:Apple"), dsl)
+  }
+
+  @Test
+  fun queryLastWriteWinsFiltersStringOverwritesBlock() {
+    val dsl = query {
+      filters { facet("brand", "Apple") }
+      filters = "brand:Nike"
+    }
+    assertJsonEquals(SearchParamsObject(filters = "brand:Nike"), dsl)
+  }
+
+  @Test
+  fun browseLastWriteWinsFiltersBlockOverwritesString() {
+    val dsl = browse {
+      filters = "brand:Nike"
+      filters { facet("brand", "Apple") }
+    }
+    assertJsonEquals(BrowseParamsObject(filters = "brand:Apple"), dsl)
+  }
+
+  @Test
+  fun deleteByLastWriteWinsFiltersBlockOverwritesString() {
+    val dsl = deleteBy {
+      filters = "brand:Nike"
+      filters { facet("brand", "Apple") }
+    }
+    assertJsonEquals(DeleteByParams(filters = "brand:Apple"), dsl)
+  }
+
+  @Test
+  fun settingsLastWriteWinsSearchableAttributesBlockOverwritesList() {
+    val dsl = settings {
+      searchableAttributes = listOf("old")
+      searchableAttributes { ordered("name") }
+    }
+    assertJsonEquals(IndexSettings(searchableAttributes = listOf("name")), dsl)
+  }
+
+  private inline fun <reified T> assertJsonEquals(constructor: T, dsl: T) {
+    val constructorJson = json.encodeToJsonElement(constructor)
+    val dslJson = json.encodeToJsonElement(dsl)
+    assertIs<JsonObject>(constructorJson)
+    assertIs<JsonObject>(dslJson)
+    assertEquals(constructorJson.jsonObject, dslJson.jsonObject)
+  }
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/FilterConverterTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/FilterConverterTest.kt
@@ -1,0 +1,365 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.filter.Filter
+import com.algolia.client.dsl.filter.FilterGroup
+import com.algolia.client.dsl.filter.FilterLegacyConverter
+import com.algolia.client.dsl.filter.FilterSqlConverter
+import com.algolia.client.dsl.filter.NumericOperator
+import com.algolia.client.dsl.filter.filters
+import com.algolia.client.dsl.filter.not
+import com.algolia.client.model.search.FacetFilters
+import com.algolia.client.model.search.NumericFilters
+import com.algolia.client.model.search.OptionalFilters
+import com.algolia.client.model.search.TagFilters
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * Golden vectors for [FilterSqlConverter] and [FilterLegacyConverter].
+ *
+ * SQL quotes only when T5 requires it (space, quote, `AND` / `OR` / `NOT`). Legacy rows always
+ * quote, matching [FilterLegacyConverter] `escape()`.
+ */
+internal class FilterConverterTest {
+
+  @Test
+  fun sqlGoldenVectors() {
+    sqlVectors.forEach { vector ->
+      assertEquals(vector.sql, FilterSqlConverter(vector.group), vector.name)
+    }
+  }
+
+  @Test
+  fun legacyGoldenVectors() {
+    legacyVectors.forEach { vector ->
+      assertEquals(
+        vector.facet,
+        FilterLegacyConverter.facet(vector.group)?.rows(),
+        "${vector.name} facet",
+      )
+      assertEquals(
+        vector.facet,
+        FilterLegacyConverter.optional(vector.group)?.rows(),
+        "${vector.name} optional",
+      )
+      assertEquals(
+        vector.numeric,
+        FilterLegacyConverter.numeric(vector.group)?.rows(),
+        "${vector.name} numeric",
+      )
+      assertEquals(
+        vector.tag,
+        FilterLegacyConverter.tag(vector.group)?.rows(),
+        "${vector.name} tag",
+      )
+    }
+  }
+
+  @Test
+  fun rejectVectors() {
+    rejectVectors.forEach { vector ->
+      assertFailsWith<IllegalArgumentException>(vector.name) { FilterSqlConverter(vector.group) }
+      if (vector.legacyFacetThrows) {
+        assertFailsWith<IllegalArgumentException>("${vector.name} legacy facet") {
+          FilterLegacyConverter.facet(vector.group)
+        }
+        assertFailsWith<IllegalArgumentException>("${vector.name} legacy optional") {
+          FilterLegacyConverter.optional(vector.group)
+        }
+      }
+      if (vector.legacyAllThrow) {
+        assertFailsWith<IllegalArgumentException>("${vector.name} legacy numeric") {
+          FilterLegacyConverter.numeric(vector.group)
+        }
+        assertFailsWith<IllegalArgumentException>("${vector.name} legacy tag") {
+          FilterLegacyConverter.tag(vector.group)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun docsDslVectorsMatchConverters() {
+    val built = filters {
+      and {
+        facet("color", "red")
+        facet("category", "shirt")
+      }
+      or {
+        range("price", 0 until 10)
+        comparison("price", NumericOperator.Equals, 15)
+      }
+    }
+    assertEquals(
+      "((color:red AND category:shirt) AND (price:0 TO 9 OR price = 15))",
+      built.asSql(),
+    )
+    assertEquals(FilterSqlConverter(built.group), built.asSql())
+    assertEquals(
+      listOf(listOf("\"color\":\"red\""), listOf("\"category\":\"shirt\"")),
+      built.asFacetFilters()?.rows(),
+    )
+    assertEquals(
+      listOf(listOf("\"price\":0 TO 9", "\"price\" = 15")),
+      built.asNumericFilters()?.rows(),
+    )
+    assertNull(built.asTagFilters())
+  }
+
+  private class SqlVector(val name: String, val group: FilterGroup, val sql: String?)
+
+  private class LegacyVector(
+    val name: String,
+    val group: FilterGroup,
+    val facet: List<List<String>>? = null,
+    val numeric: List<List<String>>? = null,
+    val tag: List<List<String>>? = null,
+  )
+
+  private class RejectVector(
+    val name: String,
+    val group: FilterGroup,
+    val legacyFacetThrows: Boolean = true,
+    val legacyAllThrow: Boolean = true,
+  )
+
+  private val colorRed = Filter.Facet("color", "red")
+  private val colorBlue = Filter.Facet("color", "blue")
+  private val categoryShirt = Filter.Facet("category", "shirt")
+  private val priceUntil10 = Filter.Range("price", 0 until 10)
+  private val priceEquals15 = Filter.Comparison("price", NumericOperator.Equals, 15)
+
+  private val sqlVectors: List<SqlVector> =
+    listOf(
+      SqlVector("facet", colorRed, "color:red"),
+      SqlVector("facet score", Filter.Facet("color", "red", score = 2), "color:red<score=2>"),
+      SqlVector("facet boolean", Filter.Facet("available", true), "available:true"),
+      SqlVector("facet number", Filter.Facet("count", 10), "count:10"),
+      SqlVector("tag", Filter.Tag("featured"), "_tags:featured"),
+      SqlVector("range until", priceUntil10, "price:0 TO 9"),
+      SqlVector("range inclusive", Filter.Range("price", 0..10), "price:0 TO 10"),
+      SqlVector("range float", Filter.Range("price", 0.0, 6.0), "price:0.0 TO 6.0"),
+      SqlVector(
+        "comparison less",
+        Filter.Comparison("price", NumericOperator.Less, 5),
+        "price < 5",
+      ),
+      SqlVector(
+        "comparison lessOrEquals",
+        Filter.Comparison("price", NumericOperator.LessOrEquals, 5),
+        "price <= 5",
+      ),
+      SqlVector("comparison equals", priceEquals15, "price = 15"),
+      SqlVector(
+        "comparison notEquals",
+        Filter.Comparison("price", NumericOperator.NotEquals, 5),
+        "price != 5",
+      ),
+      SqlVector(
+        "comparison greaterOrEquals",
+        Filter.Comparison("price", NumericOperator.GreaterOrEquals, 5),
+        "price >= 5",
+      ),
+      SqlVector(
+        "comparison greater",
+        Filter.Comparison("price", NumericOperator.Greater, 5),
+        "price > 5",
+      ),
+      SqlVector("and", FilterGroup.And(colorRed, categoryShirt), "(color:red AND category:shirt)"),
+      SqlVector("or facet", FilterGroup.Or(colorRed, colorBlue), "(color:red OR color:blue)"),
+      SqlVector(
+        "or numeric",
+        FilterGroup.Or(priceUntil10, priceEquals15),
+        "(price:0 TO 9 OR price = 15)",
+      ),
+      SqlVector(
+        "or tag",
+        FilterGroup.Or(Filter.Tag("a"), Filter.Tag("b")),
+        "(_tags:a OR _tags:b)",
+      ),
+      SqlVector("not", FilterGroup.Not(colorRed), "NOT color:red"),
+      SqlVector("not unary", colorRed.not(), "NOT color:red"),
+      SqlVector(
+        "not and",
+        FilterGroup.Not(FilterGroup.And(colorRed, categoryShirt)),
+        "NOT (color:red AND category:shirt)",
+      ),
+      SqlVector(
+        "not range",
+        FilterGroup.Not(Filter.Range("attributeA", 0..10)),
+        "NOT attributeA:0 TO 10",
+      ),
+      SqlVector("quote space", Filter.Facet("author", "John Doe"), "author:\"John Doe\""),
+      SqlVector("quote AND", Filter.Facet("title", "foo AND bar"), "title:\"foo AND bar\""),
+      SqlVector("quote OR", Filter.Facet("title", "foo OR bar"), "title:\"foo OR bar\""),
+      SqlVector("quote NOT", Filter.Facet("title", "NOT bar"), "title:\"NOT bar\""),
+      SqlVector("quote embedded", Filter.Tag("45\"-50\" tv's"), "_tags:\"45\\\"-50\\\" tv's\""),
+      SqlVector("quote attribute space", Filter.Facet("my attr", "red"), "\"my attr\":red"),
+      SqlVector("empty and", FilterGroup.And(), null),
+      SqlVector("empty or", FilterGroup.Or(), null),
+      SqlVector("empty dsl", filters {}.group, null),
+      SqlVector(
+        "docs and+orNumeric",
+        FilterGroup.And(
+          FilterGroup.And(colorRed, categoryShirt),
+          FilterGroup.Or(priceUntil10, priceEquals15),
+        ),
+        "((color:red AND category:shirt) AND (price:0 TO 9 OR price = 15))",
+      ),
+      SqlVector(
+        "optionalFilters docs",
+        FilterGroup.And(Filter.Facet("category", "Book"), Filter.Facet("author", "John Doe")),
+        "(category:Book AND author:\"John Doe\")",
+      ),
+    )
+
+  private val legacyVectors: List<LegacyVector> =
+    listOf(
+      LegacyVector("facet", colorRed, facet = listOf(listOf("\"color\":\"red\""))),
+      LegacyVector(
+        "facet score",
+        Filter.Facet("color", "red", score = 2),
+        facet = listOf(listOf("\"color\":\"red\"<score=2>")),
+      ),
+      LegacyVector("tag", Filter.Tag("featured"), tag = listOf(listOf("\"featured\""))),
+      LegacyVector("range until", priceUntil10, numeric = listOf(listOf("\"price\":0 TO 9"))),
+      LegacyVector(
+        "comparison equals",
+        priceEquals15,
+        numeric = listOf(listOf("\"price\" = 15")),
+      ),
+      LegacyVector(
+        "and facets",
+        FilterGroup.And(colorRed, categoryShirt),
+        facet = listOf(listOf("\"color\":\"red\""), listOf("\"category\":\"shirt\"")),
+      ),
+      LegacyVector(
+        "or facets",
+        FilterGroup.Or(colorRed, colorBlue),
+        facet = listOf(listOf("\"color\":\"red\"", "\"color\":\"blue\"")),
+      ),
+      LegacyVector(
+        "or numeric",
+        FilterGroup.Or(priceUntil10, priceEquals15),
+        numeric = listOf(listOf("\"price\":0 TO 9", "\"price\" = 15")),
+      ),
+      LegacyVector(
+        "not facet",
+        FilterGroup.Not(colorRed),
+        facet = listOf(listOf("\"color\":-\"red\"")),
+      ),
+      LegacyVector(
+        "not tag",
+        FilterGroup.Not(Filter.Tag("featured")),
+        tag = listOf(listOf("-\"featured\"")),
+      ),
+      LegacyVector(
+        "not comparison less",
+        FilterGroup.Not(Filter.Comparison("attributeA", NumericOperator.Less, 5)),
+        numeric = listOf(listOf("\"attributeA\" >= 5")),
+      ),
+      LegacyVector(
+        "not range",
+        FilterGroup.Not(Filter.Range("attributeA", 0..10)),
+        numeric = listOf(listOf("\"attributeA\" < 0", "\"attributeA\" > 10")),
+      ),
+      LegacyVector(
+        "quote space",
+        Filter.Facet("author", "John Doe"),
+        facet = listOf(listOf("\"author\":\"John Doe\"")),
+      ),
+      LegacyVector(
+        "quote AND",
+        Filter.Facet("title", "foo AND bar"),
+        facet = listOf(listOf("\"title\":\"foo AND bar\"")),
+      ),
+      LegacyVector(
+        "quote embedded",
+        Filter.Tag("45\"-50\" tv's"),
+        tag = listOf(listOf("\"45\\\"-50\\\" tv's\"")),
+      ),
+      LegacyVector("empty and", FilterGroup.And()),
+      LegacyVector("empty or", FilterGroup.Or()),
+      LegacyVector(
+        "v2 and+or facets",
+        FilterGroup.And(
+          FilterGroup.And(
+            Filter.Facet("attributeA", "unknown"),
+            Filter.Facet("attributeB", "unknown"),
+          ),
+          FilterGroup.Or(
+            Filter.Facet("attributeA", "unknown"),
+            Filter.Facet("attributeB", "unknown"),
+          ),
+        ),
+        facet =
+          listOf(
+            listOf("\"attributeA\":\"unknown\""),
+            listOf("\"attributeB\":\"unknown\""),
+            listOf("\"attributeA\":\"unknown\"", "\"attributeB\":\"unknown\""),
+          ),
+      ),
+      LegacyVector(
+        "family partition and",
+        FilterGroup.And(colorRed, priceUntil10, Filter.Tag("featured")),
+        facet = listOf(listOf("\"color\":\"red\"")),
+        numeric = listOf(listOf("\"price\":0 TO 9")),
+        tag = listOf(listOf("\"featured\"")),
+      ),
+    )
+
+  private val rejectVectors: List<RejectVector> =
+    listOf(
+      RejectVector(
+        "mixed-family or facet+tag",
+        FilterGroup.Or(colorRed, Filter.Tag("featured")),
+      ),
+      RejectVector(
+        "mixed-family or facet+numeric",
+        FilterGroup.Or(colorRed, priceEquals15),
+      ),
+      RejectVector(
+        "Or-of-And",
+        FilterGroup.Or(FilterGroup.And(colorRed, categoryShirt), colorBlue),
+        legacyAllThrow = false,
+      ),
+      RejectVector(
+        "Or-of-Or",
+        FilterGroup.Or(FilterGroup.Or(colorRed, colorBlue), categoryShirt),
+        legacyFacetThrows = false,
+        legacyAllThrow = false,
+      ),
+    )
+}
+
+private fun FacetFilters.rows(): List<List<String>> =
+  (this as FacetFilters.ListOfFacetFiltersValue).value.map { row ->
+    (row as FacetFilters.ListOfFacetFiltersValue).value.map { cell ->
+      (cell as FacetFilters.StringValue).value
+    }
+  }
+
+private fun OptionalFilters.rows(): List<List<String>> =
+  (this as OptionalFilters.ListOfOptionalFiltersValue).value.map { row ->
+    (row as OptionalFilters.ListOfOptionalFiltersValue).value.map { cell ->
+      (cell as OptionalFilters.StringValue).value
+    }
+  }
+
+private fun NumericFilters.rows(): List<List<String>> =
+  (this as NumericFilters.ListOfNumericFiltersValue).value.map { row ->
+    (row as NumericFilters.ListOfNumericFiltersValue).value.map { cell ->
+      (cell as NumericFilters.StringValue).value
+    }
+  }
+
+private fun TagFilters.rows(): List<List<String>> =
+  (this as TagFilters.ListOfTagFiltersValue).value.map { row ->
+    (row as TagFilters.ListOfTagFiltersValue).value.map { cell ->
+      (cell as TagFilters.StringValue).value
+    }
+  }

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
@@ -1,0 +1,163 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.dsl.rule.filters
+import com.algolia.client.dsl.rule.query
+import com.algolia.client.dsl.rule.rule
+import com.algolia.client.dsl.synonym.altCorrection1
+import com.algolia.client.dsl.synonym.altCorrection2
+import com.algolia.client.dsl.synonym.oneWaySynonym
+import com.algolia.client.dsl.synonym.placeholder
+import com.algolia.client.dsl.synonym.synonym
+import com.algolia.client.model.search.Anchoring
+import com.algolia.client.model.search.Condition
+import com.algolia.client.model.search.Consequence
+import com.algolia.client.model.search.ConsequenceParams
+import com.algolia.client.model.search.ConsequenceQuery
+import com.algolia.client.model.search.Promote
+import com.algolia.client.model.search.PromoteObjectID
+import com.algolia.client.model.search.Rule
+import com.algolia.client.model.search.SynonymHit
+import com.algolia.client.model.search.SynonymType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Serialization equivalence between rule/synonym DSL builders and data-class constructors.
+ *
+ * Uses [ClientOptions.json], the same [kotlinx.serialization.json.Json] the client sends on
+ * requests. That instance leaves `encodeDefaults` off (kotlinx default), so unset null properties
+ * are omitted. Comparison is on parsed [JsonObject], never on encoded strings.
+ */
+internal class RuleSynonymDslTest {
+
+  private val json = ClientOptions().json
+
+  @Test
+  fun ruleDslMatchesConstructor() {
+    val dsl =
+      rule("promo-iphone") {
+        condition {
+          pattern = "smartphone"
+          anchoring = Anchoring.Is
+        }
+        consequence {
+          params {
+            query("iphone")
+            filters { facet("brand", "Apple") }
+          }
+          promote("object-1", position = 0)
+        }
+      }
+    val ctor =
+      Rule(
+        objectID = "promo-iphone",
+        condition =
+          Condition(
+            pattern = "smartphone",
+            anchoring = Anchoring.Is,
+          ),
+        consequence =
+          Consequence(
+            params =
+              ConsequenceParams(
+                query = ConsequenceQuery.of("iphone"),
+                filters = "brand:Apple",
+              ),
+            promote = listOf(Promote.of(PromoteObjectID("object-1", 0))),
+          ),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun regularSynonymDslMatchesConstructor() {
+    val dsl =
+      synonym("syn-1") {
+        +"car"
+        +"auto"
+        +"vehicle"
+      }
+    val ctor =
+      SynonymHit(
+        objectID = "syn-1",
+        type = SynonymType.Synonym,
+        synonyms = listOf("car", "auto", "vehicle"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun oneWaySynonymDslMatchesConstructor() {
+    val dsl =
+      oneWaySynonym("syn-2", input = "tablet") {
+        +"ipad"
+        +"galaxy tab"
+      }
+    val ctor =
+      SynonymHit(
+        objectID = "syn-2",
+        type = SynonymType.OneWaySynonym,
+        input = "tablet",
+        synonyms = listOf("ipad", "galaxy tab"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun altCorrection1DslMatchesConstructor() {
+    val dsl = altCorrection1("syn-3", word = "trousers") { +"pants" }
+    val ctor =
+      SynonymHit(
+        objectID = "syn-3",
+        type = SynonymType.AltCorrection1,
+        word = "trousers",
+        corrections = listOf("pants"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun altCorrection2DslMatchesConstructor() {
+    val dsl = altCorrection2("syn-4", word = "trousers") { +"pants" }
+    val ctor =
+      SynonymHit(
+        objectID = "syn-4",
+        type = SynonymType.AltCorrection2,
+        word = "trousers",
+        corrections = listOf("pants"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun placeholderDslMatchesConstructor() {
+    val dsl =
+      placeholder("syn-5", placeholder = "<Street>") {
+        +"street"
+        +"st"
+      }
+    val ctor =
+      SynonymHit(
+        objectID = "syn-5",
+        type = SynonymType.Placeholder,
+        placeholder = "<Street>",
+        replacements = listOf("street", "st"),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  private inline fun <reified T> assertJsonEquals(constructor: T, dsl: T) {
+    val constructorJson = json.encodeToJsonElement(constructor)
+    val dslJson = json.encodeToJsonElement(dsl)
+    assertIs<JsonObject>(constructorJson)
+    assertIs<JsonObject>(dslJson)
+    assertEquals(constructorJson.jsonObject, dslJson.jsonObject)
+  }
+}

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
@@ -3,9 +3,7 @@
 package com.algolia.client.dsl
 
 import com.algolia.client.configuration.ClientOptions
-import com.algolia.client.dsl.rule.filters
-import com.algolia.client.dsl.rule.query
-import com.algolia.client.dsl.rule.rule
+import com.algolia.client.dsl.rule.*
 import com.algolia.client.dsl.synonym.altCorrection1
 import com.algolia.client.dsl.synonym.altCorrection2
 import com.algolia.client.dsl.synonym.oneWaySynonym

--- a/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/commonTest/kotlin/com/algolia/client/dsl/RuleSynonymDslTest.kt
@@ -151,6 +151,113 @@ internal class RuleSynonymDslTest {
     assertJsonEquals(ctor, dsl)
   }
 
+  @Test
+  fun conditionFiltersHelperMatchesConstructor() {
+    val dsl = rule("x") { condition { filters { facet("brand", "Apple") } } }
+    val ctor =
+      Rule(
+        objectID = "x",
+        condition = Condition(filters = "brand:Apple"),
+        consequence = Consequence(),
+      )
+    assertJsonEquals(ctor, dsl)
+  }
+
+  @Test
+  fun consequenceParamsLegacyFilterHelpersMatchExpectedJson() {
+    val dsl =
+      rule("x") {
+        consequence {
+          params {
+            facetFilters { facet("brand", "Apple") }
+            numericFilters { range("price", 0 until 10) }
+            tagFilters { tag("featured") }
+            optionalFilters { facet("category", "Book") }
+          }
+        }
+      }
+    val expected =
+      json.parseToJsonElement(
+        """
+        {
+          "objectID": "x",
+          "consequence": {
+            "params": {
+              "facetFilters": [["\"brand\":\"Apple\""]],
+              "numericFilters": [["\"price\":0 TO 9"]],
+              "tagFilters": [["\"featured\""]],
+              "optionalFilters": [["\"category\":\"Book\""]]
+            }
+          }
+        }
+        """
+          .trimIndent()
+      )
+    val actual = json.encodeToJsonElement(dsl)
+    assertIs<JsonObject>(actual)
+    assertEquals(expected.jsonObject, actual.jsonObject)
+  }
+
+  @Test
+  fun synonymFactoriesLeaveOtherVariantFieldsUnset() {
+    assertEquals(
+      setOf("objectID", "type", "synonyms"),
+      json
+        .encodeToJsonElement(
+          synonym("syn-1") {
+            +"car"
+            +"auto"
+            +"vehicle"
+          }
+        )
+        .jsonObject
+        .keys
+        .toSet(),
+    )
+    assertEquals(
+      setOf("objectID", "type", "input", "synonyms"),
+      json
+        .encodeToJsonElement(
+          oneWaySynonym("syn-2", input = "tablet") {
+            +"ipad"
+            +"galaxy tab"
+          }
+        )
+        .jsonObject
+        .keys
+        .toSet(),
+    )
+    assertEquals(
+      setOf("objectID", "type", "word", "corrections"),
+      json
+        .encodeToJsonElement(altCorrection1("syn-3", word = "trousers") { +"pants" })
+        .jsonObject
+        .keys
+        .toSet(),
+    )
+    assertEquals(
+      setOf("objectID", "type", "word", "corrections"),
+      json
+        .encodeToJsonElement(altCorrection2("syn-4", word = "trousers") { +"pants" })
+        .jsonObject
+        .keys
+        .toSet(),
+    )
+    assertEquals(
+      setOf("objectID", "type", "placeholder", "replacements"),
+      json
+        .encodeToJsonElement(
+          placeholder("syn-5", placeholder = "<Street>") {
+            +"street"
+            +"st"
+          }
+        )
+        .jsonObject
+        .keys
+        .toSet(),
+    )
+  }
+
   private inline fun <reified T> assertJsonEquals(constructor: T, dsl: T) {
     val constructorJson = json.encodeToJsonElement(constructor)
     val dslJson = json.encodeToJsonElement(dsl)

--- a/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
@@ -21,8 +21,8 @@ import kotlin.test.assertTrue
  * field fails compilation because `build()` still passes every builder `var` into the model
  * constructor.
  *
- * Regenerating `SearchDsl.kt` updates the builder set; this test discovers every `*Builder` in
- * `com.algolia.client.dsl.generated`.
+ * Regenerating the per-model builder files updates the builder set; this test discovers every class
+ * named `SomethingBuilder` in `com.algolia.client.dsl.generated`.
  *
  * Placed under `jvmTest` because constructor and `var` lookup needs JVM [Class] reflection.
  * `kotlin.reflect.full` (`memberProperties` / `primaryConstructor`) is not on the test classpath.

--- a/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
@@ -2,16 +2,8 @@
 
 package com.algolia.client.dsl
 
-import com.algolia.client.dsl.generated.BrowseParamsObjectBuilder
-import com.algolia.client.dsl.generated.ConsequenceParamsBuilder
-import com.algolia.client.dsl.generated.DeleteByParamsBuilder
-import com.algolia.client.dsl.generated.IndexSettingsBuilder
 import com.algolia.client.dsl.generated.SearchParamsObjectBuilder
-import com.algolia.client.model.search.BrowseParamsObject
-import com.algolia.client.model.search.ConsequenceParams
-import com.algolia.client.model.search.DeleteByParams
-import com.algolia.client.model.search.IndexSettings
-import com.algolia.client.model.search.SearchParamsObject
+import java.io.File
 import java.lang.reflect.Modifier
 import kotlin.reflect.KClass
 import kotlin.test.Test
@@ -19,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Drift guard between generated DSL builders and their allow-listed model constructors.
+ * Drift guard between generated DSL builders and their model constructors.
  *
  * Do not assert that an empty builder serializes to `{}`. Client Json omits default nulls
  * (`encodeDefaults` is off), so a builder that forgot a new spec field also serializes to `{}`.
@@ -29,7 +21,8 @@ import kotlin.test.assertTrue
  * field fails compilation because `build()` still passes every builder `var` into the model
  * constructor.
  *
- * Regenerating `SearchDsl.kt` updates the builder; this test needs no edit.
+ * Regenerating `SearchDsl.kt` updates the builder set; this test discovers every `*Builder` in
+ * `com.algolia.client.dsl.generated`.
  *
  * Placed under `jvmTest` because constructor and `var` lookup needs JVM [Class] reflection.
  * `kotlin.reflect.full` (`memberProperties` / `primaryConstructor`) is not on the test classpath.
@@ -37,28 +30,32 @@ import kotlin.test.assertTrue
 internal class GeneratedBuilderCoverageTest {
 
   @Test
-  fun searchParamsObjectBuilderMatchesConstructor() {
-    assertBuilderVarsMatchConstructor(SearchParamsObjectBuilder::class, SearchParamsObject::class)
+  fun allGeneratedBuildersMatchConstructors() {
+    val builders = generatedBuilderClasses()
+    assertTrue(builders.isNotEmpty(), "expected generated builders on the classpath")
+    for (builder in builders) {
+      val modelName = builder.simpleName.removeSuffix("Builder")
+      val model = Class.forName("com.algolia.client.model.search.$modelName").kotlin
+      assertBuilderVarsMatchConstructor(builder.kotlin, model)
+    }
   }
 
-  @Test
-  fun indexSettingsBuilderMatchesConstructor() {
-    assertBuilderVarsMatchConstructor(IndexSettingsBuilder::class, IndexSettings::class)
-  }
-
-  @Test
-  fun browseParamsObjectBuilderMatchesConstructor() {
-    assertBuilderVarsMatchConstructor(BrowseParamsObjectBuilder::class, BrowseParamsObject::class)
-  }
-
-  @Test
-  fun deleteByParamsBuilderMatchesConstructor() {
-    assertBuilderVarsMatchConstructor(DeleteByParamsBuilder::class, DeleteByParams::class)
-  }
-
-  @Test
-  fun consequenceParamsBuilderMatchesConstructor() {
-    assertBuilderVarsMatchConstructor(ConsequenceParamsBuilder::class, ConsequenceParams::class)
+  private fun generatedBuilderClasses(): List<Class<*>> {
+    val root =
+      File(SearchParamsObjectBuilder::class.java.protectionDomain.codeSource.location.toURI())
+    val prefix = "com/algolia/client/dsl/generated/"
+    return root
+      .walkTopDown()
+      .filter { file ->
+        file.isFile && file.name.endsWith("Builder.class") && file.path.contains(prefix)
+      }
+      .map { file ->
+        val qualified =
+          file.relativeTo(root).path.removeSuffix(".class").replace(File.separatorChar, '.')
+        Class.forName(qualified)
+      }
+      .sortedBy { it.simpleName }
+      .toList()
   }
 
   private fun assertBuilderVarsMatchConstructor(builder: KClass<*>, model: KClass<*>) {

--- a/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
@@ -40,6 +40,63 @@ internal class GeneratedBuilderCoverageTest {
     }
   }
 
+  /**
+   * Drift guard for generated filter helpers.
+   *
+   * The generator must emit exactly twenty public `Function1` members (`filters`, `facetFilters`,
+   * `optionalFilters`, `numericFilters`, `tagFilters`) on the five allowlisted builders. A leak
+   * onto SearchForHitsBuilder, SearchForFacetsBuilder, SecuredApiKeyRestrictionsBuilder,
+   * RankingInfoBuilder, or AutoFilteringResultBuilder fails here. A helper the generator silently
+   * stops emitting also fails here.
+   */
+  @Test
+  fun filterHelpersOnlyOnAllowlistedBuilders() {
+    val actual =
+      generatedBuilderClasses()
+        .flatMap { builder ->
+          filterHelperMethodNames(builder).map { name -> builder.simpleName to name }
+        }
+        .toSet()
+    val expected =
+      setOf(
+        "SearchParamsObjectBuilder" to "filters",
+        "SearchParamsObjectBuilder" to "facetFilters",
+        "SearchParamsObjectBuilder" to "optionalFilters",
+        "SearchParamsObjectBuilder" to "numericFilters",
+        "SearchParamsObjectBuilder" to "tagFilters",
+        "BrowseParamsObjectBuilder" to "filters",
+        "BrowseParamsObjectBuilder" to "facetFilters",
+        "BrowseParamsObjectBuilder" to "optionalFilters",
+        "BrowseParamsObjectBuilder" to "numericFilters",
+        "BrowseParamsObjectBuilder" to "tagFilters",
+        "ConsequenceParamsBuilder" to "filters",
+        "ConsequenceParamsBuilder" to "facetFilters",
+        "ConsequenceParamsBuilder" to "optionalFilters",
+        "ConsequenceParamsBuilder" to "numericFilters",
+        "ConsequenceParamsBuilder" to "tagFilters",
+        "DeleteByParamsBuilder" to "filters",
+        "DeleteByParamsBuilder" to "facetFilters",
+        "DeleteByParamsBuilder" to "numericFilters",
+        "DeleteByParamsBuilder" to "tagFilters",
+        "ConditionBuilder" to "filters",
+      )
+    assertEquals(
+      expected,
+      actual,
+      buildString {
+        append("generated filter helpers must match the allowlisted builder surface.")
+        val missing = expected - actual
+        val unexpected = actual - expected
+        if (missing.isNotEmpty()) {
+          append(" missing=$missing.")
+        }
+        if (unexpected.isNotEmpty()) {
+          append(" unexpected=$unexpected.")
+        }
+      },
+    )
+  }
+
   private fun generatedBuilderClasses(): List<Class<*>> {
     val root =
       File(SearchParamsObjectBuilder::class.java.protectionDomain.codeSource.location.toURI())
@@ -56,6 +113,25 @@ internal class GeneratedBuilderCoverageTest {
       }
       .sortedBy { it.simpleName }
       .toList()
+  }
+
+  /**
+   * Public one-argument `Function1` members named after a filter field. Synthetic/bridge methods
+   * and property accessors (`getFilters` / `setFilters`) are excluded by name and parameter shape.
+   */
+  private fun filterHelperMethodNames(builder: Class<*>): Set<String> {
+    val helperNames =
+      setOf("filters", "facetFilters", "optionalFilters", "numericFilters", "tagFilters")
+    return builder.declaredMethods
+      .filter { method ->
+        !method.isSynthetic &&
+          Modifier.isPublic(method.modifiers) &&
+          method.name in helperNames &&
+          method.parameterCount == 1 &&
+          method.parameterTypes[0].name == "kotlin.jvm.functions.Function1"
+      }
+      .map { it.name }
+      .toSet()
   }
 
   private fun assertBuilderVarsMatchConstructor(builder: KClass<*>, model: KClass<*>) {

--- a/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
+++ b/clients/algoliasearch-client-kotlin/client/src/jvmTest/kotlin/com/algolia/client/dsl/GeneratedBuilderCoverageTest.kt
@@ -1,0 +1,141 @@
+@file:OptIn(AlgoliaExperimentalDsl::class)
+
+package com.algolia.client.dsl
+
+import com.algolia.client.dsl.generated.BrowseParamsObjectBuilder
+import com.algolia.client.dsl.generated.ConsequenceParamsBuilder
+import com.algolia.client.dsl.generated.DeleteByParamsBuilder
+import com.algolia.client.dsl.generated.IndexSettingsBuilder
+import com.algolia.client.dsl.generated.SearchParamsObjectBuilder
+import com.algolia.client.model.search.BrowseParamsObject
+import com.algolia.client.model.search.ConsequenceParams
+import com.algolia.client.model.search.DeleteByParams
+import com.algolia.client.model.search.IndexSettings
+import com.algolia.client.model.search.SearchParamsObject
+import java.lang.reflect.Modifier
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Drift guard between generated DSL builders and their allow-listed model constructors.
+ *
+ * Do not assert that an empty builder serializes to `{}`. Client Json omits default nulls
+ * (`encodeDefaults` is off), so a builder that forgot a new spec field also serializes to `{}`.
+ *
+ * This test compares generated builder `var` names to model constructor parameter names via
+ * [KClass] plus JVM reflection. A new spec field that the template missed fails here. A removed
+ * field fails compilation because `build()` still passes every builder `var` into the model
+ * constructor.
+ *
+ * Regenerating `SearchDsl.kt` updates the builder; this test needs no edit.
+ *
+ * Placed under `jvmTest` because constructor and `var` lookup needs JVM [Class] reflection.
+ * `kotlin.reflect.full` (`memberProperties` / `primaryConstructor`) is not on the test classpath.
+ */
+internal class GeneratedBuilderCoverageTest {
+
+  @Test
+  fun searchParamsObjectBuilderMatchesConstructor() {
+    assertBuilderVarsMatchConstructor(SearchParamsObjectBuilder::class, SearchParamsObject::class)
+  }
+
+  @Test
+  fun indexSettingsBuilderMatchesConstructor() {
+    assertBuilderVarsMatchConstructor(IndexSettingsBuilder::class, IndexSettings::class)
+  }
+
+  @Test
+  fun browseParamsObjectBuilderMatchesConstructor() {
+    assertBuilderVarsMatchConstructor(BrowseParamsObjectBuilder::class, BrowseParamsObject::class)
+  }
+
+  @Test
+  fun deleteByParamsBuilderMatchesConstructor() {
+    assertBuilderVarsMatchConstructor(DeleteByParamsBuilder::class, DeleteByParams::class)
+  }
+
+  @Test
+  fun consequenceParamsBuilderMatchesConstructor() {
+    assertBuilderVarsMatchConstructor(ConsequenceParamsBuilder::class, ConsequenceParams::class)
+  }
+
+  private fun assertBuilderVarsMatchConstructor(builder: KClass<*>, model: KClass<*>) {
+    val builderVars = builderVarNames(builder)
+    val constructorParams = constructorParameterNames(model)
+
+    assertTrue(
+      constructorParams.isNotEmpty(),
+      "${model.simpleName} constructor parameters must not be empty",
+    )
+    assertEquals(
+      constructorParams,
+      builderVars,
+      buildString {
+        append("${builder.simpleName} vars must match ${model.simpleName} constructor parameters.")
+        val missingOnBuilder = constructorParams - builderVars
+        val extraOnBuilder = builderVars - constructorParams
+        if (missingOnBuilder.isNotEmpty()) {
+          append(" missingOnBuilder=$missingOnBuilder.")
+        }
+        if (extraOnBuilder.isNotEmpty()) {
+          append(" extraOnBuilder=$extraOnBuilder.")
+        }
+      },
+    )
+  }
+
+  /**
+   * Kotlin `var` properties compile to a field plus a one-argument setter. Static and synthetic
+   * fields are ignored.
+   */
+  private fun builderVarNames(builder: KClass<*>): Set<String> {
+    val javaClass = builder.java
+    return javaClass.declaredFields
+      .filter { field ->
+        !field.isSynthetic &&
+          !Modifier.isStatic(field.modifiers) &&
+          javaClass.methods.any { method ->
+            method.parameterCount == 1 && method.name == setterName(field.name)
+          }
+      }
+      .map { it.name }
+      .toSet()
+  }
+
+  /**
+   * Primary constructor parameter names. [java.lang.reflect.Parameter.getName] is `argN` unless
+   * MethodParameters is present, so this falls back to the data-class instance fields, which match
+   * the primary constructor.
+   */
+  private fun constructorParameterNames(model: KClass<*>): Set<String> {
+    val javaClass = model.java
+    val primary =
+      javaClass.declaredConstructors
+        .filter { constructor ->
+          constructor.parameterTypes.none { type ->
+            type.name.endsWith("DefaultConstructorMarker") ||
+              type.name.endsWith("SerializationConstructorMarker")
+          }
+        }
+        .filter { it.parameterCount > 0 }
+        .maxByOrNull { it.parameterCount }
+        ?: error("${model.simpleName} has no primary constructor")
+
+    val reflectedNames = primary.parameters.map { it.name }
+    if (
+      reflectedNames.size == primary.parameterCount && reflectedNames.none { it.startsWith("arg") }
+    ) {
+      return reflectedNames.toSet()
+    }
+
+    return javaClass.declaredFields
+      .filter { !it.isSynthetic && !Modifier.isStatic(it.modifiers) }
+      .map { it.name }
+      .toSet()
+  }
+
+  private fun setterName(propertyName: String): String =
+    "set" + propertyName.replaceFirstChar { it.uppercaseChar() }
+}

--- a/clients/algoliasearch-client-kotlin/gradle.properties
+++ b/clients/algoliasearch-client-kotlin/gradle.properties
@@ -27,4 +27,5 @@ POM_ISSUE_URL=https://github.com/algolia/algoliasearch-client-kotlin/issues
 mavenCentralPublishing=true
 mavenCentralAutomaticPublishing=true
 signAllPublications=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 kotlin.daemon.jvmargs=-Xmx4096m

--- a/config/generation.config.mjs
+++ b/config/generation.config.mjs
@@ -98,6 +98,7 @@ export const patterns = [
   'clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/BuildConfig.kt',
   'clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/api/**',
   'clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/model/**',
+  'clients/algoliasearch-client-kotlin/client/src/commonMain/kotlin/com/algolia/client/dsl/generated/**',
 
   '!tests/output/kotlin/src/commonTest/kotlin/com/algolia/utils/TestHelpers.kt',
 

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
@@ -18,6 +18,10 @@ import org.openapitools.codegen.model.OperationsMap;
 
 public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
 
+  private static final Set<String> SEARCH_DSL_MODELS = Collections.unmodifiableSet(
+    new LinkedHashSet<>(Arrays.asList("SearchParamsObject", "IndexSettings", "BrowseParamsObject", "DeleteByParams", "ConsequenceParams"))
+  );
+
   @Override
   public String getName() {
     return "algolia-kotlin";
@@ -113,6 +117,11 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     supportingFiles.add(new SupportingFile("ApiClient.kt.mustache", apiFolder, "ApiClient.kt"));
     supportingFiles.add(new SupportingFile("gradle.properties.mustache", "", "gradle.properties"));
     supportingFiles.add(new SupportingFile("README_BOM.mustache", "client-bom", "README.md"));
+
+    if ("search".equals(client)) {
+      final String dslFolder = (sourceFolder + File.separator + "com.algolia.client.dsl.generated").replace(".", "/");
+      supportingFiles.add(new SupportingFile("dsl.mustache", dslFolder, "SearchDsl.kt"));
+    }
 
     Helpers.addCommonSupportingFiles(supportingFiles, "");
 
@@ -220,7 +229,33 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     GenericPropagator.propagateGenericsToModels(models, true);
     OneOf.addOneOfMetadata(models);
     jsonParent(models);
+    collectSearchDslModels(models);
     return models;
+  }
+
+  private void collectSearchDslModels(Map<String, ModelsMap> models) {
+    if (!"search".equals(additionalProperties.get("client"))) {
+      return;
+    }
+
+    Map<String, CodegenModel> byClassname = new HashMap<>();
+    for (ModelsMap modelContainer : models.values()) {
+      CodegenModel model = modelContainer.getModels().get(0).getModel();
+      byClassname.put(model.classname, model);
+    }
+
+    List<Map<String, Object>> dslModels = new ArrayList<>();
+    for (String classname : SEARCH_DSL_MODELS) {
+      CodegenModel model = byClassname.get(classname);
+      if (model == null) {
+        continue;
+      }
+      Map<String, Object> dslModel = new LinkedHashMap<>();
+      dslModel.put("classname", model.classname);
+      dslModel.put("vars", model.vars);
+      dslModels.add(dslModel);
+    }
+    additionalProperties.put("dslModels", dslModels);
   }
 
   private static final String FREE_FORM_MAP = "Map<kotlin.String, Any>";

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
@@ -253,9 +253,56 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
       Map<String, Object> dslModel = new LinkedHashMap<>();
       dslModel.put("classname", model.classname);
       dslModel.put("vars", model.vars);
+      List<Map<String, Object>> filterHelpers = filterHelpersFor(model);
+      if (!filterHelpers.isEmpty()) {
+        dslModel.put("filterHelpers", filterHelpers);
+        dslModel.put("x-dsl-has-filter-helpers", true);
+      }
       dslModels.add(dslModel);
     }
     writeSearchDslBuilders(dslModels);
+  }
+
+  private static final Set<String> DSL_FILTER_HELPER_MODELS = Set.of(
+    "SearchParamsObject",
+    "BrowseParamsObject",
+    "DeleteByParams",
+    "ConsequenceParams",
+    "Condition"
+  );
+
+  private record DslFilterVar(String type, String converter) {}
+
+  private static final Map<String, DslFilterVar> DSL_FILTER_VARS = Map.of(
+    "filters",
+    new DslFilterVar("String", "asSql"),
+    "facetFilters",
+    new DslFilterVar("FacetFilters", "asFacetFilters"),
+    "optionalFilters",
+    new DslFilterVar("OptionalFilters", "asOptionalFilters"),
+    "numericFilters",
+    new DslFilterVar("NumericFilters", "asNumericFilters"),
+    "tagFilters",
+    new DslFilterVar("TagFilters", "asTagFilters")
+  );
+
+  private static List<Map<String, Object>> filterHelpersFor(CodegenModel model) {
+    List<Map<String, Object>> helpers = new ArrayList<>();
+    if (!DSL_FILTER_HELPER_MODELS.contains(model.classname)) {
+      return helpers;
+    }
+    for (CodegenProperty var : model.vars) {
+      DslFilterVar expected = DSL_FILTER_VARS.get(var.name);
+      if (expected == null || !expected.type().equals(var.datatypeWithEnum)) {
+        continue;
+      }
+      var.vendorExtensions.put("x-dsl-filter-converter", expected.converter());
+      Map<String, Object> helper = new LinkedHashMap<>();
+      helper.put("name", var.name);
+      helper.put("converter", expected.converter());
+      helpers.add(helper);
+    }
+    return helpers;
   }
 
   /**

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
@@ -2,10 +2,17 @@ package com.algolia.codegen;
 
 import com.algolia.codegen.utils.*;
 import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.servers.Server;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -113,11 +120,6 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     supportingFiles.add(new SupportingFile("ApiClient.kt.mustache", apiFolder, "ApiClient.kt"));
     supportingFiles.add(new SupportingFile("gradle.properties.mustache", "", "gradle.properties"));
     supportingFiles.add(new SupportingFile("README_BOM.mustache", "client-bom", "README.md"));
-
-    if ("search".equals(client)) {
-      final String dslFolder = (sourceFolder + File.separator + "com.algolia.client.dsl.generated").replace(".", "/");
-      supportingFiles.add(new SupportingFile("dsl.mustache", dslFolder, "SearchDsl.kt"));
-    }
 
     Helpers.addCommonSupportingFiles(supportingFiles, "");
 
@@ -253,7 +255,61 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
       dslModel.put("vars", model.vars);
       dslModels.add(dslModel);
     }
-    additionalProperties.put("dslModels", dslModels);
+    writeSearchDslBuilders(dslModels);
+  }
+
+  /**
+   * One builder per file. A single SearchDsl.kt with every object model OOMs the Kotlin Native
+   * compiler on the macOS CI job ({@code compileKotlinIosArm64}).
+   */
+  private void writeSearchDslBuilders(List<Map<String, Object>> dslModels) {
+    String dslFolder = (sourceFolder + File.separator + "com.algolia.client.dsl.generated").replace(".", "/");
+    File outDir = new File(getOutputDir(), dslFolder);
+    try {
+      Files.createDirectories(outDir.toPath());
+    } catch (IOException e) {
+      throw new RuntimeException("Cannot create DSL builder directory " + outDir, e);
+    }
+    File[] stale = outDir.listFiles((dir, name) -> name.endsWith(".kt"));
+    if (stale != null) {
+      for (File file : stale) {
+        if (!file.delete()) {
+          throw new RuntimeException("Cannot delete stale DSL builder " + file);
+        }
+      }
+    }
+
+    Template template = compileDslTemplate();
+    for (Map<String, Object> dslModel : dslModels) {
+      Map<String, Object> data = new HashMap<>(additionalProperties);
+      data.putAll(dslModel);
+      String classname = (String) dslModel.get("classname");
+      File out = new File(outDir, classname + "Builder.kt");
+      StringWriter rendered = new StringWriter();
+      template.execute(data, rendered);
+      try {
+        Files.writeString(out.toPath(), rendered.toString(), StandardCharsets.UTF_8);
+      } catch (IOException e) {
+        throw new RuntimeException("Cannot write DSL builder " + out, e);
+      }
+    }
+  }
+
+  private Template compileDslTemplate() {
+    File root = new File(templateDir());
+    Mustache.Compiler compiler = Mustache.compiler()
+      .defaultValue("")
+      .withLoader(name -> {
+        String fileName = name.endsWith(".mustache") ? name : name + ".mustache";
+        File partial = new File(root, fileName);
+        return new InputStreamReader(Files.newInputStream(partial.toPath()), StandardCharsets.UTF_8);
+      });
+    File dsl = new File(root, "dsl.mustache");
+    try (Reader reader = new InputStreamReader(Files.newInputStream(dsl.toPath()), StandardCharsets.UTF_8)) {
+      return compiler.compile(reader);
+    } catch (IOException e) {
+      throw new RuntimeException("Cannot compile dsl.mustache from " + dsl, e);
+    }
   }
 
   /**

--- a/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
+++ b/generators/src/main/java/com/algolia/codegen/AlgoliaKotlinGenerator.java
@@ -18,10 +18,6 @@ import org.openapitools.codegen.model.OperationsMap;
 
 public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
 
-  private static final Set<String> SEARCH_DSL_MODELS = Collections.unmodifiableSet(
-    new LinkedHashSet<>(Arrays.asList("SearchParamsObject", "IndexSettings", "BrowseParamsObject", "DeleteByParams", "ConsequenceParams"))
-  );
-
   @Override
   public String getName() {
     return "algolia-kotlin";
@@ -229,33 +225,52 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
     GenericPropagator.propagateGenericsToModels(models, true);
     OneOf.addOneOfMetadata(models);
     jsonParent(models);
-    collectSearchDslModels(models);
     return models;
   }
 
-  private void collectSearchDslModels(Map<String, ModelsMap> models) {
+  private void collectSearchDslModels(OperationsMap operations, List<ModelMap> allModels) {
     if (!"search".equals(additionalProperties.get("client"))) {
       return;
     }
 
-    Map<String, CodegenModel> byClassname = new HashMap<>();
-    for (ModelsMap modelContainer : models.values()) {
-      CodegenModel model = modelContainer.getModels().get(0).getModel();
-      byClassname.put(model.classname, model);
-    }
-
-    List<Map<String, Object>> dslModels = new ArrayList<>();
-    for (String classname : SEARCH_DSL_MODELS) {
-      CodegenModel model = byClassname.get(classname);
-      if (model == null) {
+    Set<String> orphans = new HashSet<>(ModelPruner.getOrphanModelNames(this, operations, allModels));
+    List<CodegenModel> objectModels = new ArrayList<>();
+    for (ModelMap modelMap : allModels) {
+      CodegenModel model = modelMap.getModel();
+      if (orphans.contains(toModelName(model.name))) {
         continue;
       }
+      if (isSearchDslObjectModel(model)) {
+        objectModels.add(model);
+      }
+    }
+    objectModels.sort(Comparator.comparing(model -> model.classname));
+
+    List<Map<String, Object>> dslModels = new ArrayList<>();
+    for (CodegenModel model : objectModels) {
       Map<String, Object> dslModel = new LinkedHashMap<>();
       dslModel.put("classname", model.classname);
       dslModel.put("vars", model.vars);
       dslModels.add(dslModel);
     }
     additionalProperties.put("dslModels", dslModels);
+  }
+
+  /**
+   * Object models get a builder. OneOf wrappers (FacetFilters, SearchParams) and enums do not: they
+   * have no constructor fields to assign.
+   */
+  private static boolean isSearchDslObjectModel(CodegenModel model) {
+    if (model.isEnum) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(model.vendorExtensions.get("x-is-one-of"))) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(model.vendorExtensions.get("x-map-parent"))) {
+      return false;
+    }
+    return model.vars != null && !model.vars.isEmpty();
   }
 
   private static final String FREE_FORM_MAP = "Map<kotlin.String, Any>";
@@ -308,6 +323,7 @@ public class AlgoliaKotlinGenerator extends KotlinClientCodegen {
   public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> models) {
     OperationsMap operations = super.postProcessOperationsWithModels(objs, models);
     ModelPruner.removeOrphanModelFiles(this, operations, models);
+    collectSearchDslModels(operations, models);
     Helpers.removeHelpers(operations);
     GenericPropagator.propagateGenericsToOperations(operations, models);
     return operations;

--- a/playground/kotlin/src/main/kotlin/com/algolia/playground/Search.kt
+++ b/playground/kotlin/src/main/kotlin/com/algolia/playground/Search.kt
@@ -3,6 +3,8 @@ package com.algolia.playground
 import com.algolia.client.api.SearchClient
 import com.algolia.client.configuration.ClientOptions
 import com.algolia.client.configuration.CompressionType
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.dsl.searchSingleIndex
 import com.algolia.client.model.search.SearchForHits
 import com.algolia.client.model.search.SearchMethodParams
 import com.algolia.client.model.search.SearchResponse
@@ -10,6 +12,7 @@ import io.github.cdimascio.dotenv.Dotenv
 import io.ktor.client.plugins.logging.*
 import kotlin.system.exitProcess
 
+@OptIn(AlgoliaExperimentalDsl::class)
 suspend fun main() {
     val dotenv = Dotenv.configure().directory("../").load()
 
@@ -33,6 +36,12 @@ suspend fun main() {
     val result = searchResponses.results[0] as SearchResponse
     val hits = result.hits
     println(hits)
+
+    // search index (DSL)
+    val dslResult = client.searchSingleIndex(indexName) {
+        query = "a"
+    }
+    println(dslResult.hits)
 
     exitProcess(0)
 }

--- a/scripts/cts/runCts.ts
+++ b/scripts/cts/runCts.ts
@@ -101,6 +101,11 @@ async function runCtsOne(language: Language, suites: Record<CTSType, boolean>): 
       await run(`./gradle/gradlew -p tests/output/kotlin jvmTest ${filter((f) => `--tests 'com.algolia.${f}*'`)}`, {
         language,
       });
+      if (suites.client) {
+        await run('./gradle/gradlew -p clients/algoliasearch-client-kotlin :client:jvmTest', {
+          language,
+        });
+      }
       break;
     case 'php':
       await runComposerInstall();

--- a/templates/kotlin/README.mustache
+++ b/templates/kotlin/README.mustache
@@ -115,6 +115,56 @@ println(response)
 
 For full documentation, visit the **[Algolia Kotlin API Client](https://www.algolia.com/doc/libraries/sdk/install#kotlin)**.
 
+## Optional Kotlin DSL
+
+The client includes an optional Kotlin DSL for search parameters and index settings. The DSL is optional, experimental on the first 3.x minor (`@OptIn(AlgoliaExperimentalDsl::class)`), and is not source compatible with version 2. Data-class constructors stay supported.
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val params = query {
+  query = "shoes"
+  filters { facet("brand", "Apple") }
+}
+```
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val indexSettings = settings {
+  searchableAttributes {
+    ordered("name")
+    unordered("description")
+  }
+}
+```
+
+### Migrating from version 2
+
+Map version 2 types to version 3 types:
+
+- `Query` → `SearchParamsObject` via `query { }`
+- `Settings` → `IndexSettings` via `settings { }`
+- `Attribute` → `String`
+- `initIndex` is gone. Pass the index name to the client method.
+- `index.search { }` → `client.searchSingleIndex(indexName) { }`
+
+`SearchClient.search` is multi-query. Use `searchSingleIndex` for a single index.
+
+```kotlin
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+val response = client.searchSingleIndex("products") {
+  query = "shoes"
+  filters { facet("brand", "Apple") }
+}
+```
+
+See the [Kotlin upgrade guide](https://www.algolia.com/doc/libraries/sdk/upgrade/kotlin).
+
 ## ❓ Troubleshooting
 
 Encountering an issue? Before reaching out to support, we recommend heading to our [FAQ](https://support.algolia.com/hc/sections/15061037630609-API-Client-FAQs) where you will find answers for the most common issues and gotchas with the client. You can also open [a GitHub issue](https://github.com/algolia/api-clients-automation/issues/new?assignees=&labels=&projects=&template=Bug_report.md)

--- a/templates/kotlin/dsl.mustache
+++ b/templates/kotlin/dsl.mustache
@@ -11,12 +11,12 @@ import kotlinx.serialization.json.*
 @AlgoliaExperimentalDsl
 public class {{classname}}Builder {
 {{#vars}}
-  public var {{{name}}}: {{> data_class_field_type}}{{#required}}{{#isNullable}}? = null{{/isNullable}}{{/required}}{{^required}}? = null{{/required}}
+  public var {{{name}}}: {{> data_class_field_type}}? = null
 {{/vars}}
 
   internal fun build(): {{classname}} = {{classname}}(
 {{#vars}}
-    {{{name}}} = {{{name}}},
+    {{{name}}} = {{#required}}{{^isNullable}}requireNotNull({{{name}}}) { "{{classname}}.{{{name}}} is required" }{{/isNullable}}{{#isNullable}}{{{name}}}{{/isNullable}}{{/required}}{{^required}}{{{name}}}{{/required}},
 {{/vars}}
   )
 }

--- a/templates/kotlin/dsl.mustache
+++ b/templates/kotlin/dsl.mustache
@@ -1,0 +1,24 @@
+{{> licenseInfo}}
+package com.algolia.client.dsl.generated
+
+import com.algolia.client.dsl.AlgoliaDsl
+import com.algolia.client.dsl.AlgoliaExperimentalDsl
+import com.algolia.client.model.search.*
+import kotlinx.serialization.json.*
+
+{{#dslModels}}
+@AlgoliaDsl
+@AlgoliaExperimentalDsl
+public class {{classname}}Builder {
+{{#vars}}
+  public var {{{name}}}: {{> data_class_field_type}}{{#required}}{{#isNullable}}? = null{{/isNullable}}{{/required}}{{^required}}? = null{{/required}}
+{{/vars}}
+
+  internal fun build(): {{classname}} = {{classname}}(
+{{#vars}}
+    {{{name}}} = {{{name}}},
+{{/vars}}
+  )
+}
+
+{{/dslModels}}

--- a/templates/kotlin/dsl.mustache
+++ b/templates/kotlin/dsl.mustache
@@ -6,7 +6,6 @@ import com.algolia.client.dsl.AlgoliaExperimentalDsl
 import com.algolia.client.model.search.*
 import kotlinx.serialization.json.*
 
-{{#dslModels}}
 @AlgoliaDsl
 @AlgoliaExperimentalDsl
 public class {{classname}}Builder {
@@ -20,5 +19,3 @@ public class {{classname}}Builder {
 {{/vars}}
   )
 }
-
-{{/dslModels}}

--- a/templates/kotlin/dsl.mustache
+++ b/templates/kotlin/dsl.mustache
@@ -3,6 +3,10 @@ package com.algolia.client.dsl.generated
 
 import com.algolia.client.dsl.AlgoliaDsl
 import com.algolia.client.dsl.AlgoliaExperimentalDsl
+{{#x-dsl-has-filter-helpers}}
+import com.algolia.client.dsl.filter.FilterDsl
+import com.algolia.client.dsl.filter.filters as buildFilters
+{{/x-dsl-has-filter-helpers}}
 import com.algolia.client.model.search.*
 import kotlinx.serialization.json.*
 
@@ -12,6 +16,9 @@ public class {{classname}}Builder {
 {{#vars}}
   public var {{{name}}}: {{> data_class_field_type}}? = null
 {{/vars}}
+{{#filterHelpers}}
+{{> dsl_filter_helper}}
+{{/filterHelpers}}
 
   internal fun build(): {{classname}} = {{classname}}(
 {{#vars}}

--- a/templates/kotlin/dsl_filter_helper.mustache
+++ b/templates/kotlin/dsl_filter_helper.mustache
@@ -1,0 +1,10 @@
+
+  /**
+   * Sets [{{classname}}Builder.{{{name}}}] from a typed filter block.
+   *
+   * Last write wins: this replaces any earlier `{{{name}}}` value in this builder. An empty filter
+   * block yields `null`, so the field stays omitted.
+   */
+  public fun {{{name}}}(block: FilterDsl.() -> Unit) {
+    this.{{{name}}} = buildFilters(block).{{{converter}}}()
+  }

--- a/templates/kotlin/gradle.properties.mustache
+++ b/templates/kotlin/gradle.properties.mustache
@@ -27,4 +27,5 @@ POM_ISSUE_URL=https://github.com/algolia/algoliasearch-client-kotlin/issues
 mavenCentralPublishing=true
 mavenCentralAutomaticPublishing=true
 signAllPublications=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 kotlin.daemon.jvmargs=-Xmx4096m

--- a/templates/kotlin/guides/search/searchWithDslFilters.mustache
+++ b/templates/kotlin/guides/search/searchWithDslFilters.mustache
@@ -1,0 +1,17 @@
+{{> snippets/import}}
+import com.algolia.client.model.search.*
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+suspend fun searchWithDslFilters() {
+  {{> snippets/init}}
+
+  val searchParams = query("<YOUR_SEARCH_QUERY>") {
+    filters {
+      facet("brand", "Apple")
+      range("price", 0, 100)
+    }
+  }
+
+  client.{{#dynamicSnippet}}searchWithSearchParams{{/dynamicSnippet}}
+}

--- a/templates/kotlin/guides/search/setSettingsWithDsl.mustache
+++ b/templates/kotlin/guides/search/setSettingsWithDsl.mustache
@@ -1,0 +1,22 @@
+{{> snippets/import}}
+import com.algolia.client.model.search.*
+import com.algolia.client.dsl.*
+
+@OptIn(AlgoliaExperimentalDsl::class)
+suspend fun setSettingsWithDsl() {
+  {{> snippets/init}}
+
+  val settings = settings {
+    searchableAttributes {
+      ordered("name")
+      unordered("description")
+    }
+    attributesForFaceting {
+      +"brand"
+      filterOnly("internalSku")
+      searchable("category")
+    }
+  }
+
+  client.{{#dynamicSnippet}}setSettings{{/dynamicSnippet}}
+}

--- a/website/docs/custom-helpers.md
+++ b/website/docs/custom-helpers.md
@@ -78,6 +78,6 @@ The Kotlin Search client ships an optional, experimental DSL. The DSL is not sou
 
 The generated half is one Kotlin file per Search object-model builder (`SearchParamsObjectBuilder.kt`, `RuleBuilder.kt`, and the rest).
 
-The generator emits a builder for every Search object model that survives ModelPruner. It skips enums, oneOf wrappers, and map parents. Filter algebra stays hand-written. Rules and synonyms use the generated builders.
+The generator emits a builder for every Search object model that survives ModelPruner. It skips enums, oneOf wrappers, and map parents. Filter algebra stays hand-written: `FilterDsl`, `FilterGroup`, and both converters (`asSql`, `as*Filters`). The per-field filter setters (`filters { }`, `facetFilters { }`, `optionalFilters { }`, `numericFilters { }`, `tagFilters { }`) are generated as member functions. The generator emits them from `templates/kotlin/dsl_filter_helper.mustache`. It places them on five allowlisted builders: `SearchParamsObjectBuilder`, `BrowseParamsObjectBuilder`, `ConsequenceParamsBuilder`, `DeleteByParamsBuilder`, and `ConditionBuilder`. `DeleteByParamsBuilder` has no `optionalFilters`. `ConditionBuilder` has `filters` only. `AlgoliaKotlinGenerator.collectSearchDslModels` gates emission with a classname allowlist plus an exact var-name-and-type match. Do not re-add these setters as hand-written extensions. Rules and synonyms use the generated builders.
 
 Do not emit a DSL for Insights, Analytics, or Recommend.

--- a/website/docs/custom-helpers.md
+++ b/website/docs/custom-helpers.md
@@ -76,8 +76,8 @@ The Kotlin Search client ships an optional, experimental DSL. The DSL is not sou
 - `client/src/commonMain/kotlin/com/algolia/client/dsl/**` is hand-written.
 - `dsl/generated/**` is generated.
 
-The generated half is one Search file only: `SearchDsl.kt`.
+The generated half is one Kotlin file per Search object-model builder (`SearchParamsObjectBuilder.kt`, `RuleBuilder.kt`, and the rest).
 
-The generator emits builders for field lists (`SearchParamsObject`, `IndexSettings`, and the other allow-listed Search models). Filter algebra, rules, and synonyms stay hand-written.
+The generator emits a builder for every Search object model that survives ModelPruner. It skips enums, oneOf wrappers, and map parents. Filter algebra stays hand-written. Rules and synonyms use the generated builders.
 
 Do not emit a DSL for Insights, Analytics, or Recommend.

--- a/website/docs/custom-helpers.md
+++ b/website/docs/custom-helpers.md
@@ -68,3 +68,16 @@ Now that we are certain the tmp index exist:
 #### 4. move tmp index
 
 Move the tmp index to the source index, call `waitTask` on the tmp index.
+
+## Kotlin DSL
+
+The Kotlin Search client ships an optional, experimental DSL. The DSL is not source compatible with the v2 client. The DSL covers Search only.
+
+- `client/src/commonMain/kotlin/com/algolia/client/dsl/**` is hand-written.
+- `dsl/generated/**` is generated.
+
+The generated half is one Search file only: `SearchDsl.kt`.
+
+The generator emits builders for field lists (`SearchParamsObject`, `IndexSettings`, and the other allow-listed Search models). Filter algebra, rules, and synonyms stay hand-written.
+
+Do not emit a DSL for Insights, Analytics, or Recommend.


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: —

The 3.x Kotlin client has no typed query or filter surface. Callers must build `SearchParamsObject` and filter strings by hand. This restores an optional DSL on the generated client. It is additive and opt-in (`@AlgoliaExperimentalDsl`, error-level). It is not source-compatible with the v2 DSL.

Search models stay immutable. Builders are generated from the Search spec so the DSL stays in sync. CTS now also runs the client-module test suite.