### PR TITLE
fix(specs): clarify when `_extra` and `_injectedItemKey` are present on `hits` in Composition API

### DIFF
--- a/specs/composition/common/schemas/responses/runResponseComponents/Hit.yml
+++ b/specs/composition/common/schemas/responses/runResponseComponents/Hit.yml
@@ -24,12 +24,12 @@ hit:
 
 hitMetadata:
   type: object
-  description: An object that contains the extra key-value pairs provided in the injectedItem definition.
+  description: An object that contains the extra key-value pairs provided in the injectedItem definition. Only present on hits inserted by an injectedItem that defines metadata, either in its `metadata` field or sent by an external source.
   additionalProperties: true
   properties:
     _injectedItemKey:
       type: string
-      description: The key of the injectedItem that inserted this metadata.
+      description: The key of the injectedItem that inserted this metadata. Only present when the injectedItem's `metadata.hits.addItemKey` is `true`.
 
 rankingInfo:
   allOf:


### PR DESCRIPTION
## 🧭 What and Why

🎟 JIRA Ticket: None

### Changes included:

Enrich Composition API client documentation for `metadata` field.
No code client update

## 🧪 Test

CI