### PR TITLE
docs(specs): update analytics catalog entitlement example

### DIFF
--- a/specs/analytics/common/schemas/patterns.yml
+++ b/specs/analytics/common/schemas/patterns.yml
@@ -402,7 +402,7 @@ CatalogEntry:
         type: string
     requires:
       type: array
-      description: Public ACL identifiers required to read the field, for example `clickAnalyticsEnabled`.
+      description: Public ACL identifiers required to read the field, for example `revenueAnalyticsEnabled`.
       items:
         type: string
 


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: [OPTIM-2874]

### Changes included:

- Use `revenueAnalyticsEnabled` as the catalog `requires` example after removal of the click analytics entitlement gate.

ref: https://github.com/algolia/go/pull/27558

## 🧪 Test

Analytics spec lint, validation, and bundle build passed. Generated artifacts are handled by CI.


[OPTIM-2874]: https://algolia.atlassian.net/browse/OPTIM-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ